### PR TITLE
Implement repository walker with ignore rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,43 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "core-model"
 version = "0.1.0"
 dependencies = [
@@ -10,6 +47,31 @@ dependencies = [
  "serde_json",
  "time",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deranged"
@@ -21,10 +83,143 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -39,10 +234,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -61,6 +272,66 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "repo-walker"
+version = "0.1.0"
+dependencies = [
+ "globset",
+ "ignore",
+ "tempfile",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -117,6 +388,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +436,186 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "workspace-placeholder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/core-model","crates/workspace-placeholder"]
+members = ["crates/core-model", "crates/repo-walker", "crates/workspace-placeholder"]
 resolver = "2"
 
 [workspace.package]
@@ -9,6 +9,9 @@ rust-version = "1.81"
 repository = "https://github.com/developepper/CodeAtlas"
 
 [workspace.dependencies]
+globset = "0.4.16"
+ignore = "0.4.24"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+tempfile = "3.20.0"
 time = { version = "0.3.37", features = ["parsing", "formatting"] }

--- a/crates/repo-walker/Cargo.toml
+++ b/crates/repo-walker/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "repo-walker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+globset.workspace = true
+ignore.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/repo-walker/src/lib.rs
+++ b/crates/repo-walker/src/lib.rs
@@ -1,0 +1,273 @@
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use globset::{Glob, GlobMatcher};
+use ignore::WalkBuilder;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredFile {
+    pub relative_path: PathBuf,
+    pub absolute_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WalkerOptions {
+    pub extra_ignore_rules: Vec<String>,
+    pub include_git_dir: bool,
+}
+
+#[derive(Debug)]
+pub enum WalkError {
+    InvalidRoot {
+        path: PathBuf,
+        reason: &'static str,
+    },
+    InvalidIgnoreRule {
+        rule: String,
+        reason: String,
+    },
+    Io {
+        path: Option<PathBuf>,
+        source: std::io::Error,
+    },
+}
+
+impl fmt::Display for WalkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRoot { path, reason } => {
+                write!(f, "invalid repository root '{}': {reason}", path.display())
+            }
+            Self::InvalidIgnoreRule { rule, reason } => {
+                write!(f, "invalid ignore rule '{rule}': {reason}")
+            }
+            Self::Io { path, source } => {
+                if let Some(path) = path {
+                    write!(f, "I/O error at '{}': {source}", path.display())
+                } else {
+                    write!(f, "I/O error: {source}")
+                }
+            }
+        }
+    }
+}
+
+impl Error for WalkError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct IgnoreRule {
+    matcher: GlobMatcher,
+    is_ignore: bool,
+}
+
+pub fn walk_repository(
+    root: &Path,
+    options: &WalkerOptions,
+) -> Result<Vec<DiscoveredFile>, WalkError> {
+    ensure_root_is_valid(root)?;
+    let root = fs::canonicalize(root).map_err(|source| WalkError::Io {
+        path: Some(root.to_path_buf()),
+        source,
+    })?;
+
+    let extra_rules = compile_ignore_rules(&options.extra_ignore_rules)?;
+    let mut builder = WalkBuilder::new(&root);
+    builder.hidden(false);
+    builder.git_ignore(true);
+    builder.git_global(false);
+    builder.git_exclude(false);
+    builder.ignore(true);
+    builder.require_git(false);
+    builder.parents(true);
+    builder.follow_links(false);
+
+    let mut discovered = Vec::new();
+
+    for entry in builder.build() {
+        let entry = entry.map_err(|err| WalkError::Io {
+            path: None,
+            source: std::io::Error::other(err.to_string()),
+        })?;
+
+        let Some(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let absolute = entry.path().to_path_buf();
+        let relative = absolute
+            .strip_prefix(&root)
+            .map_err(|source| WalkError::Io {
+                path: Some(absolute.clone()),
+                source: std::io::Error::other(source.to_string()),
+            })?
+            .to_path_buf();
+
+        if !options.include_git_dir && starts_with_git_dir(&relative) {
+            continue;
+        }
+
+        if is_ignored_by_extra_rules(&relative, &extra_rules) {
+            continue;
+        }
+
+        discovered.push(DiscoveredFile {
+            relative_path: relative,
+            absolute_path: absolute,
+        });
+    }
+
+    discovered.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    Ok(discovered)
+}
+
+fn ensure_root_is_valid(root: &Path) -> Result<(), WalkError> {
+    if !root.exists() {
+        return Err(WalkError::InvalidRoot {
+            path: root.to_path_buf(),
+            reason: "path does not exist",
+        });
+    }
+    if !root.is_dir() {
+        return Err(WalkError::InvalidRoot {
+            path: root.to_path_buf(),
+            reason: "path is not a directory",
+        });
+    }
+
+    Ok(())
+}
+
+fn compile_ignore_rules(rules: &[String]) -> Result<Vec<IgnoreRule>, WalkError> {
+    let mut compiled = Vec::new();
+
+    for rule in rules {
+        let trimmed = rule.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let (is_ignore, pattern) = if let Some(pattern) = trimmed.strip_prefix('!') {
+            (false, pattern.trim())
+        } else {
+            (true, trimmed)
+        };
+
+        if pattern.is_empty() {
+            return Err(WalkError::InvalidIgnoreRule {
+                rule: rule.clone(),
+                reason: "pattern is empty".to_string(),
+            });
+        }
+
+        let normalized_pattern = normalize_pattern(pattern);
+        let glob = Glob::new(&normalized_pattern).map_err(|err| WalkError::InvalidIgnoreRule {
+            rule: rule.clone(),
+            reason: err.to_string(),
+        })?;
+
+        compiled.push(IgnoreRule {
+            matcher: glob.compile_matcher(),
+            is_ignore,
+        });
+    }
+
+    Ok(compiled)
+}
+
+fn normalize_pattern(pattern: &str) -> String {
+    let mut normalized = pattern.replace('\\', "/");
+    let anchored_to_root = normalized.starts_with('/');
+    if anchored_to_root {
+        normalized = normalized.trim_start_matches('/').to_string();
+    }
+
+    if normalized.ends_with('/') {
+        normalized.push_str("**");
+    }
+
+    let has_separator = normalized.contains('/');
+    if !anchored_to_root && !has_separator {
+        normalized = format!("**/{normalized}");
+    }
+
+    normalized
+}
+
+fn starts_with_git_dir(path: &Path) -> bool {
+    path.components()
+        .next()
+        .is_some_and(|component| component.as_os_str() == ".git")
+}
+
+fn is_ignored_by_extra_rules(path: &Path, rules: &[IgnoreRule]) -> bool {
+    let candidate = path.to_string_lossy().replace('\\', "/");
+    let mut ignored = false;
+
+    for rule in rules {
+        if rule.matcher.is_match(&candidate) {
+            ignored = rule.is_ignore;
+        }
+    }
+
+    ignored
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compile_ignore_rules, is_ignored_by_extra_rules};
+    use std::path::Path;
+
+    #[test]
+    fn extra_ignore_rules_support_negation_and_ordering() {
+        let rules = compile_ignore_rules(&[
+            "src/**".to_string(),
+            "!src/main.rs".to_string(),
+            "src/generated/**".to_string(),
+        ])
+        .expect("compile rules");
+
+        assert!(!is_ignored_by_extra_rules(Path::new("src/main.rs"), &rules));
+        assert!(is_ignored_by_extra_rules(Path::new("src/lib.rs"), &rules));
+        assert!(is_ignored_by_extra_rules(
+            Path::new("src/generated/file.rs"),
+            &rules
+        ));
+    }
+
+    #[test]
+    fn empty_or_comment_rules_are_ignored() {
+        let rules = compile_ignore_rules(&[
+            "".to_string(),
+            "   ".to_string(),
+            "# ignore comments".to_string(),
+        ])
+        .expect("compile rules");
+
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn invalid_ignore_rule_is_rejected() {
+        let err = compile_ignore_rules(&["[".to_string()]).expect_err("invalid rule should fail");
+        assert!(err.to_string().contains("invalid ignore rule"));
+    }
+
+    #[test]
+    fn basename_ignore_rule_matches_nested_paths() {
+        let rules = compile_ignore_rules(&["*.log".to_string()]).expect("compile rules");
+        assert!(is_ignored_by_extra_rules(Path::new("logs/run.log"), &rules));
+        assert!(is_ignored_by_extra_rules(Path::new("run.log"), &rules));
+    }
+}

--- a/crates/repo-walker/tests/walk_integration.rs
+++ b/crates/repo-walker/tests/walk_integration.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::path::Path;
+
+use repo_walker::{walk_repository, WalkerOptions};
+use tempfile::TempDir;
+
+#[test]
+fn walker_honors_gitignore_and_returns_deterministic_order() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write(
+            ".gitignore",
+            "target/\nlogs/*.log\nsubdir/*.tmp\n!subdir/keep.tmp\n",
+        )
+        .expect("write .gitignore");
+    fixture.write("README.md", "# Repo\n").expect("write file");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write file");
+    fixture
+        .write("target/out.txt", "ignored\n")
+        .expect("write file");
+    fixture
+        .write("logs/run.log", "ignored\n")
+        .expect("write file");
+    fixture
+        .write("subdir/skip.tmp", "ignored\n")
+        .expect("write file");
+    fixture
+        .write("subdir/keep.tmp", "kept\n")
+        .expect("write file");
+
+    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&results);
+
+    assert_eq!(
+        paths,
+        vec![
+            ".gitignore".to_string(),
+            "README.md".to_string(),
+            "src/main.rs".to_string(),
+            "subdir/keep.tmp".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn walker_applies_extra_ignore_rules_with_negation() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture.write("README.md", "# Repo\n").expect("write file");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write file");
+    fixture
+        .write("src/lib.rs", "pub fn lib() {}\n")
+        .expect("write file");
+
+    let options = WalkerOptions {
+        extra_ignore_rules: vec!["src/**".to_string(), "!src/main.rs".to_string()],
+        include_git_dir: false,
+    };
+    let results = walk_repository(fixture.path(), &options).expect("walk repo");
+    let paths = relative_paths(&results);
+
+    assert_eq!(
+        paths,
+        vec!["README.md".to_string(), "src/main.rs".to_string()]
+    );
+}
+
+#[test]
+fn walker_honors_dot_ignore_files() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write(".ignore", "tmp/**\n!tmp/keep.txt\n")
+        .expect("write .ignore");
+    fixture
+        .write("tmp/skip.txt", "ignored\n")
+        .expect("write file");
+    fixture.write("tmp/keep.txt", "keep\n").expect("write file");
+    fixture.write("README.md", "# Repo\n").expect("write file");
+
+    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&results);
+
+    assert_eq!(
+        paths,
+        vec![
+            ".ignore".to_string(),
+            "README.md".to_string(),
+            "tmp/keep.txt".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn walker_rejects_invalid_root() {
+    let missing = Path::new("/definitely/not/a/repo");
+    let err = walk_repository(missing, &WalkerOptions::default()).expect_err("walk should fail");
+    assert!(err.to_string().contains("invalid repository root"));
+}
+
+fn relative_paths(results: &[repo_walker::DiscoveredFile]) -> Vec<String> {
+    results
+        .iter()
+        .map(|item| item.relative_path.to_string_lossy().replace('\\', "/"))
+        .collect()
+}
+
+struct FixtureRepo {
+    tempdir: TempDir,
+}
+
+impl FixtureRepo {
+    fn new() -> Result<Self, std::io::Error> {
+        Ok(Self {
+            tempdir: tempfile::tempdir()?,
+        })
+    }
+
+    fn path(&self) -> &Path {
+        self.tempdir.path()
+    }
+
+    fn write(&self, rel: &str, contents: &str) -> Result<(), std::io::Error> {
+        let path = self.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, contents)
+    }
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #20
  - Scope: Implement deterministic repository walking with ignore-rule support, including path filtering unit tests and fixture-based integration tests.

  ## Changes

  - Added new crate:
    - `crates/repo-walker`
  - Added deterministic repository walker API:
    - `walk_repository(root, options) -> Vec<DiscoveredFile>`
    - Stable global ordering by relative path
    - Typed options via `WalkerOptions`
    - Typed errors via `WalkError`
  - Implemented ignore behavior:
    - Honors `.gitignore` and parent ignore files
    - Honors `.ignore` files
    - Supports extra ignore rules with negation (`!pattern`) and last-match-wins semantics
    - Supports walking non-git directories (`require_git(false)`)
    - Excludes `.git` directory by default (configurable via `include_git_dir`)
  - Implemented extra-rule normalization:
    - Basename patterns (e.g. `*.log`) apply at any depth
    - Trailing `/` patterns normalized to directory globs (`.../**`)
    - Root-anchored patterns (`/foo`) handled consistently
  - Added tests:
    - Unit tests for ignore-rule parsing/ordering/validation
    - Integration tests for:
      - `.gitignore` filtering + deterministic output
      - `.ignore` filtering
      - extra-rule negation behavior
      - invalid root handling

  ## Acceptance Criteria Mapping

  - [x] Deliverable implemented and integrated.
  - [x] Edge cases and failure behavior handled explicitly.
  - [x] Deterministic behavior is test-covered where relevant.
  - [x] CI checks pass.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional checks:
    - `cargo build --workspace --all-features`
    - `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`

  ## Architectural Notes

  - This introduces a dedicated `repo-walker` crate instead of embedding discovery directly into `indexer` at this stage.
    - Intent: keep discovery deterministic and reusable as an isolated boundary.
    - Follow-on: `indexer` tickets (e.g., [#60/](https://github.com/developepper/CodeAtlas/compare/ticket/20-repository-walker-ignore-rules?expand=1#60/)#68) can depend on this crate for pipeline wiring.
  - Security filtering for sensitive/binary/path-abuse handling is intentionally deferred to `#21` per ticket scope (this ticket focuses on deterministic walking + ignore semantics).

  ## Risk and Mitigation

  - Risk: Temporary crate-structure deviation from spec’s indexer-centric list may create future integration ambiguity.
  - Mitigation: Deviation is explicit in this PR; later pipeline tickets will integrate `repo-walker` into `indexer` boundaries.

  ## Security/Observability Impact

  - Security: No code execution or symlink following; `.git` directory excluded by default.
  - Observability: No new metrics/logging in this ticket (planned in `#23`).