### PR TITLE
Create content-addressed blob storage component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +86,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,12 +120,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -155,6 +193,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -512,6 +560,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +598,7 @@ dependencies = [
  "core-model",
  "rusqlite",
  "serde_json",
+ "sha2",
  "tempfile",
 ]
 
@@ -713,6 +773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +801,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ tree-sitter = "0.25"
 tree-sitter-rust = "0.24"
 tracing = "0.1.41"
 rusqlite = { version = "0.35", features = ["bundled"] }
+sha2 = "0.10"
 tracing-subscriber = { version = "0.3.19", features = ["json"] }

--- a/crates/indexer/src/stage.rs
+++ b/crates/indexer/src/stage.rs
@@ -157,7 +157,7 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
         for adapter in &adapters {
             match adapter.index_file(&idx_ctx, &source_file) {
                 Ok(output) => {
-                    let content_hash = simple_content_hash(&file.content);
+                    let content_hash = file_content_hash(&file.content);
                     parsed_files.push(ParsedFile {
                         relative_path: file.relative_path.clone(),
                         language: file.language.clone(),
@@ -208,14 +208,12 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
     }
 }
 
-/// Simple deterministic content hash (sum of bytes mod u64). Production
-/// will use SHA-256 once blob storage (#29) lands.
-fn simple_content_hash(content: &[u8]) -> String {
-    let mut hash: u64 = 0;
-    for &byte in content {
-        hash = hash.wrapping_mul(31).wrapping_add(u64::from(byte));
-    }
-    format!("{hash:016x}")
+/// Computes the SHA-256 content hash for a file's content.
+///
+/// Delegates to [`store::content_hash`] so the indexer and blob store
+/// use the same canonical hash function.
+fn file_content_hash(content: &[u8]) -> String {
+    store::content_hash(content)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 core-model.workspace = true
 rusqlite.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/store/src/blob_store.rs
+++ b/crates/store/src/blob_store.rs
@@ -1,0 +1,338 @@
+//! Content-addressed blob storage backed by the local filesystem.
+//!
+//! Blobs are keyed by their SHA-256 hex digest and stored in a sharded
+//! directory layout (`ab/cdef0123...`) to avoid single-directory inode
+//! pressure. Writing a blob whose hash already exists on disk is a
+//! deduplicated no-op.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::StoreError;
+
+/// Computes the SHA-256 hex digest of the given content.
+///
+/// This is the canonical hash function for all content addressing in
+/// CodeAtlas. Both the blob store and the indexer pipeline must use this
+/// function to produce `file_hash` / `content_hash` values.
+#[must_use]
+pub fn content_hash(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Filesystem-backed content-addressed blob store.
+///
+/// Blobs are stored under a root directory with a two-character shard
+/// prefix derived from the first two hex characters of the SHA-256 digest:
+///
+/// ```text
+/// <root>/ab/abcdef0123456789...
+/// ```
+pub struct BlobStore {
+    root: PathBuf,
+}
+
+impl BlobStore {
+    /// Opens (or creates) a blob store at the given root directory.
+    pub fn open(root: &Path) -> Result<Self, StoreError> {
+        fs::create_dir_all(root).map_err(|e| StoreError::Blob {
+            path: Some(root.to_path_buf()),
+            reason: format!("failed to create blob store root: {e}"),
+        })?;
+
+        let root = root.canonicalize().map_err(|e| StoreError::Blob {
+            path: Some(root.to_path_buf()),
+            reason: format!("failed to canonicalize blob store root: {e}"),
+        })?;
+
+        Ok(Self { root })
+    }
+
+    /// Returns the root directory of the blob store.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Stores content and returns its SHA-256 hex digest.
+    ///
+    /// If a blob with the same hash already exists, the write is skipped
+    /// (content-addressed deduplication). The returned hash is always the
+    /// canonical SHA-256 digest regardless of whether the blob was newly
+    /// written or already present.
+    pub fn put(&self, content: &[u8]) -> Result<String, StoreError> {
+        let hash = content_hash(content);
+        let blob_path = self.blob_path(&hash);
+
+        if blob_path.exists() {
+            return Ok(hash);
+        }
+
+        let shard_dir = blob_path.parent().expect("blob path always has a parent");
+        fs::create_dir_all(shard_dir).map_err(|e| StoreError::Blob {
+            path: Some(shard_dir.to_path_buf()),
+            reason: format!("failed to create shard directory: {e}"),
+        })?;
+
+        // Write to a temporary file then rename for atomic visibility.
+        let tmp_path = blob_path.with_extension("tmp");
+        let mut file = fs::File::create(&tmp_path).map_err(|e| StoreError::Blob {
+            path: Some(tmp_path.clone()),
+            reason: format!("failed to create temp blob file: {e}"),
+        })?;
+
+        file.write_all(content).map_err(|e| StoreError::Blob {
+            path: Some(tmp_path.clone()),
+            reason: format!("failed to write blob content: {e}"),
+        })?;
+
+        file.flush().map_err(|e| StoreError::Blob {
+            path: Some(tmp_path.clone()),
+            reason: format!("failed to flush blob file: {e}"),
+        })?;
+
+        fs::rename(&tmp_path, &blob_path).map_err(|e| StoreError::Blob {
+            path: Some(blob_path),
+            reason: format!("failed to rename temp file to blob: {e}"),
+        })?;
+
+        Ok(hash)
+    }
+
+    /// Retrieves the content for the given hash.
+    ///
+    /// Returns `None` if no blob with that hash exists.
+    pub fn get(&self, hash: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        validate_hash(hash)?;
+        let blob_path = self.blob_path(hash);
+
+        if !blob_path.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read(&blob_path).map_err(|e| StoreError::Blob {
+            path: Some(blob_path),
+            reason: format!("failed to read blob: {e}"),
+        })?;
+
+        Ok(Some(content))
+    }
+
+    /// Returns whether a blob with the given hash exists.
+    pub fn exists(&self, hash: &str) -> Result<bool, StoreError> {
+        validate_hash(hash)?;
+        Ok(self.blob_path(hash).exists())
+    }
+
+    /// Deletes the blob with the given hash.
+    ///
+    /// Returns `true` if the blob existed and was removed, `false` if it
+    /// did not exist.
+    pub fn delete(&self, hash: &str) -> Result<bool, StoreError> {
+        validate_hash(hash)?;
+        let blob_path = self.blob_path(hash);
+
+        if !blob_path.exists() {
+            return Ok(false);
+        }
+
+        fs::remove_file(&blob_path).map_err(|e| StoreError::Blob {
+            path: Some(blob_path),
+            reason: format!("failed to delete blob: {e}"),
+        })?;
+
+        Ok(true)
+    }
+
+    /// Computes the filesystem path for a given hash.
+    ///
+    /// Layout: `<root>/<first-2-hex-chars>/<full-hash>`
+    fn blob_path(&self, hash: &str) -> PathBuf {
+        let shard = &hash[..2];
+        self.root.join(shard).join(hash)
+    }
+}
+
+/// Validates that a hash string looks like a valid SHA-256 hex digest.
+fn validate_hash(hash: &str) -> Result<(), StoreError> {
+    if hash.len() != 64 {
+        return Err(StoreError::Blob {
+            path: None,
+            reason: format!(
+                "invalid hash length: expected 64 hex characters, got {}",
+                hash.len()
+            ),
+        });
+    }
+    if !hash
+        .bytes()
+        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Err(StoreError::Blob {
+            path: None,
+            reason: "hash must be lowercase hex (0-9, a-f)".to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, BlobStore) {
+        let dir = TempDir::new().expect("create temp dir");
+        let store = BlobStore::open(dir.path().join("blobs").as_path()).expect("open blob store");
+        (dir, store)
+    }
+
+    #[test]
+    fn content_hash_is_sha256() {
+        let hash = content_hash(b"hello world");
+        // Known SHA-256 digest for "hello world".
+        assert_eq!(
+            hash,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn content_hash_is_deterministic() {
+        let a = content_hash(b"test data");
+        let b = content_hash(b"test data");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn content_hash_empty_input() {
+        let hash = content_hash(b"");
+        // Known SHA-256 digest for empty input.
+        assert_eq!(
+            hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn put_and_get_round_trips() {
+        let (_dir, store) = setup();
+        let content = b"fn main() {}\n";
+
+        let hash = store.put(content).expect("put blob");
+        assert_eq!(hash.len(), 64);
+
+        let retrieved = store.get(&hash).expect("get blob").expect("blob exists");
+        assert_eq!(retrieved, content);
+    }
+
+    #[test]
+    fn put_empty_content() {
+        let (_dir, store) = setup();
+        let hash = store.put(b"").expect("put empty blob");
+        assert_eq!(hash, content_hash(b""));
+
+        let retrieved = store.get(&hash).expect("get blob").expect("blob exists");
+        assert!(retrieved.is_empty());
+    }
+
+    #[test]
+    fn put_deduplicates_identical_content() {
+        let (_dir, store) = setup();
+        let content = b"deduplicated";
+
+        let hash1 = store.put(content).expect("first put");
+        let hash2 = store.put(content).expect("second put");
+        assert_eq!(hash1, hash2);
+
+        // Blob path should exist exactly once.
+        let blob_path = store.blob_path(&hash1);
+        assert!(blob_path.exists());
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_blob() {
+        let (_dir, store) = setup();
+        let hash = content_hash(b"nonexistent");
+        let result = store.get(&hash).expect("get missing blob");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn exists_returns_correct_status() {
+        let (_dir, store) = setup();
+        let hash = store.put(b"check existence").expect("put blob");
+
+        assert!(store.exists(&hash).expect("exists check"));
+
+        let missing = content_hash(b"not stored");
+        assert!(!store.exists(&missing).expect("exists check"));
+    }
+
+    #[test]
+    fn delete_removes_blob() {
+        let (_dir, store) = setup();
+        let hash = store.put(b"to be deleted").expect("put blob");
+
+        assert!(store.delete(&hash).expect("delete blob"));
+        assert!(!store.exists(&hash).expect("exists after delete"));
+        assert!(store.get(&hash).expect("get after delete").is_none());
+    }
+
+    #[test]
+    fn delete_returns_false_for_missing() {
+        let (_dir, store) = setup();
+        let hash = content_hash(b"never stored");
+        assert!(!store.delete(&hash).expect("delete missing"));
+    }
+
+    #[test]
+    fn blob_path_uses_shard_directory() {
+        let (_dir, store) = setup();
+        let hash = content_hash(b"shard test");
+        let path = store.blob_path(&hash);
+
+        let shard = &hash[..2];
+        assert!(path.to_string_lossy().contains(&format!("/{shard}/")));
+        assert!(path.to_string_lossy().ends_with(&hash));
+    }
+
+    #[test]
+    fn different_content_produces_different_hashes() {
+        let (_dir, store) = setup();
+        let hash1 = store.put(b"content a").expect("put a");
+        let hash2 = store.put(b"content b").expect("put b");
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn validate_hash_rejects_short_string() {
+        let err = validate_hash("abcd").expect_err("should reject short hash");
+        assert!(err.to_string().contains("invalid hash length"));
+    }
+
+    #[test]
+    fn validate_hash_rejects_non_hex() {
+        let bad = "g".repeat(64);
+        let err = validate_hash(&bad).expect_err("should reject non-hex");
+        assert!(err.to_string().contains("lowercase hex"));
+    }
+
+    #[test]
+    fn validate_hash_rejects_uppercase_hex() {
+        let upper = "A".repeat(64);
+        let err = validate_hash(&upper).expect_err("should reject uppercase hex");
+        assert!(err.to_string().contains("lowercase hex"));
+    }
+
+    #[test]
+    fn validate_hash_accepts_valid_sha256() {
+        let hash = content_hash(b"valid");
+        validate_hash(&hash).expect("valid hash should pass");
+    }
+}

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -1,17 +1,20 @@
-//! Metadata persistence layer (SQLite-first).
+//! Persistence layer for CodeAtlas.
 //!
-//! Provides [`MetadataStore`] for persisting repository, file, and symbol
-//! records. Schema is managed through versioned migrations.
+//! Provides [`MetadataStore`] (SQLite) for persisting repository, file,
+//! and symbol records, and [`BlobStore`] (filesystem) for content-addressed
+//! blob storage of raw file snapshots.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 
+pub mod blob_store;
 mod file_store;
 mod migrations;
 mod repo_store;
 mod symbol_store;
 
+pub use blob_store::{content_hash, BlobStore};
 pub use file_store::FileStore;
 pub use migrations::{rollback_to, SCHEMA_VERSION};
 pub use repo_store::RepoStore;
@@ -21,7 +24,7 @@ pub use symbol_store::SymbolStore;
 // Error type
 // ---------------------------------------------------------------------------
 
-/// Errors produced by the metadata store.
+/// Errors produced by the metadata or blob store.
 #[derive(Debug)]
 pub enum StoreError {
     /// A SQLite operation failed.
@@ -30,6 +33,11 @@ pub enum StoreError {
     Migration { version: u32, reason: String },
     /// A record failed validation before persistence.
     Validation(String),
+    /// A blob storage operation failed.
+    Blob {
+        path: Option<PathBuf>,
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for StoreError {
@@ -40,6 +48,13 @@ impl std::fmt::Display for StoreError {
                 write!(f, "migration v{version} failed: {reason}")
             }
             Self::Validation(msg) => write!(f, "validation error: {msg}"),
+            Self::Blob { path, reason } => {
+                if let Some(path) = path {
+                    write!(f, "blob error at '{}': {reason}", path.display())
+                } else {
+                    write!(f, "blob error: {reason}")
+                }
+            }
         }
     }
 }

--- a/crates/store/tests/blob_integration.rs
+++ b/crates/store/tests/blob_integration.rs
@@ -1,0 +1,118 @@
+//! Integration tests for the content-addressed blob store.
+
+use store::{content_hash, BlobStore};
+use tempfile::TempDir;
+
+fn setup() -> (TempDir, BlobStore) {
+    let dir = TempDir::new().expect("create temp dir");
+    let store = BlobStore::open(&dir.path().join("blobs")).expect("open blob store");
+    (dir, store)
+}
+
+#[test]
+fn full_lifecycle_put_get_exists_delete() {
+    let (_dir, store) = setup();
+    let content = b"fn main() { println!(\"hello\"); }\n";
+
+    // Put
+    let hash = store.put(content).expect("put blob");
+    assert_eq!(hash, content_hash(content));
+
+    // Exists
+    assert!(store.exists(&hash).expect("exists check"));
+
+    // Get
+    let retrieved = store.get(&hash).expect("get blob").expect("blob exists");
+    assert_eq!(retrieved, content);
+
+    // Delete
+    assert!(store.delete(&hash).expect("delete blob"));
+    assert!(!store.exists(&hash).expect("exists after delete"));
+    assert!(store.get(&hash).expect("get after delete").is_none());
+    assert!(!store.delete(&hash).expect("double delete"));
+}
+
+#[test]
+fn deduplication_across_multiple_puts() {
+    let (_dir, store) = setup();
+    let content = b"shared content";
+
+    let hash1 = store.put(content).expect("first put");
+    let hash2 = store.put(content).expect("second put");
+    let hash3 = store.put(content).expect("third put");
+
+    assert_eq!(hash1, hash2);
+    assert_eq!(hash2, hash3);
+
+    // Only one blob on disk — deleting once should suffice.
+    assert!(store.delete(&hash1).expect("delete"));
+    assert!(!store.exists(&hash1).expect("exists after delete"));
+}
+
+#[test]
+fn distinct_content_produces_distinct_blobs() {
+    let (_dir, store) = setup();
+
+    let hash_a = store.put(b"alpha").expect("put alpha");
+    let hash_b = store.put(b"beta").expect("put beta");
+    assert_ne!(hash_a, hash_b);
+
+    let a = store.get(&hash_a).expect("get a").expect("a exists");
+    let b = store.get(&hash_b).expect("get b").expect("b exists");
+    assert_eq!(a, b"alpha");
+    assert_eq!(b, b"beta");
+}
+
+#[test]
+fn empty_content_is_stored_and_retrievable() {
+    let (_dir, store) = setup();
+
+    let hash = store.put(b"").expect("put empty");
+    assert!(store.exists(&hash).expect("exists"));
+
+    let retrieved = store.get(&hash).expect("get").expect("exists");
+    assert!(retrieved.is_empty());
+}
+
+#[test]
+fn hash_function_matches_blob_store_keying() {
+    let (_dir, store) = setup();
+    let content = b"consistency check";
+
+    let standalone_hash = content_hash(content);
+    let store_hash = store.put(content).expect("put");
+
+    assert_eq!(standalone_hash, store_hash);
+}
+
+#[test]
+fn invalid_hash_is_rejected() {
+    let (_dir, store) = setup();
+
+    let err = store.get("not-a-hash").expect_err("should reject bad hash");
+    assert!(err.to_string().contains("invalid hash length"));
+
+    let err = store.exists("abcd").expect_err("should reject short hash");
+    assert!(err.to_string().contains("invalid hash length"));
+
+    // Uppercase hex is rejected to prevent silent path mismatches.
+    let upper = "A".repeat(64);
+    let err = store.get(&upper).expect_err("should reject uppercase");
+    assert!(err.to_string().contains("lowercase hex"));
+}
+
+#[test]
+fn blob_store_persists_across_reopen() {
+    let dir = TempDir::new().expect("create temp dir");
+    let blob_dir = dir.path().join("blobs");
+
+    let hash = {
+        let store = BlobStore::open(&blob_dir).expect("open store");
+        store.put(b"persistent data").expect("put blob")
+    };
+
+    // Reopen the store and verify the blob persists.
+    let store = BlobStore::open(&blob_dir).expect("reopen store");
+    let retrieved = store.get(&hash).expect("get blob").expect("blob exists");
+    assert_eq!(retrieved, b"persistent data");
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #29
  - Scope: Add a content-addressed blob storage component and integrate canonical SHA-256 content hashing into pipeline persistence flow.

  ## Changes

  - Added filesystem-backed blob store in store crate:
      - New module: crates/store/src/blob_store.rs
      - New type: BlobStore
      - New canonical hash function: content_hash(data: &[u8]) -> String (SHA-256 hex)
  - Implemented blob lifecycle API:
      - BlobStore::open(root)
      - put(content) with deduplicated write behavior
      - get(hash)
      - exists(hash)
      - delete(hash)
  - Implemented sharded on-disk layout for blob keys:
      - <root>/<first-2-hex>/<full-64-hex-hash>
  - Added explicit hash validation for read/delete/exists paths:
      - length and hex-character checks before filesystem lookup
  - Extended store error boundary:
      - Added StoreError::Blob { path, reason }
      - Integrated display formatting for blob failures
  - Exported blob API from store crate:
      - pub use blob_store::{content_hash, BlobStore};
  - Integrated indexer with canonical hash function:
      - Replaced local ad-hoc hash logic in indexer parse stage
      - Now delegates to store::content_hash(...) for content hash consistency
  - Added dependencies:
      - Workspace: sha2
      - Store crate: sha2.workspace = true

  ## Acceptance Criteria Mapping

  - [x] Deliverable implemented and integrated.
    Blob storage component added and hash function integrated into indexer content hash generation.
  - [x] Edge cases and failure behavior handled explicitly.
    Invalid hash formats return explicit errors; missing blobs return None/false; duplicate puts are no-op deduplicated.
  - [x] Deterministic behavior is test-covered where relevant.
    Deterministic SHA-256 keying and known-digest fixtures are covered in unit tests.
  - [x] CI checks pass.
    Workspace fmt, clippy, and tests pass.

  ## Test Evidence

  - [x] cargo fmt --all -- --check
  - [x] cargo clippy --all-targets --all-features -- -D warnings
  - [x] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
    Added:
      - Unit tests in crates/store/src/blob_store.rs (hash/keying, validation, dedupe, lifecycle)
      - Integration tests in crates/store/tests/blob_integration.rs (blob read/write lifecycle, reopen persistence)

  ## Risk and Mitigation

  - Risk: Hash/key mismatch between indexer and blob storage could break snapshot lookup consistency.
  - Mitigation: Centralized canonical hashing via store::content_hash and explicit indexer delegation to the same function.

  ## Security/Observability Impact

  - Security: Blob paths are content-addressed and validated by strict hash format checks; no user-controlled path joins beyond validated hashes.
  - Logs/Metrics/Tracing: No new logging/metrics/tracing surfaces introduced in this ticket.