### PR TITLE
Add language detection with deterministic fallback

### DIFF
--- a/crates/repo-walker/src/language.rs
+++ b/crates/repo-walker/src/language.rs
@@ -1,0 +1,255 @@
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    Rust,
+    TypeScript,
+    JavaScript,
+    Kotlin,
+    Java,
+    Python,
+    Php,
+    Go,
+    Ruby,
+    C,
+    Cpp,
+    CSharp,
+    Swift,
+    Shell,
+    Json,
+    Yaml,
+    Toml,
+    Markdown,
+    Sql,
+    Dockerfile,
+    Unknown,
+}
+
+impl Language {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+            Self::TypeScript => "typescript",
+            Self::JavaScript => "javascript",
+            Self::Kotlin => "kotlin",
+            Self::Java => "java",
+            Self::Python => "python",
+            Self::Php => "php",
+            Self::Go => "go",
+            Self::Ruby => "ruby",
+            Self::C => "c",
+            Self::Cpp => "cpp",
+            Self::CSharp => "csharp",
+            Self::Swift => "swift",
+            Self::Shell => "shell",
+            Self::Json => "json",
+            Self::Yaml => "yaml",
+            Self::Toml => "toml",
+            Self::Markdown => "markdown",
+            Self::Sql => "sql",
+            Self::Dockerfile => "dockerfile",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+pub fn detect_language_for_file(path: &Path) -> Result<Language, io::Error> {
+    if let Some(language) = detect_by_filename(path) {
+        return Ok(language);
+    }
+    if let Some(language) = detect_by_extension(path) {
+        return Ok(language);
+    }
+
+    let content = read_file_head(path, 4 * 1024)?;
+    Ok(detect_language(path, &content))
+}
+
+#[must_use]
+pub fn detect_language(path: &Path, content: &[u8]) -> Language {
+    if let Some(language) = detect_by_filename(path) {
+        return language;
+    }
+
+    if let Some(language) = detect_by_extension(path) {
+        return language;
+    }
+
+    if let Some(language) = detect_by_shebang(content) {
+        return language;
+    }
+
+    if let Some(language) = detect_by_content(content) {
+        return language;
+    }
+
+    Language::Unknown
+}
+
+fn detect_by_filename(path: &Path) -> Option<Language> {
+    let name = path.file_name()?.to_str()?;
+    match name {
+        "Dockerfile" => Some(Language::Dockerfile),
+        _ => None,
+    }
+}
+
+fn detect_by_extension(path: &Path) -> Option<Language> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+
+    let language = match ext.as_str() {
+        "rs" => Language::Rust,
+        "ts" | "tsx" => Language::TypeScript,
+        "js" | "jsx" | "mjs" | "cjs" => Language::JavaScript,
+        "kt" | "kts" => Language::Kotlin,
+        "java" => Language::Java,
+        "py" => Language::Python,
+        "php" | "phtml" => Language::Php,
+        "go" => Language::Go,
+        "rb" => Language::Ruby,
+        // `.h` is ambiguous between C and C++; default to C deterministically.
+        "c" | "h" => Language::C,
+        "cc" | "cpp" | "cxx" | "hpp" | "hh" | "hxx" => Language::Cpp,
+        "cs" => Language::CSharp,
+        "swift" => Language::Swift,
+        "sh" | "bash" | "zsh" => Language::Shell,
+        "json" => Language::Json,
+        "yaml" | "yml" => Language::Yaml,
+        "toml" => Language::Toml,
+        "md" | "markdown" => Language::Markdown,
+        "sql" => Language::Sql,
+        _ => return None,
+    };
+
+    Some(language)
+}
+
+fn detect_by_shebang(content: &[u8]) -> Option<Language> {
+    let text = std::str::from_utf8(content).ok()?;
+    let first_line = text.lines().next()?.trim();
+    if !first_line.starts_with("#!") {
+        return None;
+    }
+
+    let interpreter = first_line.trim_start_matches("#!").trim();
+    if interpreter.contains("python") {
+        return Some(Language::Python);
+    }
+    if interpreter.contains("node") {
+        return Some(Language::JavaScript);
+    }
+    if interpreter.ends_with("/bash")
+        || interpreter.ends_with("/zsh")
+        || interpreter.ends_with("/sh")
+        || interpreter.ends_with(" bash")
+        || interpreter.ends_with(" zsh")
+        || interpreter.ends_with(" sh")
+    {
+        return Some(Language::Shell);
+    }
+    if interpreter.contains("php") {
+        return Some(Language::Php);
+    }
+
+    None
+}
+
+fn detect_by_content(content: &[u8]) -> Option<Language> {
+    let text = std::str::from_utf8(content).ok()?;
+    let trimmed = text.trim();
+
+    if trimmed.starts_with("<?php") {
+        return Some(Language::Php);
+    }
+
+    if looks_like_json(trimmed) {
+        return Some(Language::Json);
+    }
+
+    None
+}
+
+fn looks_like_json(trimmed: &str) -> bool {
+    if trimmed.len() < 2 {
+        return false;
+    }
+
+    (trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+}
+
+fn read_file_head(path: &Path, max_bytes: usize) -> Result<Vec<u8>, io::Error> {
+    let mut file = fs::File::open(path)?;
+    let mut buffer = vec![0_u8; max_bytes];
+    let read = file.read(&mut buffer)?;
+    buffer.truncate(read);
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{detect_language, Language};
+
+    #[test]
+    fn extension_mapping_is_deterministic() {
+        let cases = [
+            ("main.rs", Language::Rust),
+            ("app.ts", Language::TypeScript),
+            ("app.js", Language::JavaScript),
+            ("Main.kt", Language::Kotlin),
+            ("Main.java", Language::Java),
+            ("script.py", Language::Python),
+            ("index.php", Language::Php),
+            ("mod.go", Language::Go),
+            ("Gemfile.rb", Language::Ruby),
+            ("main.c", Language::C),
+            ("main.cpp", Language::Cpp),
+            ("Program.cs", Language::CSharp),
+            ("main.swift", Language::Swift),
+            ("script.sh", Language::Shell),
+            ("data.json", Language::Json),
+            ("config.yaml", Language::Yaml),
+            ("Cargo.toml", Language::Toml),
+            ("README.md", Language::Markdown),
+            ("query.sql", Language::Sql),
+            ("Dockerfile", Language::Dockerfile),
+        ];
+
+        for (path, expected) in cases {
+            let detected = detect_language(Path::new(path), b"");
+            assert_eq!(detected, expected, "path={path}");
+        }
+    }
+
+    #[test]
+    fn shebang_detection_covers_unextensioned_scripts() {
+        let py = detect_language(Path::new("run"), b"#!/usr/bin/env python\nprint('hi')\n");
+        let js = detect_language(
+            Path::new("run"),
+            b"#!/usr/bin/env node\nconsole.log('hi')\n",
+        );
+        let sh = detect_language(Path::new("run"), b"#!/bin/bash\necho hi\n");
+        assert_eq!(py, Language::Python);
+        assert_eq!(js, Language::JavaScript);
+        assert_eq!(sh, Language::Shell);
+    }
+
+    #[test]
+    fn content_fallback_detects_php_and_json() {
+        let php = detect_language(Path::new("snippet"), b"<?php echo 'hi';");
+        let json = detect_language(Path::new("blob"), br#"{"ok":true}"#);
+        assert_eq!(php, Language::Php);
+        assert_eq!(json, Language::Json);
+    }
+
+    #[test]
+    fn unknown_fallback_is_stable() {
+        let detected = detect_language(Path::new("mystery.file"), b"hello world");
+        assert_eq!(detected, Language::Unknown);
+    }
+}

--- a/crates/repo-walker/src/lib.rs
+++ b/crates/repo-walker/src/lib.rs
@@ -7,6 +7,10 @@ use std::path::{Path, PathBuf};
 use globset::{Glob, GlobMatcher};
 use ignore::WalkBuilder;
 
+pub mod language;
+
+pub use language::{detect_language, detect_language_for_file, Language};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiscoveredFile {
     pub relative_path: PathBuf,

--- a/crates/repo-walker/tests/common/mod.rs
+++ b/crates/repo-walker/tests/common/mod.rs
@@ -1,0 +1,57 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+pub struct FixtureRepo {
+    tempdir: TempDir,
+}
+
+impl FixtureRepo {
+    pub fn new() -> Result<Self, std::io::Error> {
+        Ok(Self {
+            tempdir: tempfile::tempdir()?,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.tempdir.path()
+    }
+
+    pub fn write(&self, rel: &str, contents: &str) -> Result<(), std::io::Error> {
+        let path = self.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, contents)
+    }
+
+    pub fn write_bytes(&self, rel: &str, contents: &[u8]) -> Result<(), std::io::Error> {
+        let path = self.path().join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, contents)
+    }
+
+    pub fn symlink_file(&self, source_rel: &str, target_rel: &str) -> Result<(), std::io::Error> {
+        let source = self.path().join(source_rel);
+        let target = self.path().join(target_rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        create_symlink_file(&source, &target)
+    }
+}
+
+#[cfg(unix)]
+fn create_symlink_file(source: &Path, target: &Path) -> Result<(), std::io::Error> {
+    std::os::unix::fs::symlink(source, target)
+}
+
+#[cfg(windows)]
+fn create_symlink_file(source: &Path, target: &Path) -> Result<(), std::io::Error> {
+    std::os::windows::fs::symlink_file(source, target)
+}

--- a/crates/repo-walker/tests/language_detection_integration.rs
+++ b/crates/repo-walker/tests/language_detection_integration.rs
@@ -1,0 +1,51 @@
+use std::collections::BTreeMap;
+
+use repo_walker::{detect_language_for_file, walk_repository, WalkerOptions};
+
+mod common;
+use common::FixtureRepo;
+
+#[test]
+fn mixed_language_fixture_detection_is_deterministic() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write rust");
+    fixture
+        .write("web/app.ts", "export const n = 1;\n")
+        .expect("write typescript");
+    fixture
+        .write("scripts/bootstrap", "#!/usr/bin/env python\nprint('ok')\n")
+        .expect("write python shebang");
+    fixture
+        .write("php/snippet", "<?php echo 'ok';\n")
+        .expect("write php snippet");
+    fixture
+        .write("data/blob", "{\"ok\":true}\n")
+        .expect("write json blob");
+    fixture
+        .write("docs/readme.unknown", "plain text\n")
+        .expect("write unknown");
+
+    let files = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let mut detected = BTreeMap::new();
+
+    for file in files {
+        let language = detect_language_for_file(&file.absolute_path).expect("detect language");
+        detected.insert(
+            file.relative_path.to_string_lossy().replace('\\', "/"),
+            language.as_str().to_string(),
+        );
+    }
+
+    let expected = BTreeMap::from([
+        ("data/blob".to_string(), "json".to_string()),
+        ("docs/readme.unknown".to_string(), "unknown".to_string()),
+        ("php/snippet".to_string(), "php".to_string()),
+        ("scripts/bootstrap".to_string(), "python".to_string()),
+        ("src/main.rs".to_string(), "rust".to_string()),
+        ("web/app.ts".to_string(), "typescript".to_string()),
+    ]);
+
+    assert_eq!(detected, expected);
+}

--- a/crates/repo-walker/tests/walk_integration.rs
+++ b/crates/repo-walker/tests/walk_integration.rs
@@ -1,8 +1,9 @@
-use std::fs;
 use std::path::Path;
 
 use repo_walker::{walk_repository, WalkerOptions};
-use tempfile::TempDir;
+
+mod common;
+use common::FixtureRepo;
 
 #[test]
 fn walker_honors_gitignore_and_returns_deterministic_order() {
@@ -191,55 +192,4 @@ fn relative_paths(results: &[repo_walker::DiscoveredFile]) -> Vec<String> {
         .iter()
         .map(|item| item.relative_path.to_string_lossy().replace('\\', "/"))
         .collect()
-}
-
-struct FixtureRepo {
-    tempdir: TempDir,
-}
-
-impl FixtureRepo {
-    fn new() -> Result<Self, std::io::Error> {
-        Ok(Self {
-            tempdir: tempfile::tempdir()?,
-        })
-    }
-
-    fn path(&self) -> &Path {
-        self.tempdir.path()
-    }
-
-    fn write(&self, rel: &str, contents: &str) -> Result<(), std::io::Error> {
-        let path = self.path().join(rel);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(path, contents)
-    }
-
-    fn write_bytes(&self, rel: &str, contents: &[u8]) -> Result<(), std::io::Error> {
-        let path = self.path().join(rel);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(path, contents)
-    }
-
-    fn symlink_file(&self, source_rel: &str, target_rel: &str) -> Result<(), std::io::Error> {
-        let source = self.path().join(source_rel);
-        let target = self.path().join(target_rel);
-        if let Some(parent) = target.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        create_symlink_file(&source, &target)
-    }
-}
-
-#[cfg(unix)]
-fn create_symlink_file(source: &Path, target: &Path) -> Result<(), std::io::Error> {
-    std::os::unix::fs::symlink(source, target)
-}
-
-#[cfg(windows)]
-fn create_symlink_file(source: &Path, target: &Path) -> Result<(), std::io::Error> {
-    std::os::windows::fs::symlink_file(source, target)
 }


### PR DESCRIPTION
## Summary

  - Issue: Closes #22
  - Scope: Add deterministic language detection with explicit fallback behavior for unknown/ambiguous files, including extension/content mapping unit tests and mixed-language integration coverage.

  ## Changes

  - Added language detection module:
    - `crates/repo-walker/src/language.rs`
  - Introduced `Language` enum with stable string mapping (`as_str()`), including:
    - `rust`, `typescript`, `javascript`, `kotlin`, `java`, `python`, `php`, `go`, `ruby`, `c`, `cpp`, `csharp`, `swift`, `shell`, `json`, `yaml`, `toml`, `markdown`, `sql`, `dockerfile`, `unknown`
  - Added public APIs:
    - `detect_language(path, content)`
    - `detect_language_for_file(path)`
  - Deterministic detection order:
    1. Filename override (e.g., `Dockerfile`)
    2. Extension mapping
    3. Shebang detection
    4. Content fallback (PHP open tag / lightweight JSON shape)
    5. `Unknown`
  - Performance and dependency refinements:
    - Removed runtime `serde_json` dependency from `repo-walker`
    - `detect_language_for_file` now short-circuits before reading content when filename/extension is sufficient
    - When content is needed, reads only a bounded head (4KB), not whole file
  - Detection precision improvements:
    - Tightened shell shebang matching (removed overly broad `/sh` contains check)
    - Documented deterministic `.h -> c` default mapping decision
  - Test utility cleanup:
    - Added shared integration fixture helper:
      - `crates/repo-walker/tests/common/mod.rs`
    - Reused by multiple integration test files to remove duplication

  ## Acceptance Criteria Mapping

  - [x] Deliverable implemented and integrated.
  - [x] Edge cases and failure behavior handled explicitly.
  - [x] Deterministic behavior is test-covered where relevant.
  - [x] CI checks pass.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional checks:
    - `cargo build --workspace --all-features`
    - `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`

  ### New/updated test coverage

  - Unit tests in `language.rs`:
    - deterministic extension mapping matrix
    - shebang detection for unextensioned scripts
    - content fallback for PHP/JSON
    - stable `unknown` fallback
  - Integration test:
    - `crates/repo-walker/tests/language_detection_integration.rs`
    - mixed-language fixture repo with deterministic expected language map
  - Existing walker integration tests remain passing with shared fixture utility.

  ## Risk and Mitigation

  - Risk: Lightweight JSON fallback heuristic may produce occasional false positives on extensionless files.
  - Mitigation: Fallback only applies after filename/extension/shebang checks fail; adapter pipeline can still validate/handle downstream parsing.

  ## Security/Observability Impact

  - Security: No new execution surface; bounded head-read avoids full-file memory reads during detection.
  - Observability: No metrics/logging changes in this ticket (planned separately in #23).