### PR TITLE
Create core-model crate with canonical schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,162 @@
 version = 3
 
 [[package]]
+name = "core-model"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "time",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
 name = "workspace-placeholder"
 version = "0.1.0"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/workspace-placeholder"]
+members = ["crates/core-model","crates/workspace-placeholder"]
 resolver = "2"
 
 [workspace.package]
@@ -7,3 +7,8 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.81"
 repository = "https://github.com/developepper/CodeAtlas"
+
+[workspace.dependencies]
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+time = { version = "0.3.37", features = ["parsing", "formatting"] }

--- a/crates/core-model/Cargo.toml
+++ b/crates/core-model/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "core-model"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde.workspace = true
+time.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/core-model/src/lib.rs
+++ b/crates/core-model/src/lib.rs
@@ -1,0 +1,542 @@
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+pub type ValidationResult = Result<(), ValidationError>;
+
+pub trait Validate {
+    fn validate(&self) -> ValidationResult;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    MissingField {
+        field: &'static str,
+    },
+    InvalidField {
+        field: &'static str,
+        reason: &'static str,
+    },
+    InvalidElement {
+        field: &'static str,
+        index: usize,
+        reason: &'static str,
+    },
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingField { field } => write!(f, "missing required field: {field}"),
+            Self::InvalidField { field, reason } => {
+                write!(f, "invalid field {field}: {reason}")
+            }
+            Self::InvalidElement {
+                field,
+                index,
+                reason,
+            } => write!(f, "invalid value in {field}[{index}]: {reason}"),
+        }
+    }
+}
+
+impl Error for ValidationError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QualityLevel {
+    Semantic,
+    Syntax,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolKind {
+    Function,
+    Class,
+    Method,
+    Type,
+    Constant,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SymbolRecord {
+    pub id: String,
+    pub repo_id: String,
+    pub file_path: String,
+    pub language: String,
+    pub kind: SymbolKind,
+    pub name: String,
+    pub qualified_name: String,
+    pub signature: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub start_byte: u64,
+    pub byte_length: u64,
+    pub content_hash: String,
+    pub quality_level: QualityLevel,
+    pub confidence_score: f32,
+    pub source_adapter: String,
+    pub indexed_at: String,
+    pub docstring: Option<String>,
+    pub summary: Option<String>,
+    pub parent_symbol_id: Option<String>,
+    pub keywords: Option<Vec<String>>,
+    pub decorators_or_attributes: Option<Vec<String>>,
+    pub semantic_refs: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QualityMix {
+    pub semantic_percent: f32,
+    pub syntax_percent: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FileRecord {
+    pub repo_id: String,
+    pub file_path: String,
+    pub language: String,
+    pub file_hash: String,
+    pub summary: String,
+    pub symbol_count: u64,
+    pub quality_mix: QualityMix,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RepoRecord {
+    pub repo_id: String,
+    pub display_name: String,
+    pub source_root: String,
+    pub indexed_at: String,
+    pub index_version: String,
+    pub language_counts: BTreeMap<String, u64>,
+    pub file_count: u64,
+    pub symbol_count: u64,
+    pub git_head: Option<String>,
+}
+
+impl Validate for SymbolRecord {
+    fn validate(&self) -> ValidationResult {
+        require_non_empty(&self.id, "id")?;
+        require_non_empty(&self.repo_id, "repo_id")?;
+        require_non_empty(&self.file_path, "file_path")?;
+        require_non_empty(&self.language, "language")?;
+        require_non_empty(&self.name, "name")?;
+        require_non_empty(&self.qualified_name, "qualified_name")?;
+        require_non_empty(&self.signature, "signature")?;
+        require_non_empty(&self.content_hash, "content_hash")?;
+        require_non_empty(&self.source_adapter, "source_adapter")?;
+        require_non_empty(&self.indexed_at, "indexed_at")?;
+
+        if self.kind == SymbolKind::Unknown {
+            return Err(ValidationError::InvalidField {
+                field: "kind",
+                reason: "must be a known symbol kind",
+            });
+        }
+
+        if self.start_line == 0 {
+            return Err(ValidationError::InvalidField {
+                field: "start_line",
+                reason: "must be greater than zero",
+            });
+        }
+
+        if self.end_line < self.start_line {
+            return Err(ValidationError::InvalidField {
+                field: "end_line",
+                reason: "must be greater than or equal to start_line",
+            });
+        }
+
+        if self.byte_length == 0 {
+            return Err(ValidationError::InvalidField {
+                field: "byte_length",
+                reason: "must be greater than zero",
+            });
+        }
+
+        if !self.confidence_score.is_finite() {
+            return Err(ValidationError::InvalidField {
+                field: "confidence_score",
+                reason: "must be finite",
+            });
+        }
+
+        if !(0.0..=1.0).contains(&self.confidence_score) {
+            return Err(ValidationError::InvalidField {
+                field: "confidence_score",
+                reason: "must be within 0.0..=1.0",
+            });
+        }
+
+        validate_rfc3339_timestamp(&self.indexed_at, "indexed_at")?;
+        validate_optional_string(&self.docstring, "docstring")?;
+        validate_optional_string(&self.summary, "summary")?;
+        validate_optional_string(&self.parent_symbol_id, "parent_symbol_id")?;
+        validate_optional_non_empty_items(&self.keywords, "keywords")?;
+        validate_optional_non_empty_items(
+            &self.decorators_or_attributes,
+            "decorators_or_attributes",
+        )?;
+        validate_optional_non_empty_items(&self.semantic_refs, "semantic_refs")?;
+
+        Ok(())
+    }
+}
+
+impl Validate for QualityMix {
+    fn validate(&self) -> ValidationResult {
+        validate_percentage(self.semantic_percent, "quality_mix.semantic_percent")?;
+        validate_percentage(self.syntax_percent, "quality_mix.syntax_percent")?;
+
+        let total = self.semantic_percent + self.syntax_percent;
+        if total > 100.0 + f32::EPSILON {
+            return Err(ValidationError::InvalidField {
+                field: "quality_mix",
+                reason: "semantic_percent + syntax_percent must be <= 100",
+            });
+        }
+
+        Ok(())
+    }
+}
+
+impl Validate for FileRecord {
+    fn validate(&self) -> ValidationResult {
+        require_non_empty(&self.repo_id, "repo_id")?;
+        require_non_empty(&self.file_path, "file_path")?;
+        require_non_empty(&self.language, "language")?;
+        require_non_empty(&self.file_hash, "file_hash")?;
+        require_non_empty(&self.summary, "summary")?;
+        require_non_empty(&self.updated_at, "updated_at")?;
+        validate_rfc3339_timestamp(&self.updated_at, "updated_at")?;
+        self.quality_mix.validate()?;
+        Ok(())
+    }
+}
+
+impl Validate for RepoRecord {
+    fn validate(&self) -> ValidationResult {
+        require_non_empty(&self.repo_id, "repo_id")?;
+        require_non_empty(&self.display_name, "display_name")?;
+        require_non_empty(&self.source_root, "source_root")?;
+        require_non_empty(&self.indexed_at, "indexed_at")?;
+        require_non_empty(&self.index_version, "index_version")?;
+
+        validate_rfc3339_timestamp(&self.indexed_at, "indexed_at")?;
+        validate_optional_string(&self.git_head, "git_head")?;
+
+        for language in self.language_counts.keys() {
+            require_non_empty(language, "language_counts key")?;
+        }
+
+        Ok(())
+    }
+}
+
+fn require_non_empty(value: &str, field: &'static str) -> ValidationResult {
+    if value.trim().is_empty() {
+        return Err(ValidationError::MissingField { field });
+    }
+    Ok(())
+}
+
+fn validate_optional_string(value: &Option<String>, field: &'static str) -> ValidationResult {
+    if let Some(value) = value {
+        if value.trim().is_empty() {
+            return Err(ValidationError::InvalidField {
+                field,
+                reason: "must not be empty when present",
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_optional_non_empty_items(
+    values: &Option<Vec<String>>,
+    field: &'static str,
+) -> ValidationResult {
+    if let Some(values) = values {
+        for (index, value) in values.iter().enumerate() {
+            if value.trim().is_empty() {
+                return Err(ValidationError::InvalidElement {
+                    field,
+                    index,
+                    reason: "must not contain empty values",
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_percentage(value: f32, field: &'static str) -> ValidationResult {
+    if !value.is_finite() {
+        return Err(ValidationError::InvalidField {
+            field,
+            reason: "must be finite",
+        });
+    }
+
+    if !(0.0..=100.0).contains(&value) {
+        return Err(ValidationError::InvalidField {
+            field,
+            reason: "must be within 0.0..=100.0",
+        });
+    }
+
+    Ok(())
+}
+
+fn validate_rfc3339_timestamp(value: &str, field: &'static str) -> ValidationResult {
+    if OffsetDateTime::parse(value, &Rfc3339).is_err() {
+        return Err(ValidationError::InvalidField {
+            field,
+            reason: "must be RFC 3339 timestamp",
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde_json::json;
+
+    use super::{
+        FileRecord, QualityLevel, QualityMix, RepoRecord, SymbolKind, SymbolRecord, Validate,
+    };
+
+    fn valid_symbol_record() -> SymbolRecord {
+        SymbolRecord {
+            id: "src/main.rs::run#index_fn".to_string(),
+            repo_id: "repo-1".to_string(),
+            file_path: "src/main.rs".to_string(),
+            language: "rust".to_string(),
+            kind: SymbolKind::Function,
+            name: "run".to_string(),
+            qualified_name: "crate::run".to_string(),
+            signature: "fn run()".to_string(),
+            start_line: 10,
+            end_line: 12,
+            start_byte: 120,
+            byte_length: 25,
+            content_hash: "abc123".to_string(),
+            quality_level: QualityLevel::Semantic,
+            confidence_score: 0.95,
+            source_adapter: "semantic-rust-v1".to_string(),
+            indexed_at: "2026-03-09T00:00:00Z".to_string(),
+            docstring: Some("Executes the app.".to_string()),
+            summary: Some("Entry point".to_string()),
+            parent_symbol_id: None,
+            keywords: Some(vec!["entrypoint".to_string(), "startup".to_string()]),
+            decorators_or_attributes: None,
+            semantic_refs: Some(vec!["crate::Config".to_string()]),
+        }
+    }
+
+    fn valid_file_record() -> FileRecord {
+        FileRecord {
+            repo_id: "repo-1".to_string(),
+            file_path: "src/main.rs".to_string(),
+            language: "rust".to_string(),
+            file_hash: "def456".to_string(),
+            summary: "Main executable module".to_string(),
+            symbol_count: 7,
+            quality_mix: QualityMix {
+                semantic_percent: 80.0,
+                syntax_percent: 20.0,
+            },
+            updated_at: "2026-03-09T00:00:00Z".to_string(),
+        }
+    }
+
+    fn valid_repo_record() -> RepoRecord {
+        let mut language_counts = BTreeMap::new();
+        language_counts.insert("rust".to_string(), 10);
+        RepoRecord {
+            repo_id: "repo-1".to_string(),
+            display_name: "CodeAtlas".to_string(),
+            source_root: "/repo".to_string(),
+            indexed_at: "2026-03-09T00:00:00Z".to_string(),
+            index_version: "v1".to_string(),
+            language_counts,
+            file_count: 10,
+            symbol_count: 90,
+            git_head: None,
+        }
+    }
+
+    #[test]
+    fn symbol_validation_accepts_valid_record() {
+        let record = valid_symbol_record();
+        assert!(record.validate().is_ok());
+    }
+
+    #[test]
+    fn symbol_validation_rejects_invalid_confidence_score() {
+        let mut record = valid_symbol_record();
+        record.confidence_score = 1.2;
+
+        let err = record.validate().expect_err("expected validation failure");
+        assert!(format!("{err}").contains("confidence_score"));
+    }
+
+    #[test]
+    fn symbol_validation_rejects_zero_start_line() {
+        let mut record = valid_symbol_record();
+        record.start_line = 0;
+
+        let err = record.validate().expect_err("expected validation failure");
+        assert!(format!("{err}").contains("start_line"));
+    }
+
+    #[test]
+    fn symbol_validation_rejects_zero_byte_length() {
+        let mut record = valid_symbol_record();
+        record.byte_length = 0;
+
+        let err = record.validate().expect_err("expected validation failure");
+        assert!(format!("{err}").contains("byte_length"));
+    }
+
+    #[test]
+    fn symbol_validation_rejects_invalid_timestamp() {
+        let mut record = valid_symbol_record();
+        record.indexed_at = "yesterday".to_string();
+
+        let err = record.validate().expect_err("expected validation failure");
+        assert!(format!("{err}").contains("indexed_at"));
+    }
+
+    #[test]
+    fn symbol_round_trips_through_json() {
+        let record = valid_symbol_record();
+        let payload = serde_json::to_string(&record).expect("serialize symbol");
+        let decoded: SymbolRecord = serde_json::from_str(&payload).expect("deserialize symbol");
+
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn symbol_deserialization_fails_when_required_field_missing() {
+        let payload = json!({
+            "repo_id": "repo-1",
+            "file_path": "src/main.rs",
+            "language": "rust",
+            "kind": "function",
+            "name": "run",
+            "qualified_name": "crate::run",
+            "signature": "fn run()",
+            "start_line": 10,
+            "end_line": 12,
+            "start_byte": 120,
+            "byte_length": 25,
+            "content_hash": "abc123",
+            "quality_level": "semantic",
+            "confidence_score": 0.9,
+            "source_adapter": "semantic-rust-v1",
+            "indexed_at": "2026-03-09T00:00:00Z",
+            "docstring": null,
+            "summary": null,
+            "parent_symbol_id": null,
+            "keywords": null,
+            "decorators_or_attributes": null,
+            "semantic_refs": null
+        });
+
+        let result = serde_json::from_value::<SymbolRecord>(payload);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn file_validation_rejects_invalid_quality_mix() {
+        let mut record = valid_file_record();
+        record.quality_mix.semantic_percent = 70.0;
+        record.quality_mix.syntax_percent = 40.0;
+
+        let err = record.validate().expect_err("expected validation failure");
+        assert!(format!("{err}").contains("quality_mix"));
+    }
+
+    #[test]
+    fn file_round_trips_through_json() {
+        let record = valid_file_record();
+        let payload = serde_json::to_string(&record).expect("serialize file");
+        let decoded: FileRecord = serde_json::from_str(&payload).expect("deserialize file");
+
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn repo_validation_rejects_missing_repo_id() {
+        let mut record = valid_repo_record();
+        record.repo_id.clear();
+
+        let err = record.validate().expect_err("expected validation failure");
+        assert!(format!("{err}").contains("repo_id"));
+    }
+
+    #[test]
+    fn repo_validation_accepts_missing_git_head_when_not_available() {
+        let record = valid_repo_record();
+        assert!(record.validate().is_ok());
+    }
+
+    #[test]
+    fn repo_round_trips_through_json() {
+        let record = valid_repo_record();
+        let payload = serde_json::to_string(&record).expect("serialize repo");
+        let decoded: RepoRecord = serde_json::from_str(&payload).expect("deserialize repo");
+
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn symbol_kind_unknown_deserializes_and_fails_validation() {
+        let payload = json!({
+            "id": "src/main.rs::run#index_fn",
+            "repo_id": "repo-1",
+            "file_path": "src/main.rs",
+            "language": "rust",
+            "kind": "fucntion",
+            "name": "run",
+            "qualified_name": "crate::run",
+            "signature": "fn run()",
+            "start_line": 10,
+            "end_line": 12,
+            "start_byte": 120,
+            "byte_length": 25,
+            "content_hash": "abc123",
+            "quality_level": "semantic",
+            "confidence_score": 0.9,
+            "source_adapter": "semantic-rust-v1",
+            "indexed_at": "2026-03-09T00:00:00Z",
+            "docstring": null,
+            "summary": null,
+            "parent_symbol_id": null,
+            "keywords": null,
+            "decorators_or_attributes": null,
+            "semantic_refs": null
+        });
+
+        let record: SymbolRecord =
+            serde_json::from_value(payload).expect("unknown kind maps to SymbolKind::Unknown");
+        let err = record
+            .validate()
+            .expect_err("expected unknown kind to fail");
+        assert!(format!("{err}").contains("kind"));
+    }
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #16
  - Scope: Create `core-model` crate with canonical Symbol/File/Repo schemas, required-field validation utilities, and unit tests for validation + serialization boundaries.

  ## Changes

  - Added new crate:
    - `crates/core-model`
  - Added canonical schema types:
    - `SymbolRecord`
    - `FileRecord`
    - `RepoRecord`
    - Supporting enums/types: `QualityLevel`, `SymbolKind`, `QualityMix`
  - Added validation framework:
    - `Validate` trait
    - `ValidationError` with typed failure variants
    - Field-level validation for required/invalid values
  - Implemented schema-specific constraints:
    - `SymbolRecord`
      - Required fields enforced (including `source_adapter`)
      - `confidence_score` must be finite and in `0.0..=1.0`
      - `start_line > 0`, `end_line >= start_line`, `byte_length > 0`
      - `kind` modeled as enum; unknown deserializes to `Unknown` and fails validation
      - RFC3339 validation for `indexed_at`
    - `FileRecord`
      - Required fields enforced
      - `QualityMix` percentages validated; total must be `<= 100`
      - RFC3339 validation for `updated_at`
    - `RepoRecord`
      - Required fields enforced
      - RFC3339 validation for `indexed_at`
      - `git_head` modeled as optional (`Option<String>`) to match “when available”
  - Added workspace dependency wiring for serialization/time parsing:
    - `serde`, `serde_json`, `time`
  - Updated workspace membership and lockfile:
    - Added `crates/core-model` to workspace
    - Updated `Cargo.lock`

  ## Acceptance Criteria Mapping

  - [x] `core-model` crate exists and builds.
  - [x] Symbol/File/Repo structures include required fields from spec.
  - [x] Validation rejects missing/invalid required fields.
  - [x] Unit tests cover success and failure cases.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional checks:
    - `cargo build --workspace --all-features`
    - `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`

  ### Unit test coverage added

  - Validation success:
    - valid symbol/file/repo records
  - Validation failure:
    - invalid confidence score
    - `start_line == 0`
    - `byte_length == 0`
    - invalid timestamp (`indexed_at`)
    - invalid quality mix totals
    - missing required `repo_id`
    - unknown symbol kind fails validation
  - Serialization boundaries:
    - JSON round-trip for Symbol/File/Repo
    - deserialization failure when required symbol field is missing

  ## Risk and Mitigation

  - Risk: Introducing stricter schema validation can reject previously tolerated loose data.
  - Mitigation: Validation rules are explicit and tested; failures are surfaced with field-specific errors.

  ## Security/Observability Impact

  - Security: Improves input hardening by rejecting malformed/untrusted schema data early.
  - Logs/Metrics/Tracing: None in this ticket (model/validation layer only).
