### PR TITLE
Add discovery metrics and structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +253,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "powerfmt"
@@ -303,6 +324,8 @@ dependencies = [
  "globset",
  "ignore",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -377,6 +400,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +436,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -432,6 +479,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "nu-ansi-term",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +559,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tempfile = "3.20.0"
 time = { version = "0.3.37", features = ["parsing", "formatting"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["json"] }

--- a/crates/repo-walker/Cargo.toml
+++ b/crates/repo-walker/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 [dependencies]
 globset.workspace = true
 ignore.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/repo-walker/src/lib.rs
+++ b/crates/repo-walker/src/lib.rs
@@ -3,9 +3,11 @@ use std::fmt;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use globset::{Glob, GlobMatcher};
 use ignore::WalkBuilder;
+use tracing::{debug, info, info_span, warn};
 
 pub mod language;
 
@@ -24,6 +26,11 @@ pub struct WalkerOptions {
     pub max_file_size_bytes: Option<u64>,
     pub max_file_count: Option<usize>,
     pub skip_binary_files: bool,
+    /// Optional correlation ID attached to every log event emitted during the
+    /// walk, allowing logs from a single request/job to be traced end-to-end.
+    /// When `None`, the field is still emitted as an empty string for schema
+    /// consistency in structured log consumers.
+    pub correlation_id: Option<String>,
 }
 
 impl Default for WalkerOptions {
@@ -34,8 +41,62 @@ impl Default for WalkerOptions {
             max_file_size_bytes: None,
             max_file_count: None,
             skip_binary_files: true,
+            correlation_id: None,
         }
     }
+}
+
+/// Metrics collected during repository discovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryMetrics {
+    /// Number of files accepted by all filters.
+    pub files_discovered: usize,
+    /// Files skipped because they reside under `.git/`.
+    pub files_skipped_git_dir: usize,
+    /// Files skipped because they are symlinks.
+    pub files_skipped_symlink: usize,
+    /// Files skipped by user-provided extra ignore rules.
+    pub files_skipped_extra_rules: usize,
+    /// Files skipped because they exceed the configured size cap.
+    pub files_skipped_size: usize,
+    /// Files skipped because they appear to be binary.
+    pub files_skipped_binary: usize,
+    /// Wall-clock duration of the walk in milliseconds.
+    /// Non-deterministic; do not assert on exact values in tests.
+    pub walk_duration_ms: u64,
+}
+
+impl DiscoveryMetrics {
+    fn new() -> Self {
+        Self {
+            files_discovered: 0,
+            files_skipped_git_dir: 0,
+            files_skipped_symlink: 0,
+            files_skipped_extra_rules: 0,
+            files_skipped_size: 0,
+            files_skipped_binary: 0,
+            walk_duration_ms: 0,
+        }
+    }
+
+    /// Total number of file entries evaluated (discovered + all skipped).
+    pub fn total_entries_evaluated(&self) -> usize {
+        self.files_discovered
+            + self.files_skipped_git_dir
+            + self.files_skipped_symlink
+            + self.files_skipped_extra_rules
+            + self.files_skipped_size
+            + self.files_skipped_binary
+    }
+}
+
+/// Result of a successful repository walk.
+#[derive(Debug)]
+pub struct WalkResult {
+    /// Discovered files, sorted by relative path.
+    pub files: Vec<DiscoveredFile>,
+    /// Metrics collected during the walk.
+    pub metrics: DiscoveryMetrics,
 }
 
 #[derive(Debug)]
@@ -96,15 +157,22 @@ struct IgnoreRule {
     is_ignore: bool,
 }
 
-pub fn walk_repository(
-    root: &Path,
-    options: &WalkerOptions,
-) -> Result<Vec<DiscoveredFile>, WalkError> {
+pub fn walk_repository(root: &Path, options: &WalkerOptions) -> Result<WalkResult, WalkError> {
+    let start = Instant::now();
+
     ensure_root_is_valid(root)?;
     let root = fs::canonicalize(root).map_err(|source| WalkError::Io {
         path: Some(root.to_path_buf()),
         source,
     })?;
+
+    // Intentionally emit an empty string when no correlation ID is provided,
+    // so the field is always present in structured logs for schema consistency.
+    let correlation_id = options.correlation_id.as_deref().unwrap_or("");
+    let span = info_span!("discovery", correlation_id = %correlation_id);
+    let _guard = span.enter();
+
+    info!(root = %root.display(), "discovery walk started");
 
     let extra_rules = compile_ignore_rules(&options.extra_ignore_rules)?;
     let mut builder = WalkBuilder::new(&root);
@@ -118,6 +186,7 @@ pub fn walk_repository(
     builder.follow_links(false);
 
     let mut discovered = Vec::new();
+    let mut metrics = DiscoveryMetrics::new();
 
     for entry in builder.build() {
         let entry = entry.map_err(|err| WalkError::Io {
@@ -128,6 +197,19 @@ pub fn walk_repository(
         let Some(file_type) = entry.file_type() else {
             continue;
         };
+
+        // Symlink check must precede is_file() because the walker may report
+        // symlinks with a non-file type, which would skip them without counting.
+        if file_type.is_symlink() {
+            metrics.files_skipped_symlink += 1;
+            debug!(
+                path = %entry.path().display(),
+                reason = "symlink",
+                "file skipped"
+            );
+            continue;
+        }
+
         if !file_type.is_file() {
             continue;
         }
@@ -143,30 +225,62 @@ pub fn walk_repository(
         validate_relative_path(&relative)?;
 
         if !options.include_git_dir && starts_with_git_dir(&relative) {
+            metrics.files_skipped_git_dir += 1;
+            debug!(
+                path = %relative.display(),
+                reason = "git_dir",
+                "file skipped"
+            );
             continue;
         }
 
-        // `follow_links(false)` prevents descending into symlinked directories,
-        // but symlink entries can still be yielded as files. Explicitly drop them.
+        // Safety net: even after the file_type check above, verify via
+        // symlink_metadata in case the walker resolved the symlink target type.
         let metadata = symlink_metadata(&absolute)?;
         if metadata.file_type().is_symlink() {
+            metrics.files_skipped_symlink += 1;
+            debug!(
+                path = %relative.display(),
+                reason = "symlink",
+                "file skipped"
+            );
             continue;
         }
 
         if is_ignored_by_extra_rules(&relative, &extra_rules) {
+            metrics.files_skipped_extra_rules += 1;
+            debug!(
+                path = %relative.display(),
+                reason = "extra_rules",
+                "file skipped"
+            );
             continue;
         }
 
         if exceeds_size_cap(metadata.len(), options.max_file_size_bytes) {
+            metrics.files_skipped_size += 1;
+            debug!(
+                path = %relative.display(),
+                reason = "size_cap",
+                file_size = metadata.len(),
+                "file skipped"
+            );
             continue;
         }
 
         if options.skip_binary_files && is_probably_binary_file(&absolute)? {
+            metrics.files_skipped_binary += 1;
+            debug!(
+                path = %relative.display(),
+                reason = "binary",
+                "file skipped"
+            );
             continue;
         }
 
         if let Some(limit) = options.max_file_count {
             if discovered.len() >= limit {
+                warn!(kind = "file_count", limit, "discovery limit exceeded");
                 return Err(WalkError::LimitExceeded {
                     kind: "file_count",
                     limit,
@@ -181,7 +295,25 @@ pub fn walk_repository(
     }
 
     discovered.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
-    Ok(discovered)
+    metrics.files_discovered = discovered.len();
+    metrics.walk_duration_ms = start.elapsed().as_millis() as u64;
+
+    info!(
+        files_discovered = metrics.files_discovered,
+        files_skipped_git_dir = metrics.files_skipped_git_dir,
+        files_skipped_symlink = metrics.files_skipped_symlink,
+        files_skipped_extra_rules = metrics.files_skipped_extra_rules,
+        files_skipped_size = metrics.files_skipped_size,
+        files_skipped_binary = metrics.files_skipped_binary,
+        total_entries_evaluated = metrics.total_entries_evaluated(),
+        walk_duration_ms = metrics.walk_duration_ms,
+        "discovery walk completed"
+    );
+
+    Ok(WalkResult {
+        files: discovered,
+        metrics,
+    })
 }
 
 fn ensure_root_is_valid(root: &Path) -> Result<(), WalkError> {
@@ -394,5 +526,45 @@ mod tests {
     fn size_cap_is_strictly_greater_than_limit() {
         assert!(!exceeds_size_cap(5, Some(5)));
         assert!(exceeds_size_cap(6, Some(5)));
+    }
+
+    #[test]
+    fn discovery_metrics_total_entries_evaluated() {
+        use super::DiscoveryMetrics;
+        let mut m = DiscoveryMetrics::new();
+        m.files_discovered = 10;
+        m.files_skipped_git_dir = 1;
+        m.files_skipped_symlink = 2;
+        m.files_skipped_extra_rules = 3;
+        m.files_skipped_size = 4;
+        m.files_skipped_binary = 5;
+        assert_eq!(m.total_entries_evaluated(), 25);
+    }
+
+    /// Unit test: log field schema contract.
+    /// Verifies that `DiscoveryMetrics` exposes the exact fields that the
+    /// structured log events must contain per spec 13.1.
+    #[test]
+    fn discovery_metrics_field_schema() {
+        use super::DiscoveryMetrics;
+        let m = DiscoveryMetrics::new();
+        // Assert every metric field exists and initialises to its zero value.
+        assert_eq!(m.files_discovered, 0);
+        assert_eq!(m.files_skipped_git_dir, 0);
+        assert_eq!(m.files_skipped_symlink, 0);
+        assert_eq!(m.files_skipped_extra_rules, 0);
+        assert_eq!(m.files_skipped_size, 0);
+        assert_eq!(m.files_skipped_binary, 0);
+        assert_eq!(m.walk_duration_ms, 0);
+        assert_eq!(m.total_entries_evaluated(), 0);
+    }
+
+    /// Unit test: `WalkerOptions` carries an optional correlation ID
+    /// for structured log correlation per spec 13.2.
+    #[test]
+    fn walker_options_correlation_id_defaults_to_none() {
+        use super::WalkerOptions;
+        let opts = WalkerOptions::default();
+        assert!(opts.correlation_id.is_none());
     }
 }

--- a/crates/repo-walker/tests/language_detection_integration.rs
+++ b/crates/repo-walker/tests/language_detection_integration.rs
@@ -27,7 +27,8 @@ fn mixed_language_fixture_detection_is_deterministic() {
         .write("docs/readme.unknown", "plain text\n")
         .expect("write unknown");
 
-    let files = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let result = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let files = result.files;
     let mut detected = BTreeMap::new();
 
     for file in files {

--- a/crates/repo-walker/tests/metrics_and_logging_integration.rs
+++ b/crates/repo-walker/tests/metrics_and_logging_integration.rs
@@ -1,0 +1,232 @@
+use std::sync::{Arc, Mutex};
+
+use repo_walker::{walk_repository, WalkerOptions};
+use tracing_subscriber::fmt::MakeWriter;
+
+mod common;
+use common::FixtureRepo;
+
+/// A writer that captures all output into a shared buffer.
+#[derive(Clone)]
+struct CapturedWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CapturedWriter {
+    fn new() -> Self {
+        Self {
+            buffer: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn contents(&self) -> String {
+        let buf = self.buffer.lock().expect("lock buffer");
+        String::from_utf8_lossy(&buf).to_string()
+    }
+}
+
+impl std::io::Write for CapturedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer
+            .lock()
+            .expect("lock buffer")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CapturedWriter {
+    type Writer = CapturedWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[test]
+fn structured_log_contains_expected_fields() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write text");
+    fixture
+        .write_bytes("bin/data.bin", &[0, 1, 2])
+        .expect("write binary");
+
+    let writer = CapturedWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let _result =
+            walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    });
+
+    let output = writer.contents();
+    // The "discovery walk completed" log line must contain all metric fields.
+    let completed_line = output
+        .lines()
+        .find(|line| line.contains("discovery walk completed"))
+        .expect("should have a 'discovery walk completed' log line");
+
+    // Verify structured field presence in the JSON log line.
+    for field in &[
+        "files_discovered",
+        "files_skipped_git_dir",
+        "files_skipped_symlink",
+        "files_skipped_extra_rules",
+        "files_skipped_size",
+        "files_skipped_binary",
+        "total_entries_evaluated",
+        "walk_duration_ms",
+    ] {
+        assert!(
+            completed_line.contains(field),
+            "expected field '{field}' in log line: {completed_line}"
+        );
+    }
+
+    // Verify the "discovery walk started" log is also emitted.
+    assert!(
+        output
+            .lines()
+            .any(|line| line.contains("discovery walk started")),
+        "should have a 'discovery walk started' log line"
+    );
+
+    // All log lines must carry the correlation_id span field (spec 13.2).
+    for line in output.lines() {
+        assert!(
+            line.contains("correlation_id"),
+            "log line missing 'correlation_id' span field: {line}"
+        );
+    }
+}
+
+#[test]
+fn correlation_id_propagates_to_all_log_events() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write text");
+    fixture
+        .write_bytes("bin/data.bin", &[0, 1, 2])
+        .expect("write binary");
+
+    let writer = CapturedWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+
+    let options = WalkerOptions {
+        correlation_id: Some("job-42".to_string()),
+        ..WalkerOptions::default()
+    };
+
+    tracing::subscriber::with_default(subscriber, || {
+        let _result = walk_repository(fixture.path(), &options).expect("walk repo");
+    });
+
+    let output = writer.contents();
+    assert!(!output.is_empty(), "should have log output");
+
+    // Every log line must carry the caller-supplied correlation ID value.
+    for line in output.lines() {
+        assert!(
+            line.contains("job-42"),
+            "log line missing correlation_id value 'job-42': {line}"
+        );
+    }
+}
+
+#[test]
+fn debug_logs_emit_skip_reason_per_file() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write text");
+    fixture
+        .write_bytes("bin/data.bin", &[0, 1, 2])
+        .expect("write binary");
+    fixture
+        .write("big.txt", &"x".repeat(200))
+        .expect("write big");
+
+    let writer = CapturedWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+
+    let options = WalkerOptions {
+        max_file_size_bytes: Some(100),
+        ..WalkerOptions::default()
+    };
+
+    tracing::subscriber::with_default(subscriber, || {
+        let _result = walk_repository(fixture.path(), &options).expect("walk repo");
+    });
+
+    let output = writer.contents();
+    let skip_lines: Vec<&str> = output
+        .lines()
+        .filter(|line| line.contains("file skipped"))
+        .collect();
+
+    // Should have skip events for binary and size
+    assert!(
+        skip_lines
+            .iter()
+            .any(|line| line.contains("\"reason\":\"binary\"")),
+        "expected a binary skip event in: {skip_lines:?}"
+    );
+    assert!(
+        skip_lines
+            .iter()
+            .any(|line| line.contains("\"reason\":\"size_cap\"")),
+        "expected a size_cap skip event in: {skip_lines:?}"
+    );
+
+    // Each skip event must include a path field
+    for line in &skip_lines {
+        assert!(
+            line.contains("path"),
+            "skip event missing 'path' field: {line}"
+        );
+    }
+}
+
+#[test]
+fn metrics_deterministic_across_repeated_walks() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    fixture.write("a.rs", "fn a() {}\n").expect("write file");
+    fixture.write("b.rs", "fn b() {}\n").expect("write file");
+    fixture
+        .write_bytes("c.bin", &[0, 1, 2])
+        .expect("write binary");
+
+    let opts = WalkerOptions::default();
+    let r1 = walk_repository(fixture.path(), &opts).expect("walk 1");
+    let r2 = walk_repository(fixture.path(), &opts).expect("walk 2");
+
+    // Deterministic counters must match exactly.
+    assert_eq!(r1.metrics.files_discovered, r2.metrics.files_discovered);
+    assert_eq!(
+        r1.metrics.files_skipped_binary,
+        r2.metrics.files_skipped_binary
+    );
+    assert_eq!(
+        r1.metrics.total_entries_evaluated(),
+        r2.metrics.total_entries_evaluated()
+    );
+}

--- a/crates/repo-walker/tests/walk_integration.rs
+++ b/crates/repo-walker/tests/walk_integration.rs
@@ -31,8 +31,8 @@ fn walker_honors_gitignore_and_returns_deterministic_order() {
         .write("subdir/keep.tmp", "kept\n")
         .expect("write file");
 
-    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
-    let paths = relative_paths(&results);
+    let result = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&result.files);
 
     assert_eq!(
         paths,
@@ -43,6 +43,7 @@ fn walker_honors_gitignore_and_returns_deterministic_order() {
             "subdir/keep.tmp".to_string(),
         ]
     );
+    assert_eq!(result.metrics.files_discovered, 4);
 }
 
 #[test]
@@ -58,18 +59,17 @@ fn walker_applies_extra_ignore_rules_with_negation() {
 
     let options = WalkerOptions {
         extra_ignore_rules: vec!["src/**".to_string(), "!src/main.rs".to_string()],
-        include_git_dir: false,
-        max_file_size_bytes: None,
-        max_file_count: None,
-        skip_binary_files: true,
+        ..WalkerOptions::default()
     };
-    let results = walk_repository(fixture.path(), &options).expect("walk repo");
-    let paths = relative_paths(&results);
+    let result = walk_repository(fixture.path(), &options).expect("walk repo");
+    let paths = relative_paths(&result.files);
 
     assert_eq!(
         paths,
         vec!["README.md".to_string(), "src/main.rs".to_string()]
     );
+    assert_eq!(result.metrics.files_discovered, 2);
+    assert_eq!(result.metrics.files_skipped_extra_rules, 1);
 }
 
 #[test]
@@ -84,8 +84,8 @@ fn walker_honors_dot_ignore_files() {
     fixture.write("tmp/keep.txt", "keep\n").expect("write file");
     fixture.write("README.md", "# Repo\n").expect("write file");
 
-    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
-    let paths = relative_paths(&results);
+    let result = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&result.files);
 
     assert_eq!(
         paths,
@@ -114,9 +114,10 @@ fn walker_skips_binary_files_by_default() {
         .write_bytes("bin/data.bin", &[0, 1, 2, 3, 4, 5])
         .expect("write binary file");
 
-    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
-    let paths = relative_paths(&results);
+    let result = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&result.files);
     assert_eq!(paths, vec!["src/main.rs".to_string()]);
+    assert_eq!(result.metrics.files_skipped_binary, 1);
 }
 
 #[test]
@@ -133,10 +134,11 @@ fn walker_applies_file_size_cap() {
         max_file_size_bytes: Some(5),
         ..WalkerOptions::default()
     };
-    let results = walk_repository(fixture.path(), &options).expect("walk repo");
-    let paths = relative_paths(&results);
+    let result = walk_repository(fixture.path(), &options).expect("walk repo");
+    let paths = relative_paths(&result.files);
     // Boundary behavior: exactly 5 bytes is included, >5 bytes is excluded.
     assert_eq!(paths, vec!["small.txt".to_string()]);
+    assert_eq!(result.metrics.files_skipped_size, 1);
 }
 
 #[test]
@@ -152,12 +154,13 @@ fn walker_skips_symlinked_files() {
         .symlink_file("outside.txt", "src/outside-link.txt")
         .expect("create symlink");
 
-    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
-    let paths = relative_paths(&results);
+    let result = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&result.files);
     assert_eq!(
         paths,
         vec!["outside.txt".to_string(), "src/main.rs".to_string()]
     );
+    assert_eq!(result.metrics.files_skipped_symlink, 1);
 }
 
 #[test]
@@ -168,9 +171,10 @@ fn walker_skips_known_binary_extensions_even_without_nul_bytes() {
         .expect("write extension-marked binary");
     fixture.write("README.md", "# Repo\n").expect("write file");
 
-    let results = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
-    let paths = relative_paths(&results);
+    let result = walk_repository(fixture.path(), &WalkerOptions::default()).expect("walk repo");
+    let paths = relative_paths(&result.files);
     assert_eq!(paths, vec!["README.md".to_string()]);
+    assert_eq!(result.metrics.files_skipped_binary, 1);
 }
 
 #[test]
@@ -185,6 +189,47 @@ fn walker_enforces_file_count_limit() {
     };
     let err = walk_repository(fixture.path(), &options).expect_err("expected file count limit");
     assert!(err.to_string().contains("file_count"));
+}
+
+#[test]
+fn metrics_reflect_all_skip_reasons() {
+    let fixture = FixtureRepo::new().expect("create fixture repo");
+    // Accepted files
+    fixture
+        .write("src/main.rs", "fn main() {}\n")
+        .expect("write text");
+    // Binary file (nul byte)
+    fixture
+        .write_bytes("bin/data.bin", &[0, 1, 2, 3])
+        .expect("write binary");
+    // Oversized file
+    fixture
+        .write("big.txt", &"x".repeat(200))
+        .expect("write big");
+    // Extra-rule-ignored file
+    fixture
+        .write("tmp/cache.txt", "cache")
+        .expect("write ignored");
+    // Symlinked file
+    fixture.write("target.txt", "target").expect("write target");
+    fixture
+        .symlink_file("target.txt", "link.txt")
+        .expect("create symlink");
+
+    let options = WalkerOptions {
+        extra_ignore_rules: vec!["tmp/**".to_string()],
+        max_file_size_bytes: Some(100),
+        ..WalkerOptions::default()
+    };
+    let result = walk_repository(fixture.path(), &options).expect("walk repo");
+
+    assert_eq!(result.metrics.files_discovered, 2); // src/main.rs + target.txt
+    assert_eq!(result.metrics.files_skipped_binary, 1);
+    assert_eq!(result.metrics.files_skipped_size, 1);
+    assert_eq!(result.metrics.files_skipped_extra_rules, 1);
+    assert_eq!(result.metrics.files_skipped_symlink, 1);
+    assert_eq!(result.metrics.total_entries_evaluated(), 6);
+    assert!(result.metrics.walk_duration_ms < 10_000); // sanity: under 10s
 }
 
 fn relative_paths(results: &[repo_walker::DiscoveredFile]) -> Vec<String> {


### PR DESCRIPTION
## Summary

- Issue: Closes #23 
- Scope: Add discovery metrics and structured logging to repo-walker per spec sections 13.1 and 13.2.

## Changes

- Added DiscoveryMetrics struct with deterministic skip counters (git_dir, symlink, extra_rules, size, binary) and wall-clock duration.                                                                                                                                                                                  
- Changed walk_repository return type from Vec<DiscoveredFile> to WalkResult { files, metrics } (pre-1.0 internal API).
- Added correlation_id: Option<String> to WalkerOptions; emitted as a tracing span field on all log events (empty string when None for schema consistency).                                                                                                                                                              
- Instrumented walk with structured tracing events: info at start/completion with all metric fields, debug per skipped file with path and reason, warn on limit exceeded.                                                                                                                                                
- Moved symlink detection before is_file() check so symlinks are counted in metrics regardless of platform walker behavior.                                                                                                                                                                                              
- Added tracing and tracing-subscriber as workspace dependencies. 

## Acceptance Criteria Mapping

- Deliverable implemented and integrated: DiscoveryMetrics, structured log events, and correlation ID support added to walk_repository.                                                                                                                                                                                  
- Edge cases and failure behavior handled explicitly: skip reasons tracked per filter, limit exceeded emits warn, correlation ID defaults to empty string for schema consistency.
- Deterministic behavior is test-covered where relevant: metric counters verified deterministic across repeated walks; timing excluded from determinism assertions.                                                                                                                                                      
- CI checks pass: fmt, clippy, 69 tests all green.  

## Test Evidence

- cargo fmt --all -- --check                                                                                                                                                                                                                                                                                             
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --all-features                                                                                                                                                                                                                                                                                        
- Additional tests/benchmarks (if required by issue)      
  - Unit: discovery_metrics_field_schema (field names and zero-init contract), walker_options_correlation_id_defaults_to_none                                                                                                                                                                                            
  - Integration: structured_log_contains_expected_fields (JSON schema with all 8 metric fields + correlation_id), correlation_id_propagates_to_all_log_events, debug_logs_emit_skip_reason_per_file (reason + path fields), metrics_reflect_all_skip_reasons (all skip categories), metrics_deterministic_across_repeated_walks   

## Risk and Mitigation

- Risk: walk_repository return type change breaks any external consumers.                                                                                                                                                                                                                                                
- Mitigation: Crate is pre-1.0 and internal-only; all call sites updated in this PR.

## Security/Observability Impact

- Security: No new untrusted-input handling. Correlation ID is caller-provided and used only as a log field value.                                                                                                                                                                                                       
- Logs/Metrics/Tracing: Core deliverable. Structured JSON logs via tracing with correlation IDs (spec 13.2), discovery metric counters (spec 13.1). All events scoped under a discovery span.
                                                                                                                                                                                                    
