### PR TITLE
Add schema versioning baseline and migration contract

### DIFF
--- a/crates/core-model/src/lib.rs
+++ b/crates/core-model/src/lib.rs
@@ -6,8 +6,13 @@ use serde::{Deserialize, Serialize};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+pub mod schema_version;
 pub mod symbol_id;
 
+pub use schema_version::{
+    current_index_schema_version, migration_decision, parse_schema_version,
+    CoreModelMigrationContract, MigrationContract, MigrationDecision, SchemaVersion,
+};
 pub use symbol_id::{
     build_symbol_id, disambiguate_symbol_id, normalize_file_path, normalize_qualified_name,
     parse_symbol_id, validate_symbol_id, ParsedSymbolId,
@@ -268,6 +273,7 @@ impl Validate for RepoRecord {
         require_non_empty(&self.indexed_at, "indexed_at")?;
         require_non_empty(&self.index_version, "index_version")?;
 
+        parse_schema_version(&self.index_version)?;
         validate_rfc3339_timestamp(&self.indexed_at, "indexed_at")?;
         validate_optional_string(&self.git_head, "git_head")?;
 
@@ -412,7 +418,7 @@ mod tests {
             display_name: "CodeAtlas".to_string(),
             source_root: "/repo".to_string(),
             indexed_at: "2026-03-09T00:00:00Z".to_string(),
-            index_version: "v1".to_string(),
+            index_version: "1.0.0".to_string(),
             language_counts,
             file_count: 10,
             symbol_count: 90,

--- a/crates/core-model/src/schema_version.rs
+++ b/crates/core-model/src/schema_version.rs
@@ -1,0 +1,256 @@
+use std::cmp::Ordering;
+use std::fmt;
+
+use crate::ValidationError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchemaVersion {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+}
+
+impl SchemaVersion {
+    #[must_use]
+    pub const fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl PartialOrd for SchemaVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SchemaVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.major, self.minor, self.patch).cmp(&(other.major, other.minor, other.patch))
+    }
+}
+
+impl fmt::Display for SchemaVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationDecision {
+    NoAction,
+    MigrateInPlace {
+        from: SchemaVersion,
+        to: SchemaVersion,
+    },
+    ReindexRequired {
+        from: SchemaVersion,
+        to: SchemaVersion,
+    },
+    UnsupportedFutureVersion {
+        from: SchemaVersion,
+        to: SchemaVersion,
+    },
+}
+
+pub trait MigrationContract {
+    fn current_version(&self) -> SchemaVersion;
+
+    fn decision_for(&self, from: SchemaVersion) -> MigrationDecision {
+        migration_decision(from, self.current_version())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CoreModelMigrationContract;
+
+impl MigrationContract for CoreModelMigrationContract {
+    fn current_version(&self) -> SchemaVersion {
+        current_index_schema_version()
+    }
+}
+
+#[must_use]
+pub const fn current_index_schema_version() -> SchemaVersion {
+    SchemaVersion::new(1, 0, 0)
+}
+
+pub fn parse_schema_version(value: &str) -> Result<SchemaVersion, ValidationError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ValidationError::MissingField {
+            field: "index_version",
+        });
+    }
+
+    // Legacy `v<major>` is accepted for backward compatibility, but canonical
+    // persisted/displayed form is semver `major.minor.patch`.
+    if let Some(legacy_major) = value.strip_prefix('v') {
+        let major = parse_numeric(legacy_major, "index_version")?;
+        return Ok(SchemaVersion::new(major, 0, 0));
+    }
+
+    let parts: Vec<&str> = value.split('.').collect();
+    if parts.len() != 3 {
+        return Err(ValidationError::InvalidField {
+            field: "index_version",
+            reason: "must be semver `major.minor.patch` or legacy `v<major>`",
+        });
+    }
+
+    let major = parse_numeric(parts[0], "index_version")?;
+    let minor = parse_numeric(parts[1], "index_version")?;
+    let patch = parse_numeric(parts[2], "index_version")?;
+    Ok(SchemaVersion::new(major, minor, patch))
+}
+
+#[must_use]
+pub fn migration_decision(from: SchemaVersion, to: SchemaVersion) -> MigrationDecision {
+    if from == to {
+        return MigrationDecision::NoAction;
+    }
+
+    if from > to {
+        return MigrationDecision::UnsupportedFutureVersion { from, to };
+    }
+
+    // Pre-1.0 schema versions are treated conservatively as incompatible.
+    if from.major == 0 || to.major == 0 {
+        return MigrationDecision::ReindexRequired { from, to };
+    }
+
+    // Same-major upgrades are considered backward compatible for schema readers.
+    if from.major == to.major {
+        return MigrationDecision::NoAction;
+    }
+
+    // N-1 major support: one major behind can be migrated in place.
+    if from.major + 1 == to.major {
+        return MigrationDecision::MigrateInPlace { from, to };
+    }
+
+    MigrationDecision::ReindexRequired { from, to }
+}
+
+fn parse_numeric(value: &str, field: &'static str) -> Result<u16, ValidationError> {
+    if value.is_empty() {
+        return Err(ValidationError::InvalidField {
+            field,
+            reason: "contains empty numeric component",
+        });
+    }
+
+    if !value.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(ValidationError::InvalidField {
+            field,
+            reason: "contains non-numeric component",
+        });
+    }
+
+    value
+        .parse::<u16>()
+        .map_err(|_| ValidationError::InvalidField {
+            field,
+            reason: "numeric component is out of range",
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        current_index_schema_version, migration_decision, parse_schema_version,
+        CoreModelMigrationContract, MigrationContract, MigrationDecision, SchemaVersion,
+    };
+
+    #[test]
+    fn parses_semver_schema_version() {
+        let parsed = parse_schema_version("1.2.3").expect("parse semver");
+        assert_eq!(parsed, SchemaVersion::new(1, 2, 3));
+    }
+
+    #[test]
+    fn parses_legacy_schema_version() {
+        let parsed = parse_schema_version("v2").expect("parse legacy version");
+        assert_eq!(parsed, SchemaVersion::new(2, 0, 0));
+    }
+
+    #[test]
+    fn rejects_invalid_schema_versions() {
+        for invalid in ["", "v", "v2.1", "1.2", "1.a.0", "a.b.c", "1..0"] {
+            assert!(
+                parse_schema_version(invalid).is_err(),
+                "expected invalid schema version: {invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn migration_decision_covers_no_action() {
+        let version = SchemaVersion::new(1, 0, 0);
+        assert_eq!(
+            migration_decision(version, version),
+            MigrationDecision::NoAction
+        );
+    }
+
+    #[test]
+    fn migration_decision_supports_n_minus_one_major() {
+        let from = SchemaVersion::new(1, 4, 2);
+        let to = SchemaVersion::new(2, 0, 0);
+        assert_eq!(
+            migration_decision(from, to),
+            MigrationDecision::MigrateInPlace { from, to }
+        );
+    }
+
+    #[test]
+    fn migration_decision_treats_same_major_as_no_action() {
+        let from = SchemaVersion::new(1, 0, 0);
+        let to = SchemaVersion::new(1, 5, 0);
+        assert_eq!(migration_decision(from, to), MigrationDecision::NoAction);
+    }
+
+    #[test]
+    fn migration_decision_requires_reindex_for_pre_one_zero() {
+        let from = SchemaVersion::new(0, 1, 0);
+        let to = SchemaVersion::new(0, 2, 0);
+        assert_eq!(
+            migration_decision(from, to),
+            MigrationDecision::ReindexRequired { from, to }
+        );
+    }
+
+    #[test]
+    fn migration_decision_requires_reindex_for_older_majors() {
+        let from = SchemaVersion::new(1, 0, 0);
+        let to = SchemaVersion::new(3, 0, 0);
+        assert_eq!(
+            migration_decision(from, to),
+            MigrationDecision::ReindexRequired { from, to }
+        );
+    }
+
+    #[test]
+    fn migration_decision_rejects_future_versions() {
+        let from = SchemaVersion::new(2, 0, 0);
+        let to = SchemaVersion::new(1, 9, 0);
+        assert_eq!(
+            migration_decision(from, to),
+            MigrationDecision::UnsupportedFutureVersion { from, to }
+        );
+    }
+
+    #[test]
+    fn migration_contract_uses_current_version() {
+        let contract = CoreModelMigrationContract;
+        let current = contract.current_version();
+        assert_eq!(current, current_index_schema_version());
+
+        let from = SchemaVersion::new(1, 0, 0);
+        let decision = contract.decision_for(from);
+        assert_eq!(decision, MigrationDecision::NoAction);
+    }
+}

--- a/crates/core-model/tests/fixtures/migration_contract_cases.v1.json
+++ b/crates/core-model/tests/fixtures/migration_contract_cases.v1.json
@@ -1,0 +1,32 @@
+[
+  {
+    "from": "1.0.0",
+    "to": "1.0.0",
+    "expected": "no_action"
+  },
+  {
+    "from": "1.2.0",
+    "to": "1.3.0",
+    "expected": "no_action"
+  },
+  {
+    "from": "1.5.0",
+    "to": "2.0.0",
+    "expected": "migrate_in_place"
+  },
+  {
+    "from": "1.0.0",
+    "to": "3.0.0",
+    "expected": "reindex_required"
+  },
+  {
+    "from": "2.1.0",
+    "to": "1.9.0",
+    "expected": "unsupported_future_version"
+  },
+  {
+    "from": "0.1.0",
+    "to": "0.2.0",
+    "expected": "reindex_required"
+  }
+]

--- a/crates/core-model/tests/fixtures/repo_record.v1.extra_field.json
+++ b/crates/core-model/tests/fixtures/repo_record.v1.extra_field.json
@@ -3,7 +3,7 @@
   "display_name": "CodeAtlas",
   "source_root": "/repo",
   "indexed_at": "2026-03-09T00:00:00Z",
-  "index_version": "v1",
+  "index_version": "1.0.0",
   "language_counts": {
     "kotlin": 3,
     "rust": 10,

--- a/crates/core-model/tests/fixtures/repo_record.v1.json
+++ b/crates/core-model/tests/fixtures/repo_record.v1.json
@@ -3,7 +3,7 @@
   "display_name": "CodeAtlas",
   "source_root": "/repo",
   "indexed_at": "2026-03-09T00:00:00Z",
-  "index_version": "v1",
+  "index_version": "1.0.0",
   "language_counts": {
     "kotlin": 3,
     "rust": 10,

--- a/crates/core-model/tests/schema_migration_contract.rs
+++ b/crates/core-model/tests/schema_migration_contract.rs
@@ -1,0 +1,41 @@
+use serde::Deserialize;
+
+use core_model::{migration_decision, parse_schema_version, MigrationDecision};
+
+const MIGRATION_CASES_V1: &str = include_str!("fixtures/migration_contract_cases.v1.json");
+
+#[derive(Debug, Deserialize)]
+struct MigrationCase {
+    from: String,
+    to: String,
+    expected: String,
+}
+
+#[test]
+fn migration_contract_fixture_cases_match_expected_decisions() {
+    let cases: Vec<MigrationCase> =
+        serde_json::from_str(MIGRATION_CASES_V1).expect("deserialize migration cases fixture");
+
+    for case in cases {
+        let from = parse_schema_version(&case.from).expect("parse from version");
+        let to = parse_schema_version(&case.to).expect("parse to version");
+        let decision = migration_decision(from, to);
+        let expected = expected_decision(case.expected.as_str(), from, to);
+
+        assert_eq!(decision, expected, "case from={} to={}", case.from, case.to);
+    }
+}
+
+fn expected_decision(
+    expected: &str,
+    from: core_model::SchemaVersion,
+    to: core_model::SchemaVersion,
+) -> MigrationDecision {
+    match expected {
+        "no_action" => MigrationDecision::NoAction,
+        "migrate_in_place" => MigrationDecision::MigrateInPlace { from, to },
+        "reindex_required" => MigrationDecision::ReindexRequired { from, to },
+        "unsupported_future_version" => MigrationDecision::UnsupportedFutureVersion { from, to },
+        other => panic!("unexpected expected decision token: {other}"),
+    }
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #19
  - Scope: Add schema versioning baseline and migration contract in `core-model`, with deterministic version parsing/guards and fixture-backed migration compatibility tests.

  ## Changes

  - Added schema versioning module:
    - `crates/core-model/src/schema_version.rs`
    - Introduced:
      - `SchemaVersion { major, minor, patch }`
      - `MigrationDecision` (`NoAction`, `MigrateInPlace`, `ReindexRequired`, `UnsupportedFutureVersion`)
      - `MigrationContract` trait
      - `CoreModelMigrationContract` baseline implementation
      - `current_index_schema_version()`
      - `parse_schema_version(...)`
      - `migration_decision(...)`
  - Integrated schema version guard into model validation:
    - `RepoRecord::validate()` now parses/validates `index_version`
    - via `parse_schema_version(&self.index_version)`
  - Made semver ordering explicit:
    - Manual `Ord`/`PartialOrd` implementation for `SchemaVersion` (tuple compare on `(major, minor, patch)`)
  - Clarified compatibility semantics:
    - Same-major upgrades => `NoAction`
    - N-1 major upgrades => `MigrateInPlace`
    - Older majors => `ReindexRequired`
    - Future versions => `UnsupportedFutureVersion`
    - Pre-1.0 (`0.x`) treated conservatively as `ReindexRequired`
  - Preserved backward parsing compatibility while canonicalizing format:
    - `v<N>` is still accepted by parser
    - Canonical format remains `major.minor.patch`

  ## Fixtures and Tests

  - Added migration contract fixture:
    - `crates/core-model/tests/fixtures/migration_contract_cases.v1.json`
  - Added integration test:
    - `crates/core-model/tests/schema_migration_contract.rs`
  - Added/updated unit tests in `schema_version.rs`:
    - semver + legacy parsing
    - invalid version guards
    - decision branches (same-major, N-1, reindex, future, pre-1.0)
    - contract current-version behavior
  - Updated repo compatibility fixtures to canonical semver:
    - `crates/core-model/tests/fixtures/repo_record.v1.json` (`index_version: "1.0.0"`)
    - `crates/core-model/tests/fixtures/repo_record.v1.extra_field.json` (`index_version: "1.0.0"`)

  ## Acceptance Criteria Mapping

  - [x] Deliverable implemented and integrated.
  - [x] Edge cases and failure behavior handled explicitly.
  - [x] Deterministic behavior is test-covered where relevant.
  - [x] CI checks pass.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional checks:
    - `cargo build --workspace --all-features`
    - `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`

  ## Risk and Mitigation

  - Risk: Decision semantics changed for same-major upgrades (`MigrateInPlace` -> `NoAction`), which may affect downstream branching.
  - Mitigation: Behavior is now explicitly tested in unit + fixture integration tests and aligned to semver-compatible expectations.

  ## Security/Observability Impact

  - Security: No runtime security-surface expansion; improves validation strictness for `index_version`.
  - Logs/Metrics/Tracing: None in this ticket (model/versioning contract layer only).
