### PR TITLE
Add security filters for traversal, symlink, binary, and size caps

### DIFF
--- a/crates/repo-walker/src/lib.rs
+++ b/crates/repo-walker/src/lib.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fmt;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use globset::{Glob, GlobMatcher};
@@ -12,10 +13,25 @@ pub struct DiscoveredFile {
     pub absolute_path: PathBuf,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct WalkerOptions {
     pub extra_ignore_rules: Vec<String>,
     pub include_git_dir: bool,
+    pub max_file_size_bytes: Option<u64>,
+    pub max_file_count: Option<usize>,
+    pub skip_binary_files: bool,
+}
+
+impl Default for WalkerOptions {
+    fn default() -> Self {
+        Self {
+            extra_ignore_rules: Vec::new(),
+            include_git_dir: false,
+            max_file_size_bytes: None,
+            max_file_count: None,
+            skip_binary_files: true,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -27,6 +43,10 @@ pub enum WalkError {
     InvalidIgnoreRule {
         rule: String,
         reason: String,
+    },
+    LimitExceeded {
+        kind: &'static str,
+        limit: usize,
     },
     Io {
         path: Option<PathBuf>,
@@ -42,6 +62,9 @@ impl fmt::Display for WalkError {
             }
             Self::InvalidIgnoreRule { rule, reason } => {
                 write!(f, "invalid ignore rule '{rule}': {reason}")
+            }
+            Self::LimitExceeded { kind, limit } => {
+                write!(f, "configured {kind} limit exceeded: {limit}")
             }
             Self::Io { path, source } => {
                 if let Some(path) = path {
@@ -113,13 +136,38 @@ pub fn walk_repository(
                 source: std::io::Error::other(source.to_string()),
             })?
             .to_path_buf();
+        validate_relative_path(&relative)?;
 
         if !options.include_git_dir && starts_with_git_dir(&relative) {
             continue;
         }
 
+        // `follow_links(false)` prevents descending into symlinked directories,
+        // but symlink entries can still be yielded as files. Explicitly drop them.
+        let metadata = symlink_metadata(&absolute)?;
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+
         if is_ignored_by_extra_rules(&relative, &extra_rules) {
             continue;
+        }
+
+        if exceeds_size_cap(metadata.len(), options.max_file_size_bytes) {
+            continue;
+        }
+
+        if options.skip_binary_files && is_probably_binary_file(&absolute)? {
+            continue;
+        }
+
+        if let Some(limit) = options.max_file_count {
+            if discovered.len() >= limit {
+                return Err(WalkError::LimitExceeded {
+                    kind: "file_count",
+                    limit,
+                });
+            }
         }
 
         discovered.push(DiscoveredFile {
@@ -211,6 +259,64 @@ fn starts_with_git_dir(path: &Path) -> bool {
         .is_some_and(|component| component.as_os_str() == ".git")
 }
 
+fn validate_relative_path(path: &Path) -> Result<(), WalkError> {
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => {
+                return Err(WalkError::Io {
+                    path: Some(path.to_path_buf()),
+                    source: std::io::Error::other("detected unsafe traversal component"),
+                });
+            }
+            std::path::Component::CurDir | std::path::Component::Normal(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn symlink_metadata(path: &Path) -> Result<fs::Metadata, WalkError> {
+    fs::symlink_metadata(path).map_err(|source| WalkError::Io {
+        path: Some(path.to_path_buf()),
+        source,
+    })
+}
+
+fn exceeds_size_cap(file_size: u64, max_file_size_bytes: Option<u64>) -> bool {
+    let Some(limit) = max_file_size_bytes else {
+        return false;
+    };
+    file_size > limit
+}
+
+fn is_probably_binary_file(path: &Path) -> Result<bool, WalkError> {
+    const SAMPLE_BYTES: usize = 8 * 1024;
+    const KNOWN_BINARY_EXTENSIONS: &[&str] = &[
+        "png", "jpg", "jpeg", "gif", "webp", "bmp", "ico", "pdf", "zip", "gz", "tar", "7z", "exe",
+        "dll", "so", "dylib", "class", "jar", "woff", "woff2",
+    ];
+
+    if let Some(extension) = path.extension().and_then(|ext| ext.to_str()) {
+        let ext = extension.to_ascii_lowercase();
+        if KNOWN_BINARY_EXTENSIONS.contains(&ext.as_str()) {
+            return Ok(true);
+        }
+    }
+
+    let mut file = fs::File::open(path).map_err(|source| WalkError::Io {
+        path: Some(path.to_path_buf()),
+        source,
+    })?;
+    let mut buffer = [0_u8; SAMPLE_BYTES];
+    let read = file.read(&mut buffer).map_err(|source| WalkError::Io {
+        path: Some(path.to_path_buf()),
+        source,
+    })?;
+
+    Ok(buffer[..read].contains(&0))
+}
+
 fn is_ignored_by_extra_rules(path: &Path, rules: &[IgnoreRule]) -> bool {
     let candidate = path.to_string_lossy().replace('\\', "/");
     let mut ignored = false;
@@ -226,7 +332,9 @@ fn is_ignored_by_extra_rules(path: &Path, rules: &[IgnoreRule]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{compile_ignore_rules, is_ignored_by_extra_rules};
+    use super::{
+        compile_ignore_rules, exceeds_size_cap, is_ignored_by_extra_rules, validate_relative_path,
+    };
     use std::path::Path;
 
     #[test]
@@ -269,5 +377,18 @@ mod tests {
         let rules = compile_ignore_rules(&["*.log".to_string()]).expect("compile rules");
         assert!(is_ignored_by_extra_rules(Path::new("logs/run.log"), &rules));
         assert!(is_ignored_by_extra_rules(Path::new("run.log"), &rules));
+    }
+
+    #[test]
+    fn traversal_components_are_rejected() {
+        let err = validate_relative_path(Path::new("../outside.txt"))
+            .expect_err("path traversal should fail");
+        assert!(err.to_string().contains("unsafe traversal"));
+    }
+
+    #[test]
+    fn size_cap_is_strictly_greater_than_limit() {
+        assert!(!exceeds_size_cap(5, Some(5)));
+        assert!(exceeds_size_cap(6, Some(5)));
     }
 }

--- a/crates/repo-walker/tests/walk_integration.rs
+++ b/crates/repo-walker/tests/walk_integration.rs
@@ -58,6 +58,9 @@ fn walker_applies_extra_ignore_rules_with_negation() {
     let options = WalkerOptions {
         extra_ignore_rules: vec!["src/**".to_string(), "!src/main.rs".to_string()],
         include_git_dir: false,
+        max_file_size_bytes: None,
+        max_file_count: None,
+        skip_binary_files: true,
     };
     let results = walk_repository(fixture.path(), &options).expect("walk repo");
     let paths = relative_paths(&results);
@@ -100,6 +103,89 @@ fn walker_rejects_invalid_root() {
     assert!(err.to_string().contains("invalid repository root"));
 }
 
+#[test]
+fn walker_skips_binary_files_by_default() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write text file");
+    fixture
+        .write_bytes("bin/data.bin", &[0, 1, 2, 3, 4, 5])
+        .expect("write binary file");
+
+    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&results);
+    assert_eq!(paths, vec!["src/main.rs".to_string()]);
+}
+
+#[test]
+fn walker_applies_file_size_cap() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("small.txt", "12345")
+        .expect("write small file");
+    fixture
+        .write("large.txt", "1234567890")
+        .expect("write large file");
+
+    let options = WalkerOptions {
+        max_file_size_bytes: Some(5),
+        ..WalkerOptions::default()
+    };
+    let results = walk_repository(fixture.path(), &options).expect("walk repo");
+    let paths = relative_paths(&results);
+    // Boundary behavior: exactly 5 bytes is included, >5 bytes is excluded.
+    assert_eq!(paths, vec!["small.txt".to_string()]);
+}
+
+#[test]
+fn walker_skips_symlinked_files() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write text file");
+    fixture
+        .write("outside.txt", "outside")
+        .expect("write outside file");
+    fixture
+        .symlink_file("outside.txt", "src/outside-link.txt")
+        .expect("create symlink");
+
+    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&results);
+    assert_eq!(
+        paths,
+        vec!["outside.txt".to_string(), "src/main.rs".to_string()]
+    );
+}
+
+#[test]
+fn walker_skips_known_binary_extensions_even_without_nul_bytes() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("assets/image.png", "not-a-real-png-but-binary-by-extension")
+        .expect("write extension-marked binary");
+    fixture.write("README.md", "# Repo\n").expect("write file");
+
+    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&results);
+    assert_eq!(paths, vec!["README.md".to_string()]);
+}
+
+#[test]
+fn walker_enforces_file_count_limit() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture.write("a.txt", "a").expect("write file");
+    fixture.write("b.txt", "b").expect("write file");
+
+    let options = WalkerOptions {
+        max_file_count: Some(1),
+        ..WalkerOptions::default()
+    };
+    let err = walk_repository(fixture.path(), &options).expect_err("expected file count limit");
+    assert!(err.to_string().contains("file_count"));
+}
+
 fn relative_paths(results: &[repo_walker::DiscoveredFile]) -> Vec<String> {
     results
         .iter()
@@ -129,4 +215,31 @@ impl FixtureRepo {
         }
         fs::write(path, contents)
     }
+
+    fn write_bytes(&self, rel: &str, contents: &[u8]) -> Result<(), std::io::Error> {
+        let path = self.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, contents)
+    }
+
+    fn symlink_file(&self, source_rel: &str, target_rel: &str) -> Result<(), std::io::Error> {
+        let source = self.path().join(source_rel);
+        let target = self.path().join(target_rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        create_symlink_file(&source, &target)
+    }
+}
+
+#[cfg(unix)]
+fn create_symlink_file(source: &Path, target: &Path) -> Result<(), std::io::Error> {
+    std::os::unix::fs::symlink(source, target)
+}
+
+#[cfg(windows)]
+fn create_symlink_file(source: &Path, target: &Path) -> Result<(), std::io::Error> {
+    std::os::windows::fs::symlink_file(source, target)
 }


### PR DESCRIPTION
## Summary

  - Issue: Closes #21
  - Scope: Add security filters to discovery for traversal/symlink/binary/size-cap handling, with deterministic behavior and explicit security-focused tests.

  ## Changes

  - Extended `repo-walker` security filtering in `walk_repository`:
    - Traversal guard on discovered relative paths
    - Symlink exclusion for yielded file entries
    - Binary-file filtering (enabled by default)
    - Optional max file size cap
    - Optional max file count limit to prevent unbounded memory growth
  - Added/updated walker options:
    - `max_file_size_bytes: Option<u64>`
    - `max_file_count: Option<usize>`
    - `skip_binary_files: bool` (default `true`)
  - Added richer limit error:
    - `WalkError::LimitExceeded { kind, limit }`
  - Binary detection improvements:
    - Fast-path skip for known binary extensions
    - Fallback NUL-byte heuristic from first 8KB sample
  - Performance refinement:
    - Reused single `symlink_metadata` call for symlink + size checks (avoids double stat)

  ## Acceptance Criteria Mapping

  - [x] Deliverable implemented and integrated.
  - [x] Edge cases and failure behavior handled explicitly.
  - [x] Deterministic behavior is test-covered where relevant.
  - [x] CI checks pass.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional checks:
    - `cargo build --workspace --all-features`
    - `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`

  ### Security test coverage added

  - Traversal guard:
    - Unit test rejects `../...` components
  - Symlink handling:
    - Integration test ensures symlinked files are skipped
  - Binary filtering:
    - Integration test for NUL-byte binary
    - Integration test for known binary extension fast-path
  - Size cap:
    - Integration test enforces cap
    - Unit test confirms strict boundary (`len > limit` excluded; `len == limit` included)
  - File count cap:
    - Integration test returns `LimitExceeded` when limit is exceeded

  ## Design Notes

  - `follow_links(false)` prevents descending into symlinked directories, but symlink entries can still be yielded as file entries; explicit symlink filtering is retained intentionally.
  - Security scope is now covered for traversal/symlink/binary/size/file-count filtering in discovery stage.

  ## Risk and Mitigation

  - Risk: Aggressive binary heuristics may exclude edge-case text-like files with binary extensions.
  - Mitigation: Fast-path is extension-based for common binaries plus content heuristic; behavior is configurable via `skip_binary_files`.

  ## Security/Observability Impact

  - Security: Positive hardening for untrusted repository inputs; reduces traversal/symlink abuse and oversized/binary ingestion risk.
  - Observability: No new metrics/logging in this ticket (planned in #23).