### PR TITLE
Add contribution governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership for all repository paths.
+* @hotsaucejake


### PR DESCRIPTION
## Summary

  - Issue: Closes #13
  - Scope: Add missing governance files and verify repository contribution workflow/templates are complete and unambiguous.

  ## Changes

  - Added `.github/CODEOWNERS` with repository-wide ownership:
    - `* @hotsaucejake`
  - Verified existing governance artifacts already satisfy the remaining ticket scope:
    - `CONTRIBUTING.md`
    - `.github/ISSUE_TEMPLATE/{ticket,epic,manual}.yml`
    - `.github/pull_request_template.md`

  ## Acceptance Criteria Mapping

  - [x] Governance files exist and are visible in GitHub UI.
  - [x] PR/issue templates enforce acceptance criteria and testing evidence.
  - [x] Contribution workflow is unambiguous.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional tests/benchmarks (if required by issue): N/A (docs/governance-only change)

  ## Risk and Mitigation

  - Risk: `CODEOWNERS` handle (`@hotsaucejake`) must remain valid to avoid reviewer assignment issues.
  - Mitigation: Use a single repo-wide rule now; adjust ownership paths/teams as crate structure expands.

  ## Security/Observability Impact

  - Security: Positive governance impact via enforced ownership/review path; no runtime security surface changes.
  - Logs/Metrics/Tracing: None (non-runtime change).