### PR TITLE
Implement stable symbol ID construction and validation

### DIFF
--- a/crates/core-model/src/lib.rs
+++ b/crates/core-model/src/lib.rs
@@ -6,6 +6,13 @@ use serde::{Deserialize, Serialize};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+pub mod symbol_id;
+
+pub use symbol_id::{
+    build_symbol_id, disambiguate_symbol_id, normalize_file_path, normalize_qualified_name,
+    parse_symbol_id, validate_symbol_id, ParsedSymbolId,
+};
+
 pub type ValidationResult = Result<(), ValidationError>;
 
 pub trait Validate {
@@ -63,6 +70,33 @@ pub enum SymbolKind {
     Constant,
     #[serde(other)]
     Unknown,
+}
+
+impl SymbolKind {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Function => "function",
+            Self::Class => "class",
+            Self::Method => "method",
+            Self::Type => "type",
+            Self::Constant => "constant",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    #[must_use]
+    pub fn from_id_token(value: &str) -> Option<Self> {
+        match value {
+            "function" => Some(Self::Function),
+            "class" => Some(Self::Class),
+            "method" => Some(Self::Method),
+            "type" => Some(Self::Type),
+            "constant" => Some(Self::Constant),
+            "unknown" => Some(Self::Unknown),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -135,11 +169,13 @@ impl Validate for SymbolRecord {
         require_non_empty(&self.content_hash, "content_hash")?;
         require_non_empty(&self.source_adapter, "source_adapter")?;
         require_non_empty(&self.indexed_at, "indexed_at")?;
+        validate_symbol_id(&self.id)?;
 
-        if self.kind == SymbolKind::Unknown {
+        let expected_id = build_symbol_id(&self.file_path, &self.qualified_name, self.kind)?;
+        if self.id != expected_id {
             return Err(ValidationError::InvalidField {
-                field: "kind",
-                reason: "must be a known symbol kind",
+                field: "id",
+                reason: "must match canonical {file}::{qualified_name}#{kind} format",
             });
         }
 
@@ -316,18 +352,23 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        FileRecord, QualityLevel, QualityMix, RepoRecord, SymbolKind, SymbolRecord, Validate,
+        build_symbol_id, disambiguate_symbol_id, normalize_file_path, parse_symbol_id,
+        validate_symbol_id, FileRecord, QualityLevel, QualityMix, RepoRecord, SymbolKind,
+        SymbolRecord, Validate,
     };
 
     fn valid_symbol_record() -> SymbolRecord {
+        let file_path = "src/main.rs";
+        let qualified_name = "crate::run";
+        let kind = SymbolKind::Function;
         SymbolRecord {
-            id: "src/main.rs::run#index_fn".to_string(),
+            id: build_symbol_id(file_path, qualified_name, kind).expect("build canonical id"),
             repo_id: "repo-1".to_string(),
-            file_path: "src/main.rs".to_string(),
+            file_path: file_path.to_string(),
             language: "rust".to_string(),
-            kind: SymbolKind::Function,
+            kind,
             name: "run".to_string(),
-            qualified_name: "crate::run".to_string(),
+            qualified_name: qualified_name.to_string(),
             signature: "fn run()".to_string(),
             start_line: 10,
             end_line: 12,
@@ -507,7 +548,7 @@ mod tests {
     #[test]
     fn symbol_kind_unknown_deserializes_and_fails_validation() {
         let payload = json!({
-            "id": "src/main.rs::run#index_fn",
+            "id": "src/main.rs::crate::run#unknown",
             "repo_id": "repo-1",
             "file_path": "src/main.rs",
             "language": "rust",
@@ -537,6 +578,113 @@ mod tests {
         let err = record
             .validate()
             .expect_err("expected unknown kind to fail");
-        assert!(format!("{err}").contains("kind"));
+        assert!(format!("{err}").contains("id"));
+    }
+
+    #[test]
+    fn symbol_id_constructor_is_stable_for_unchanged_identity() {
+        let id_a = build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Function)
+            .expect("build id");
+        let id_b = build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Function)
+            .expect("build id");
+
+        assert_eq!(id_a, id_b);
+    }
+
+    #[test]
+    fn symbol_id_changes_on_symbol_rename() {
+        let original = build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Function)
+            .expect("build id");
+        let renamed = build_symbol_id(
+            "src/lib.rs",
+            "crate::service::execute",
+            SymbolKind::Function,
+        )
+        .expect("build id");
+
+        assert_ne!(original, renamed);
+    }
+
+    #[test]
+    fn symbol_id_changes_on_file_move() {
+        let original = build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Function)
+            .expect("build id");
+        let moved = build_symbol_id(
+            "src/engine/lib.rs",
+            "crate::service::run",
+            SymbolKind::Function,
+        )
+        .expect("build id");
+
+        assert_ne!(original, moved);
+    }
+
+    #[test]
+    fn symbol_id_changes_on_kind_change() {
+        let function_id =
+            build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Function)
+                .expect("build id");
+        let method_id = build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Method)
+            .expect("build id");
+
+        assert_ne!(function_id, method_id);
+    }
+
+    #[test]
+    fn symbol_id_validation_rejects_malformed_values() {
+        for malformed in [
+            "",
+            "src/lib.rs#function",
+            "src/lib.rs::#function",
+            "::crate::run#function",
+            "src/lib.rs::crate::run",
+            "src/lib.rs::crate::run#",
+            "src/lib.rs::crate::run#invalid",
+            "src/lib.rs::crate::run#function@bad",
+            "src/lib.rs::crate::run#function@10:zero",
+            "src/lib.rs::crate::run#function@10:0",
+        ] {
+            assert!(
+                parse_symbol_id(malformed).is_err(),
+                "expected malformed id to fail: {malformed}"
+            );
+        }
+    }
+
+    #[test]
+    fn symbol_id_collision_disambiguation_is_deterministic() {
+        let base = build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Function)
+            .expect("build id");
+        let first = disambiguate_symbol_id(&base, 10, 20).expect("disambiguate");
+        let again = disambiguate_symbol_id(&base, 10, 20).expect("disambiguate");
+        let second = disambiguate_symbol_id(&base, 30, 20).expect("disambiguate");
+
+        assert_eq!(first, again);
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn symbol_id_parser_accepts_disambiguated_ids() {
+        let base = build_symbol_id("src/lib.rs", "crate::service::run", SymbolKind::Function)
+            .expect("build id");
+        let disambiguated = disambiguate_symbol_id(&base, 10, 20).expect("disambiguate");
+        let parsed = parse_symbol_id(&disambiguated).expect("parse disambiguated id");
+
+        assert_eq!(parsed.file_path, "src/lib.rs");
+        assert_eq!(parsed.qualified_name, "crate::service::run");
+        assert_eq!(parsed.kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn canonical_symbol_id_rejects_unknown_kind_token() {
+        let err = validate_symbol_id("src/lib.rs::crate::service::run#unknown")
+            .expect_err("unknown kind should fail canonical validation");
+        assert!(format!("{err}").contains("unknown"));
+    }
+
+    #[test]
+    fn file_path_normalization_removes_trailing_slashes() {
+        let normalized = normalize_file_path("src/lib.rs///").expect("normalize path");
+        assert_eq!(normalized, "src/lib.rs");
     }
 }

--- a/crates/core-model/src/symbol_id.rs
+++ b/crates/core-model/src/symbol_id.rs
@@ -1,0 +1,178 @@
+use crate::{SymbolKind, ValidationError, ValidationResult};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSymbolId {
+    pub file_path: String,
+    pub qualified_name: String,
+    pub kind: SymbolKind,
+}
+
+pub fn build_symbol_id(
+    file_path: &str,
+    qualified_name: &str,
+    kind: SymbolKind,
+) -> Result<String, ValidationError> {
+    let file_path = normalize_file_path(file_path)?;
+    let qualified_name = normalize_qualified_name(qualified_name)?;
+    if kind == SymbolKind::Unknown {
+        return Err(ValidationError::InvalidField {
+            field: "kind",
+            reason: "unknown is not allowed for canonical symbol id construction",
+        });
+    }
+
+    Ok(format!("{file_path}::{qualified_name}#{}", kind.as_str()))
+}
+
+pub fn parse_symbol_id(value: &str) -> Result<ParsedSymbolId, ValidationError> {
+    // ID format invariant: `file_path` must not contain `::`.
+    // We split on the first `::` and treat the remainder as `{qualified_name}#{kind}`.
+    let (file_path, symbol_part) = value
+        .split_once("::")
+        .ok_or(ValidationError::InvalidField {
+            field: "id",
+            reason: "must contain '::' separator",
+        })?;
+
+    let (qualified_name, kind_with_suffix) =
+        symbol_part
+            .rsplit_once('#')
+            .ok_or(ValidationError::InvalidField {
+                field: "id",
+                reason: "must contain '#{kind}' suffix",
+            })?;
+
+    let (kind_token, disambiguator) = match kind_with_suffix.split_once('@') {
+        Some((kind_token, disambiguator)) => (kind_token, Some(disambiguator)),
+        None => (kind_with_suffix, None),
+    };
+
+    let normalized_file = normalize_file_path(file_path)?;
+    let normalized_qualified = normalize_qualified_name(qualified_name)?;
+    let kind = SymbolKind::from_id_token(kind_token).ok_or(ValidationError::InvalidField {
+        field: "id",
+        reason: "kind token is invalid",
+    })?;
+    if let Some(disambiguator) = disambiguator {
+        validate_disambiguator(disambiguator)?;
+    }
+
+    Ok(ParsedSymbolId {
+        file_path: normalized_file,
+        qualified_name: normalized_qualified,
+        kind,
+    })
+}
+
+pub fn disambiguate_symbol_id(
+    base_id: &str,
+    start_byte: u64,
+    byte_length: u64,
+) -> Result<String, ValidationError> {
+    parse_symbol_id(base_id)?;
+    if byte_length == 0 {
+        return Err(ValidationError::InvalidField {
+            field: "byte_length",
+            reason: "must be greater than zero for collision disambiguation",
+        });
+    }
+
+    Ok(format!("{base_id}@{start_byte}:{byte_length}"))
+}
+
+pub fn normalize_file_path(value: &str) -> Result<String, ValidationError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(ValidationError::MissingField { field: "file_path" });
+    }
+
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut previous_was_slash = false;
+    for ch in trimmed.chars() {
+        let mapped = if ch == '\\' { '/' } else { ch };
+        if mapped == '/' {
+            if previous_was_slash {
+                continue;
+            }
+            previous_was_slash = true;
+        } else {
+            previous_was_slash = false;
+        }
+        normalized.push(mapped);
+    }
+
+    while normalized.ends_with('/') {
+        normalized.pop();
+    }
+
+    if normalized.is_empty() {
+        return Err(ValidationError::MissingField { field: "file_path" });
+    }
+    if normalized.contains("::") {
+        return Err(ValidationError::InvalidField {
+            field: "file_path",
+            reason: "must not contain '::' because it conflicts with symbol ID separators",
+        });
+    }
+
+    Ok(normalized)
+}
+
+pub fn normalize_qualified_name(value: &str) -> Result<String, ValidationError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(ValidationError::MissingField {
+            field: "qualified_name",
+        });
+    }
+
+    let parts: Vec<&str> = trimmed.split("::").map(str::trim).collect();
+    if parts.iter().any(|part| part.is_empty()) {
+        return Err(ValidationError::InvalidField {
+            field: "qualified_name",
+            reason: "must not contain empty path segments",
+        });
+    }
+
+    Ok(parts.join("::"))
+}
+
+pub fn validate_symbol_id(value: &str) -> ValidationResult {
+    let parsed = parse_symbol_id(value)?;
+    if parsed.kind == SymbolKind::Unknown {
+        return Err(ValidationError::InvalidField {
+            field: "id",
+            reason: "kind token 'unknown' is not allowed in canonical symbol IDs",
+        });
+    }
+    Ok(())
+}
+
+fn validate_disambiguator(value: &str) -> ValidationResult {
+    let (start_byte, byte_length) = value.split_once(':').ok_or(ValidationError::InvalidField {
+        field: "id",
+        reason: "invalid disambiguator; expected '@{start_byte}:{byte_length}'",
+    })?;
+
+    if start_byte.parse::<u64>().is_err() {
+        return Err(ValidationError::InvalidField {
+            field: "id",
+            reason: "disambiguator start_byte must be an unsigned integer",
+        });
+    }
+
+    let byte_length = byte_length
+        .parse::<u64>()
+        .map_err(|_| ValidationError::InvalidField {
+            field: "id",
+            reason: "disambiguator byte_length must be an unsigned integer",
+        })?;
+    if byte_length == 0 {
+        return Err(ValidationError::InvalidField {
+            field: "id",
+            reason: "disambiguator byte_length must be greater than zero",
+        });
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #17
  - Scope: Implement deterministic symbol ID construction/validation, normalization rules, and collision handling for canonical IDs in `core-model`.

  ## Changes

  - Added new `symbol_id` module:
    - `build_symbol_id(file, qualified_name, kind)` -> canonical `{file}::{qualified_name}#{kind}`
    - `parse_symbol_id(id)` -> parsed components (`file_path`, `qualified_name`, `kind`)
    - `validate_symbol_id(id)` -> canonical ID validity checks
    - `disambiguate_symbol_id(base_id, start_byte, byte_length)` -> deterministic collision suffix `@{start}:{len}`
    - Normalizers:
      - `normalize_file_path` (trim, slash normalization, dedupe, trailing slash removal)
      - `normalize_qualified_name` (segment trim and canonical `::` rejoin)
  - Added `ParsedSymbolId` struct for parsed representation.
  - Extended `SymbolKind` helpers for ID token conversion:
    - `as_str()`
    - `from_id_token(...)`
  - Wired canonical ID validation into `SymbolRecord::validate`:
    - ID must be valid canonical syntax
    - ID must match reconstructed canonical value from `file_path + qualified_name + kind`
    - Unknown kind token is rejected at canonical ID validation boundary
  - Added/clarified format invariants and separator constraints:
    - `file_path` must not contain `::` (reserved separator)
    - Disambiguated IDs are parseable and validated (`@{start_byte}:{byte_length}`)

  ## Acceptance Criteria Mapping

  - [x] ID constructor returns stable values for unchanged symbol identity.
  - [x] Validation rejects malformed IDs.
  - [x] Tests cover rename/move/change scenarios.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional checks:
    - `cargo build --workspace --all-features`
    - `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`

  ### New/updated test coverage

  - ID stability for unchanged identity
  - ID changes for:
    - symbol rename
    - file move
    - symbol kind change
  - Malformed ID rejection:
    - missing separators
    - invalid kind token
    - malformed disambiguator formats
  - Deterministic collision disambiguation
  - Parser acceptance of disambiguated IDs
  - Canonical validation rejects `#unknown` kind token
  - Path normalization strips trailing slashes

  ## Collision Handling Policy

  - Canonical ID: `{file}::{qualified_name}#{kind}`
  - If canonical identity collides (same canonical tuple at multiple spans), append deterministic suffix:
    - `@{start_byte}:{byte_length}`
  - Suffix format is parseable and validated; `byte_length` must be > 0.

  ## Risk and Mitigation

  - Risk: Stricter normalization/validation may reject previously accepted malformed IDs.
  - Mitigation: Added explicit parser/validator tests and deterministic normalization rules to keep behavior predictable and auditable.

  ## Security/Observability Impact

  - Security: Improves input hardening by rejecting malformed/ambiguous IDs and enforcing canonical provenance.
  - Logs/Metrics/Tracing: None in this ticket (model/validation layer only).