### PR TITLE
Create adapter-syntax-treesitter baseline crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "adapter-syntax-treesitter"
+version = "0.1.0"
+dependencies = [
+ "adapter-api",
+ "core-model",
+ "tempfile",
+ "tree-sitter",
+ "tree-sitter-rust",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +49,16 @@ checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -110,6 +131,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -308,6 +335,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +438,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -416,10 +456,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "syn"
@@ -553,6 +605,36 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/adapter-api", "crates/core-model", "crates/repo-walker", "crates/workspace-placeholder"]
+members = ["crates/adapter-api", "crates/adapter-syntax-treesitter", "crates/core-model", "crates/repo-walker", "crates/workspace-placeholder"]
 resolver = "2"
 
 [workspace.package]
@@ -9,6 +9,7 @@ rust-version = "1.81"
 repository = "https://github.com/developepper/CodeAtlas"
 
 [workspace.dependencies]
+adapter-api = { path = "crates/adapter-api" }
 core-model = { path = "crates/core-model" }
 globset = "0.4.16"
 ignore = "0.4.24"
@@ -16,5 +17,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tempfile = "3.20.0"
 time = { version = "0.3.37", features = ["parsing", "formatting"] }
+tree-sitter = "0.25"
+tree-sitter-rust = "0.24"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["json"] }

--- a/crates/adapter-api/src/lib.rs
+++ b/crates/adapter-api/src/lib.rs
@@ -181,10 +181,17 @@ impl Validate for ExtractedSymbol {
 // ---------------------------------------------------------------------------
 
 /// The result of processing a single source file through an adapter.
+///
+/// Self-describing: carries provenance metadata so downstream consumers
+/// do not need to query the adapter separately.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AdapterOutput {
     /// Symbols extracted from the file.
     pub symbols: Vec<ExtractedSymbol>,
+    /// Stable identifier of the adapter that produced this output.
+    pub source_adapter: String,
+    /// Quality level of the adapter that produced this output.
+    pub quality_level: QualityLevel,
 }
 
 // ---------------------------------------------------------------------------
@@ -382,6 +389,8 @@ mod tests {
                     docstring: None,
                     parent_qualified_name: None,
                 }],
+                source_adapter: "mock-syntax-rust".to_string(),
+                quality_level: QualityLevel::Syntax,
             })
         }
     }

--- a/crates/adapter-syntax-treesitter/Cargo.toml
+++ b/crates/adapter-syntax-treesitter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "adapter-syntax-treesitter"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+adapter-api.workspace = true
+core-model.workspace = true
+tree-sitter.workspace = true
+tree-sitter-rust.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/adapter-syntax-treesitter/src/languages.rs
+++ b/crates/adapter-syntax-treesitter/src/languages.rs
@@ -1,0 +1,120 @@
+use core_model::SymbolKind;
+
+/// Languages supported by this crate.
+pub static SUPPORTED_LANGUAGES: &[&str] = &["rust"];
+
+/// A mapping from a tree-sitter node type to a symbol kind.
+pub struct NodeMapping {
+    pub node_type: &'static str,
+    pub kind: SymbolKind,
+    pub name_field: &'static str,
+}
+
+/// Describes how to extract scope names from scope-creating nodes.
+pub struct ScopeMapping {
+    pub node_type: &'static str,
+    pub name_field: &'static str,
+}
+
+/// Language-specific configuration for tree-sitter symbol extraction.
+pub struct LanguageProfile {
+    pub language_id: &'static str,
+    pub ts_language: fn() -> tree_sitter::Language,
+    definitions: &'static [NodeMapping],
+    scopes: &'static [ScopeMapping],
+}
+
+impl LanguageProfile {
+    pub fn find_definition(&self, node_type: &str) -> Option<&NodeMapping> {
+        self.definitions.iter().find(|m| m.node_type == node_type)
+    }
+
+    pub fn is_scope_type(&self, node_type: &str) -> bool {
+        self.scopes.iter().any(|s| s.node_type == node_type)
+    }
+
+    pub fn find_scope(&self, node_type: &str) -> Option<&ScopeMapping> {
+        self.scopes.iter().find(|s| s.node_type == node_type)
+    }
+}
+
+/// Returns the language profile for the given language ID, if supported.
+pub fn profile_for(language: &str) -> Option<&'static LanguageProfile> {
+    match language {
+        "rust" => Some(&RUST_PROFILE),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rust
+// ---------------------------------------------------------------------------
+
+fn rust_language() -> tree_sitter::Language {
+    tree_sitter_rust::LANGUAGE.into()
+}
+
+static RUST_DEFINITIONS: &[NodeMapping] = &[
+    NodeMapping {
+        node_type: "function_item",
+        kind: SymbolKind::Function,
+        name_field: "name",
+    },
+    NodeMapping {
+        node_type: "function_signature_item",
+        kind: SymbolKind::Function,
+        name_field: "name",
+    },
+    NodeMapping {
+        node_type: "struct_item",
+        kind: SymbolKind::Class,
+        name_field: "name",
+    },
+    NodeMapping {
+        node_type: "enum_item",
+        kind: SymbolKind::Type,
+        name_field: "name",
+    },
+    NodeMapping {
+        node_type: "trait_item",
+        kind: SymbolKind::Type,
+        name_field: "name",
+    },
+    NodeMapping {
+        node_type: "type_item",
+        kind: SymbolKind::Type,
+        name_field: "name",
+    },
+    NodeMapping {
+        node_type: "const_item",
+        kind: SymbolKind::Constant,
+        name_field: "name",
+    },
+    NodeMapping {
+        node_type: "static_item",
+        kind: SymbolKind::Constant,
+        name_field: "name",
+    },
+];
+
+static RUST_SCOPES: &[ScopeMapping] = &[
+    ScopeMapping {
+        node_type: "impl_item",
+        name_field: "type",
+    },
+    ScopeMapping {
+        node_type: "trait_item",
+        name_field: "name",
+    },
+    ScopeMapping {
+        node_type: "mod_item",
+        name_field: "name",
+    },
+];
+
+static RUST_PROFILE: LanguageProfile = LanguageProfile {
+    language_id: "rust",
+    ts_language: rust_language,
+    definitions: RUST_DEFINITIONS,
+    scopes: RUST_SCOPES,
+};

--- a/crates/adapter-syntax-treesitter/src/lib.rs
+++ b/crates/adapter-syntax-treesitter/src/lib.rs
@@ -1,0 +1,623 @@
+use adapter_api::{
+    AdapterCapabilities, AdapterError, AdapterOutput, ExtractedSymbol, IndexContext,
+    LanguageAdapter, SourceFile, SourceSpan,
+};
+use core_model::SymbolKind;
+use tree_sitter::{Node, Parser};
+
+mod languages;
+
+use languages::LanguageProfile;
+
+/// A tree-sitter-based syntax adapter that extracts symbols from source files.
+///
+/// Each adapter instance handles exactly one language. Use [`create_adapter`]
+/// to obtain an adapter for a supported language.
+pub struct TreeSitterAdapter {
+    adapter_id: String,
+    language_id: String,
+    capabilities: AdapterCapabilities,
+    profile: &'static LanguageProfile,
+}
+
+impl TreeSitterAdapter {
+    /// Creates a new adapter for the given language profile.
+    fn new(profile: &'static LanguageProfile) -> Self {
+        Self {
+            adapter_id: format!("syntax-treesitter-{}", profile.language_id),
+            language_id: profile.language_id.to_string(),
+            capabilities: AdapterCapabilities::syntax_baseline(),
+            profile,
+        }
+    }
+}
+
+/// Create an adapter for the given language, if supported.
+///
+/// Returns `None` if no tree-sitter grammar is available for the language.
+#[must_use]
+pub fn create_adapter(language: &str) -> Option<TreeSitterAdapter> {
+    languages::profile_for(language).map(TreeSitterAdapter::new)
+}
+
+/// Returns the list of languages supported by this crate.
+#[must_use]
+pub fn supported_languages() -> &'static [&'static str] {
+    languages::SUPPORTED_LANGUAGES
+}
+
+impl LanguageAdapter for TreeSitterAdapter {
+    fn adapter_id(&self) -> &str {
+        &self.adapter_id
+    }
+
+    fn language(&self) -> &str {
+        &self.language_id
+    }
+
+    fn capabilities(&self) -> &AdapterCapabilities {
+        &self.capabilities
+    }
+
+    fn index_file(
+        &self,
+        _ctx: &IndexContext,
+        file: &SourceFile,
+    ) -> Result<AdapterOutput, AdapterError> {
+        if file.language != self.language_id {
+            return Err(AdapterError::Unsupported {
+                language: file.language.clone(),
+            });
+        }
+
+        let mut parser = Parser::new();
+        parser
+            .set_language(&(self.profile.ts_language)())
+            .map_err(|err| AdapterError::Parse {
+                path: file.relative_path.clone(),
+                reason: format!("failed to set language: {err}"),
+            })?;
+
+        let tree = parser
+            .parse(&file.content, None)
+            .ok_or_else(|| AdapterError::Parse {
+                path: file.relative_path.clone(),
+                reason: "tree-sitter parse returned no tree".to_string(),
+            })?;
+
+        let mut symbols = extract_symbols(tree.root_node(), &file.content, self.profile);
+
+        // Resolve provenance: fill in default confidence for symbols that
+        // did not receive a per-symbol override.
+        let default_confidence = self.capabilities.default_confidence;
+        for sym in &mut symbols {
+            if sym.confidence_score.is_none() {
+                sym.confidence_score = Some(default_confidence);
+            }
+        }
+
+        Ok(AdapterOutput {
+            symbols,
+            source_adapter: self.adapter_id.clone(),
+            quality_level: self.capabilities.quality_level,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol extraction
+// ---------------------------------------------------------------------------
+
+fn extract_symbols(root: Node, source: &[u8], profile: &LanguageProfile) -> Vec<ExtractedSymbol> {
+    let mut symbols = Vec::new();
+    let mut scope_stack: Vec<String> = Vec::new();
+    walk_node(root, source, profile, &mut symbols, &mut scope_stack);
+    symbols
+}
+
+fn walk_node(
+    node: Node,
+    source: &[u8],
+    profile: &LanguageProfile,
+    symbols: &mut Vec<ExtractedSymbol>,
+    scope_stack: &mut Vec<String>,
+) {
+    let node_type = node.kind();
+
+    // Check if this node is a symbol definition.
+    if let Some(mapping) = profile.find_definition(node_type) {
+        if let Some(name) = child_text(&node, mapping.name_field, source) {
+            let kind = if mapping.kind == SymbolKind::Function && is_method_context(&node) {
+                SymbolKind::Method
+            } else {
+                mapping.kind
+            };
+
+            let qualified_name = build_qualified_name(scope_stack, &name);
+            let parent = if scope_stack.is_empty() {
+                None
+            } else {
+                Some(scope_stack.join("::"))
+            };
+
+            symbols.push(ExtractedSymbol {
+                name,
+                qualified_name,
+                kind,
+                span: node_to_span(&node),
+                signature: extract_signature(&node, source),
+                confidence_score: None,
+                docstring: extract_docstring(&node, source),
+                parent_qualified_name: parent,
+            });
+        }
+    }
+
+    // Track scope for qualified names. Only pop if we actually pushed.
+    let pushed_scope = if profile.is_scope_type(node_type) {
+        if let Some(scope_name) = extract_scope_name(&node, source, profile) {
+            scope_stack.push(scope_name);
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    // Recurse into children.
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            walk_node(cursor.node(), source, profile, symbols, scope_stack);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+
+    if pushed_scope {
+        scope_stack.pop();
+    }
+}
+
+/// Returns `true` if a function node is inside an impl or trait body.
+fn is_method_context(node: &Node) -> bool {
+    node.parent()
+        .and_then(|p| p.parent())
+        .is_some_and(|gp| matches!(gp.kind(), "impl_item" | "trait_item"))
+}
+
+fn build_qualified_name(scope_stack: &[String], name: &str) -> String {
+    if scope_stack.is_empty() {
+        name.to_string()
+    } else {
+        format!("{}::{name}", scope_stack.join("::"))
+    }
+}
+
+fn node_to_span(node: &Node) -> SourceSpan {
+    SourceSpan {
+        start_line: node.start_position().row as u32 + 1,
+        end_line: node.end_position().row as u32 + 1,
+        start_byte: node.start_byte() as u64,
+        byte_length: (node.end_byte() - node.start_byte()) as u64,
+    }
+}
+
+/// Extracts the text of a named child field.
+fn child_text(node: &Node, field_name: &str, source: &[u8]) -> Option<String> {
+    node.child_by_field_name(field_name)
+        .and_then(|child| child.utf8_text(source).ok())
+        .map(|s| s.to_string())
+}
+
+/// Extracts a signature by taking text from the node start up to the body.
+fn extract_signature(node: &Node, source: &[u8]) -> String {
+    // Find the body child (declaration_list, field_declaration_list, block, etc.)
+    let body_start = find_body_start(node);
+
+    let sig_end = body_start.unwrap_or(node.end_byte());
+    let sig_bytes = &source[node.start_byte()..sig_end];
+    let sig = String::from_utf8_lossy(sig_bytes);
+    // Trim trailing whitespace and opening brace if present.
+    sig.trim().trim_end_matches('{').trim().to_string()
+}
+
+fn find_body_start(node: &Node) -> Option<usize> {
+    let body_fields = ["body", "block"];
+    for field in &body_fields {
+        if let Some(body) = node.child_by_field_name(field) {
+            return Some(body.start_byte());
+        }
+    }
+    // Fallback: look for a `{` child node.
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            if cursor.node().kind() == "{" {
+                return Some(cursor.node().start_byte());
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
+}
+
+/// Extracts doc comments preceding a definition node.
+fn extract_docstring(node: &Node, source: &[u8]) -> Option<String> {
+    let mut doc_lines = Vec::new();
+    let mut sibling = node.prev_sibling();
+
+    while let Some(sib) = sibling {
+        match sib.kind() {
+            "line_comment" => {
+                let text = sib.utf8_text(source).unwrap_or("").trim();
+                if let Some(doc) = text.strip_prefix("///") {
+                    doc_lines.push(doc.strip_prefix(' ').unwrap_or(doc).to_string());
+                } else {
+                    break;
+                }
+            }
+            "block_comment" => {
+                let text = sib.utf8_text(source).unwrap_or("");
+                if text.starts_with("/**") {
+                    let inner = text
+                        .strip_prefix("/**")
+                        .and_then(|s| s.strip_suffix("*/"))
+                        .unwrap_or(text)
+                        .trim();
+                    doc_lines.push(inner.to_string());
+                }
+                break;
+            }
+            _ => break,
+        }
+        sibling = sib.prev_sibling();
+    }
+
+    if doc_lines.is_empty() {
+        return None;
+    }
+    doc_lines.reverse();
+    Some(doc_lines.join("\n"))
+}
+
+/// Extracts the scope name from a scope-creating node.
+fn extract_scope_name(node: &Node, source: &[u8], profile: &LanguageProfile) -> Option<String> {
+    let node_type = node.kind();
+
+    if let Some(scope_def) = profile.find_scope(node_type) {
+        if let Some(type_node) = node.child_by_field_name(scope_def.name_field) {
+            return extract_base_type_name(&type_node, source);
+        }
+    }
+
+    None
+}
+
+/// Extracts the base type name, handling generic types like `Foo<T>`.
+fn extract_base_type_name(node: &Node, source: &[u8]) -> Option<String> {
+    match node.kind() {
+        "type_identifier" | "identifier" => node.utf8_text(source).ok().map(|s| s.to_string()),
+        "generic_type" => {
+            // For `Foo<T>`, extract just `Foo`.
+            node.child_by_field_name("type")
+                .and_then(|t| t.utf8_text(source).ok())
+                .map(|s| s.to_string())
+        }
+        _ => node.utf8_text(source).ok().map(|s| s.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use adapter_api::LanguageAdapter;
+    use std::path::PathBuf;
+
+    fn index_rust_source(source: &str) -> AdapterOutput {
+        let adapter = create_adapter("rust").expect("rust adapter");
+        let ctx = IndexContext {
+            repo_id: "test".to_string(),
+            source_root: PathBuf::from("/tmp/test"),
+        };
+        let file = SourceFile {
+            relative_path: PathBuf::from("src/lib.rs"),
+            absolute_path: PathBuf::from("/tmp/test/src/lib.rs"),
+            content: source.as_bytes().to_vec(),
+            language: "rust".to_string(),
+        };
+        adapter.index_file(&ctx, &file).expect("index file")
+    }
+
+    fn find_symbol<'a>(symbols: &'a [ExtractedSymbol], name: &str) -> &'a ExtractedSymbol {
+        symbols
+            .iter()
+            .find(|s| s.name == name)
+            .unwrap_or_else(|| panic!("symbol '{name}' not found in: {:?}", symbol_names(symbols)))
+    }
+
+    fn symbol_names(symbols: &[ExtractedSymbol]) -> Vec<&str> {
+        symbols.iter().map(|s| s.name.as_str()).collect()
+    }
+
+    // -- Adapter identity --
+
+    #[test]
+    fn adapter_id_follows_naming_convention() {
+        let adapter = create_adapter("rust").unwrap();
+        assert_eq!(adapter.adapter_id(), "syntax-treesitter-rust");
+        assert_eq!(adapter.language(), "rust");
+    }
+
+    #[test]
+    fn adapter_capabilities_are_syntax_level() {
+        let adapter = create_adapter("rust").unwrap();
+        let caps = adapter.capabilities();
+        assert_eq!(caps.quality_level, core_model::QualityLevel::Syntax);
+        assert!(caps.default_confidence > 0.0 && caps.default_confidence <= 1.0);
+    }
+
+    #[test]
+    fn unsupported_language_returns_none() {
+        assert!(create_adapter("brainfuck").is_none());
+    }
+
+    #[test]
+    fn language_mismatch_returns_error() {
+        let adapter = create_adapter("rust").unwrap();
+        let ctx = IndexContext {
+            repo_id: "test".to_string(),
+            source_root: PathBuf::from("/tmp"),
+        };
+        let file = SourceFile {
+            relative_path: PathBuf::from("main.py"),
+            absolute_path: PathBuf::from("/tmp/main.py"),
+            content: b"print('hello')".to_vec(),
+            language: "python".to_string(),
+        };
+        let err = adapter.index_file(&ctx, &file).expect_err("wrong language");
+        assert!(err.to_string().contains("unsupported language"));
+    }
+
+    #[test]
+    fn supported_languages_includes_rust() {
+        assert!(supported_languages().contains(&"rust"));
+    }
+
+    // -- Provenance --
+
+    #[test]
+    fn output_carries_provenance_fields() {
+        let output = index_rust_source("fn hello() {}\n");
+        assert_eq!(output.source_adapter, "syntax-treesitter-rust");
+        assert_eq!(output.quality_level, core_model::QualityLevel::Syntax);
+    }
+
+    #[test]
+    fn symbols_have_resolved_confidence_scores() {
+        let output = index_rust_source("fn hello() {}\nfn world() {}\n");
+        for sym in &output.symbols {
+            assert!(
+                sym.confidence_score.is_some(),
+                "symbol '{}' should have resolved confidence",
+                sym.name
+            );
+            let score = sym.confidence_score.unwrap();
+            assert!(score > 0.0 && score <= 1.0);
+        }
+    }
+
+    // -- Function extraction --
+
+    #[test]
+    fn extracts_free_function() {
+        let output = index_rust_source("fn hello() {}\n");
+        assert_eq!(output.symbols.len(), 1);
+        let sym = &output.symbols[0];
+        assert_eq!(sym.name, "hello");
+        assert_eq!(sym.kind, SymbolKind::Function);
+        assert_eq!(sym.qualified_name, "hello");
+        assert_eq!(sym.span.start_line, 1);
+        assert!(sym.span.byte_length > 0);
+        assert!(sym.parent_qualified_name.is_none());
+    }
+
+    #[test]
+    fn extracts_function_signature() {
+        let output = index_rust_source("pub fn process(input: &str) -> bool {\n    true\n}\n");
+        let sym = find_symbol(&output.symbols, "process");
+        assert_eq!(sym.signature, "pub fn process(input: &str) -> bool");
+    }
+
+    // -- Struct extraction --
+
+    #[test]
+    fn extracts_struct_as_class() {
+        let output = index_rust_source("struct Point {\n    x: f64,\n    y: f64,\n}\n");
+        let sym = find_symbol(&output.symbols, "Point");
+        assert_eq!(sym.kind, SymbolKind::Class);
+        assert_eq!(sym.qualified_name, "Point");
+    }
+
+    // -- Impl methods --
+
+    #[test]
+    fn extracts_impl_methods_with_qualified_names() {
+        let source = "struct Foo;\nimpl Foo {\n    fn bar() {}\n    fn baz() {}\n}\n";
+        let output = index_rust_source(source);
+        let bar = find_symbol(&output.symbols, "bar");
+        assert_eq!(bar.kind, SymbolKind::Method);
+        assert_eq!(bar.qualified_name, "Foo::bar");
+        assert_eq!(bar.parent_qualified_name.as_deref(), Some("Foo"));
+    }
+
+    #[test]
+    fn extracts_impl_methods_for_generic_type() {
+        let source = "struct Wrapper<T>(T);\nimpl<T> Wrapper<T> {\n    fn inner(&self) -> &T { &self.0 }\n}\n";
+        let output = index_rust_source(source);
+        let sym = find_symbol(&output.symbols, "inner");
+        assert_eq!(sym.kind, SymbolKind::Method);
+        assert_eq!(sym.qualified_name, "Wrapper::inner");
+    }
+
+    // -- Enum, trait, const, type alias --
+
+    #[test]
+    fn extracts_enum_as_type() {
+        let output = index_rust_source("enum Color {\n    Red,\n    Green,\n}\n");
+        let sym = find_symbol(&output.symbols, "Color");
+        assert_eq!(sym.kind, SymbolKind::Type);
+    }
+
+    #[test]
+    fn extracts_trait_as_type() {
+        let output = index_rust_source("trait Drawable {\n    fn draw(&self);\n}\n");
+        let sym = find_symbol(&output.symbols, "Drawable");
+        assert_eq!(sym.kind, SymbolKind::Type);
+    }
+
+    #[test]
+    fn extracts_trait_method_declarations() {
+        let source = "trait Drawable {\n    fn draw(&self);\n}\n";
+        let output = index_rust_source(source);
+        let draw = find_symbol(&output.symbols, "draw");
+        assert_eq!(draw.kind, SymbolKind::Method);
+        assert_eq!(draw.qualified_name, "Drawable::draw");
+    }
+
+    #[test]
+    fn extracts_const() {
+        let output = index_rust_source("const MAX_SIZE: usize = 100;\n");
+        let sym = find_symbol(&output.symbols, "MAX_SIZE");
+        assert_eq!(sym.kind, SymbolKind::Constant);
+    }
+
+    #[test]
+    fn extracts_static() {
+        let output = index_rust_source("static INSTANCE: u32 = 0;\n");
+        let sym = find_symbol(&output.symbols, "INSTANCE");
+        assert_eq!(sym.kind, SymbolKind::Constant);
+    }
+
+    #[test]
+    fn extracts_type_alias() {
+        let output = index_rust_source("type Result<T> = std::result::Result<T, Error>;\n");
+        let sym = find_symbol(&output.symbols, "Result");
+        assert_eq!(sym.kind, SymbolKind::Type);
+    }
+
+    // -- Docstrings --
+
+    #[test]
+    fn extracts_doc_comments() {
+        let source = "/// Does something useful.\n/// With multiple lines.\nfn documented() {}\n";
+        let output = index_rust_source(source);
+        let sym = find_symbol(&output.symbols, "documented");
+        assert_eq!(
+            sym.docstring.as_deref(),
+            Some("Does something useful.\nWith multiple lines.")
+        );
+    }
+
+    #[test]
+    fn no_docstring_when_absent() {
+        let output = index_rust_source("fn bare() {}\n");
+        let sym = find_symbol(&output.symbols, "bare");
+        assert!(sym.docstring.is_none());
+    }
+
+    // -- Edge cases --
+
+    #[test]
+    fn empty_file_produces_no_symbols() {
+        let output = index_rust_source("");
+        assert!(output.symbols.is_empty());
+    }
+
+    #[test]
+    fn whitespace_only_file_produces_no_symbols() {
+        let output = index_rust_source("   \n\n  \n");
+        assert!(output.symbols.is_empty());
+    }
+
+    // -- Comprehensive fixture --
+
+    #[test]
+    fn comprehensive_fixture_extraction_is_deterministic() {
+        let source = r#"
+/// Module-level constant.
+const VERSION: &str = "1.0";
+
+/// A point in 2D space.
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+impl Point {
+    /// Creates a new point.
+    fn new(x: f64, y: f64) -> Self {
+        Point { x, y }
+    }
+
+    fn origin() -> Self {
+        Point::new(0.0, 0.0)
+    }
+}
+
+enum Shape {
+    Circle(f64),
+    Rectangle(f64, f64),
+}
+
+trait Area {
+    fn area(&self) -> f64;
+}
+
+type Coord = f64;
+"#;
+
+        let output1 = index_rust_source(source);
+        let output2 = index_rust_source(source);
+
+        // Deterministic: same output on repeated runs.
+        assert_eq!(output1.symbols.len(), output2.symbols.len());
+        for (a, b) in output1.symbols.iter().zip(output2.symbols.iter()) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.qualified_name, b.qualified_name);
+            assert_eq!(a.span, b.span);
+        }
+
+        // Verify expected symbols.
+        let names: Vec<(&str, SymbolKind)> = output1
+            .symbols
+            .iter()
+            .map(|s| (s.name.as_str(), s.kind))
+            .collect();
+
+        assert!(names.contains(&("VERSION", SymbolKind::Constant)));
+        assert!(names.contains(&("Point", SymbolKind::Class)));
+        assert!(names.contains(&("new", SymbolKind::Method)));
+        assert!(names.contains(&("origin", SymbolKind::Method)));
+        assert!(names.contains(&("Shape", SymbolKind::Type)));
+        assert!(names.contains(&("Area", SymbolKind::Type)));
+        assert!(names.contains(&("area", SymbolKind::Method)));
+        assert!(names.contains(&("Coord", SymbolKind::Type)));
+
+        // Verify docstrings on documented items.
+        let version = find_symbol(&output1.symbols, "VERSION");
+        assert_eq!(version.docstring.as_deref(), Some("Module-level constant."));
+        let new = find_symbol(&output1.symbols, "new");
+        assert_eq!(new.docstring.as_deref(), Some("Creates a new point."));
+        assert_eq!(new.parent_qualified_name.as_deref(), Some("Point"));
+    }
+}

--- a/crates/adapter-syntax-treesitter/tests/fixture_repo_integration.rs
+++ b/crates/adapter-syntax-treesitter/tests/fixture_repo_integration.rs
@@ -1,0 +1,215 @@
+use std::fs;
+use std::path::PathBuf;
+
+use adapter_api::{AdapterOutput, IndexContext, LanguageAdapter, SourceFile};
+use adapter_syntax_treesitter::create_adapter;
+use core_model::SymbolKind;
+use tempfile::TempDir;
+
+/// Helper: create a temporary fixture repository with Rust source files.
+struct FixtureRepo {
+    _tempdir: TempDir,
+    root: PathBuf,
+}
+
+impl FixtureRepo {
+    fn new() -> Self {
+        let tempdir = tempfile::tempdir().expect("create tempdir");
+        let root = tempdir.path().to_path_buf();
+        Self {
+            _tempdir: tempdir,
+            root,
+        }
+    }
+
+    fn write(&self, rel: &str, contents: &str) {
+        let path = self.root.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create dirs");
+        }
+        fs::write(&path, contents).expect("write file");
+    }
+
+    fn index_file(&self, rel: &str) -> AdapterOutput {
+        let adapter = create_adapter("rust").expect("rust adapter");
+        let ctx = IndexContext {
+            repo_id: "fixture-repo".to_string(),
+            source_root: self.root.clone(),
+        };
+        let abs = self.root.join(rel);
+        let content = fs::read(&abs).expect("read file");
+        let file = SourceFile {
+            relative_path: PathBuf::from(rel),
+            absolute_path: abs,
+            content,
+            language: "rust".to_string(),
+        };
+        adapter.index_file(&ctx, &file).expect("index file")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: realistic Rust project layout
+// ---------------------------------------------------------------------------
+
+const LIB_RS: &str = r#"//! Crate-level docs.
+
+/// A 2D point.
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point {
+    /// Creates a new point.
+    pub fn new(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+
+    /// Euclidean distance from origin.
+    pub fn distance(&self) -> f64 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+}
+
+/// Shape enumeration.
+pub enum Shape {
+    Circle(f64),
+    Rect { w: f64, h: f64 },
+}
+
+pub trait Area {
+    fn area(&self) -> f64;
+}
+
+pub type Meters = f64;
+
+pub const DEFAULT_ORIGIN: Point = Point { x: 0.0, y: 0.0 };
+"#;
+
+const MAIN_RS: &str = r#"use lib::Point;
+
+fn main() {
+    let p = Point::new(3.0, 4.0);
+    println!("distance = {}", p.distance());
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixture_repo_lib_extracts_expected_symbols() {
+    let repo = FixtureRepo::new();
+    repo.write("src/lib.rs", LIB_RS);
+
+    let output = repo.index_file("src/lib.rs");
+
+    let names: Vec<(&str, SymbolKind)> = output
+        .symbols
+        .iter()
+        .map(|s| (s.name.as_str(), s.kind))
+        .collect();
+
+    assert!(names.contains(&("Point", SymbolKind::Class)));
+    assert!(names.contains(&("new", SymbolKind::Method)));
+    assert!(names.contains(&("distance", SymbolKind::Method)));
+    assert!(names.contains(&("Shape", SymbolKind::Type)));
+    assert!(names.contains(&("Area", SymbolKind::Type)));
+    assert!(names.contains(&("area", SymbolKind::Method)));
+    assert!(names.contains(&("Meters", SymbolKind::Type)));
+    assert!(names.contains(&("DEFAULT_ORIGIN", SymbolKind::Constant)));
+}
+
+#[test]
+fn fixture_repo_main_extracts_main_function() {
+    let repo = FixtureRepo::new();
+    repo.write("src/main.rs", MAIN_RS);
+
+    let output = repo.index_file("src/main.rs");
+
+    assert_eq!(output.symbols.len(), 1);
+    assert_eq!(output.symbols[0].name, "main");
+    assert_eq!(output.symbols[0].kind, SymbolKind::Function);
+    assert_eq!(output.symbols[0].qualified_name, "main");
+}
+
+#[test]
+fn fixture_repo_output_provenance_is_self_describing() {
+    let repo = FixtureRepo::new();
+    repo.write("src/lib.rs", LIB_RS);
+
+    let output = repo.index_file("src/lib.rs");
+
+    assert_eq!(output.source_adapter, "syntax-treesitter-rust");
+    assert_eq!(output.quality_level, core_model::QualityLevel::Syntax);
+
+    // Every symbol must have a resolved confidence score.
+    for sym in &output.symbols {
+        let score = sym
+            .confidence_score
+            .unwrap_or_else(|| panic!("symbol '{}' missing confidence", sym.name));
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "symbol '{}' confidence {score} out of range",
+            sym.name
+        );
+    }
+}
+
+#[test]
+fn fixture_repo_extraction_is_deterministic_across_files() {
+    let repo = FixtureRepo::new();
+    repo.write("src/lib.rs", LIB_RS);
+    repo.write("src/main.rs", MAIN_RS);
+
+    let lib1 = repo.index_file("src/lib.rs");
+    let lib2 = repo.index_file("src/lib.rs");
+    let main1 = repo.index_file("src/main.rs");
+    let main2 = repo.index_file("src/main.rs");
+
+    assert_eq!(lib1.symbols.len(), lib2.symbols.len());
+    assert_eq!(main1.symbols.len(), main2.symbols.len());
+
+    for (a, b) in lib1.symbols.iter().zip(lib2.symbols.iter()) {
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.kind, b.kind);
+        assert_eq!(a.span, b.span);
+    }
+}
+
+#[test]
+fn fixture_repo_empty_file_produces_no_symbols() {
+    let repo = FixtureRepo::new();
+    repo.write("src/empty.rs", "");
+
+    let output = repo.index_file("src/empty.rs");
+    assert!(output.symbols.is_empty());
+    // Provenance still present even with no symbols.
+    assert_eq!(output.source_adapter, "syntax-treesitter-rust");
+}
+
+#[test]
+fn fixture_repo_qualified_names_reflect_impl_scope() {
+    let repo = FixtureRepo::new();
+    repo.write("src/lib.rs", LIB_RS);
+
+    let output = repo.index_file("src/lib.rs");
+
+    let new_sym = output
+        .symbols
+        .iter()
+        .find(|s| s.name == "new")
+        .expect("find 'new'");
+    assert_eq!(new_sym.qualified_name, "Point::new");
+    assert_eq!(new_sym.parent_qualified_name.as_deref(), Some("Point"));
+
+    let area_sym = output
+        .symbols
+        .iter()
+        .find(|s| s.name == "area")
+        .expect("find 'area'");
+    assert_eq!(area_sym.qualified_name, "Area::area");
+    assert_eq!(area_sym.parent_qualified_name.as_deref(), Some("Area"));
+}


### PR DESCRIPTION
## Summary

- Issue: Closes #25 
- Scope: Create adapter-syntax-treesitter crate implementing baseline tree-sitter symbol extraction for Rust, with self-describing provenance output aligned to adapter-api contracts.

## Changes

- Created crates/adapter-syntax-treesitter crate with tree-sitter 0.25 and tree-sitter-rust 0.24 dependencies.
- Implemented TreeSitterAdapter (LanguageAdapter trait) with table-driven LanguageProfile system for extensible language support.
- Rust baseline extracts: functions, methods (impl/trait context detection), structs (Class), enums/traits/type aliases (Type), consts/statics (Constant), /// doc comments, signatures (text before body block).                                                                                                        
- Qualified names built via scope tracking through impl, trait, and mod containers; generic type handling (impl<T> Foo<T> → scope "Foo").
- Added source_adapter and quality_level provenance fields to AdapterOutput in adapter-api crate, making output self-describing per spec 5.3.
- Adapter resolves all None confidence scores to default_confidence before returning, so every emitted symbol carries explicit provenance.
- Fixed scope stack push/pop to only pop when a scope name was actually pushed (prevents mismatch if extract_scope_name returns None).
- Added adapter-api and tree-sitter/tree-sitter-rust as workspace dependencies.  

## Acceptance Criteria Mapping

- Crate builds and exposes adapter implementation: create_adapter("rust") factory, supported_languages(), TreeSitterAdapter implementing LanguageAdapter.
- Baseline extraction works on fixture repositories: 6 integration tests using tempfile-backed fixture repos with realistic Rust project layout (src/lib.rs, src/main.rs).
- Contract tests pass for supported baseline languages: 23 unit tests covering Rust extraction (functions, structs, enums, traits, impl methods, generics, consts, statics, type aliases, doc comments, signatures, provenance, determinism, edge cases).

## Test Evidence

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --all-features (119 tests total, 29 new in adapter-syntax-treesitter)
- Additional tests/benchmarks (if required by issue)
  - Unit (23): adapter identity/capabilities, provenance fields, resolved confidence scores, function/struct/enum/trait/const/static/type-alias extraction, impl methods with qualified names, generic impl methods, trait method declarations, function signatures, doc comments, empty/whitespace files, comprehensive 
  determinism fixture
  - Integration (6): fixture repo lib extraction, main function extraction, provenance self-description, determinism across files, empty file handling, qualified name/impl scope correctness  

## Risk and Mitigation

- Risk: tree-sitter 0.25 and tree-sitter-rust 0.24 add native C compilation to the build (tree-sitter parser is C code compiled via cc).
- Mitigation: Both are widely-used stable crates; build is tested in CI. Grammar version is pinned via workspace dependency.
- Risk: AdapterOutput provenance field addition is a breaking change to adapter-api.
- Mitigation: Crate is pre-1.0 and internal; all consumers updated in this PR.

## Security/Observability Impact

- Security: Tree-sitter parses untrusted source code in a memory-safe Rust binding. Content is bounded by upstream discovery-stage size caps. No file I/O performed by the adapter (content provided via SourceFile).
- Logs/Metrics/Tracing: None added in this crate. Adapter output carries provenance fields (source_adapter, quality_level, confidence_score) for downstream observability.