### PR TITLE
Implement staging-to-swap atomic index commit

### DIFF
--- a/crates/indexer/src/context.rs
+++ b/crates/indexer/src/context.rs
@@ -5,6 +5,9 @@ use adapter_api::{AdapterPolicy, AdapterRouter, IndexContext};
 /// Configuration and shared state for a single pipeline run.
 ///
 /// Constructed once per index invocation and threaded through every stage.
+/// The metadata store is **not** part of this context — it is passed
+/// separately (as `&mut`) to stages that need write access, keeping the
+/// context immutably shareable across read-only stages.
 pub struct PipelineContext<'a> {
     /// Unique identifier for the repository being indexed.
     pub repo_id: String,
@@ -12,8 +15,6 @@ pub struct PipelineContext<'a> {
     pub source_root: PathBuf,
     /// Adapter router for selecting language adapters.
     pub router: &'a dyn AdapterRouter,
-    /// Metadata store for persistence.
-    pub store: &'a store::MetadataStore,
     /// Default adapter selection policy applied when no per-language override
     /// is configured.
     pub default_policy: AdapterPolicy,

--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -24,9 +24,16 @@ pub struct IndexResult {
 
 /// Runs the full indexing pipeline: discovery → parse → persist.
 ///
+/// The metadata store is passed separately from the pipeline context so that
+/// only the persist stage borrows it mutably, while discovery and parse
+/// operate with an immutable context.
+///
 /// Returns an [`IndexResult`] with aggregate metrics and any per-file
 /// errors encountered during parsing.
-pub fn run(ctx: &PipelineContext<'_>) -> Result<IndexResult, PipelineError> {
+pub fn run(
+    ctx: &PipelineContext<'_>,
+    store: &mut store::MetadataStore,
+) -> Result<IndexResult, PipelineError> {
     info!(repo_id = %ctx.repo_id, "pipeline started");
 
     // Stage 1: Discovery
@@ -42,7 +49,7 @@ pub fn run(ctx: &PipelineContext<'_>) -> Result<IndexResult, PipelineError> {
         .sum();
 
     // Stage 3: Persist
-    stage::persist(ctx, &parse_output)?;
+    stage::persist(ctx, store, &parse_output)?;
 
     let metrics = IndexMetrics {
         files_discovered: discovery.metrics.files_discovered,

--- a/crates/indexer/src/stage.rs
+++ b/crates/indexer/src/stage.rs
@@ -220,11 +220,18 @@ fn file_content_hash(content: &[u8]) -> String {
 // Persist stage
 // ---------------------------------------------------------------------------
 
-/// Persists parsed results to the metadata store.
+/// Persists parsed results to the metadata store inside a single SQLite
+/// transaction. All repo, file, and symbol writes are atomic: either
+/// everything commits or nothing does.
 ///
-/// Respects FK ordering: repo → files → symbols. Validation failures on
-/// individual records are logged and skipped (non-fatal).
-pub fn persist(ctx: &PipelineContext<'_>, parse_output: &ParseOutput) -> Result<(), PipelineError> {
+/// Respects FK ordering: repo → files → symbols. Any validation failure
+/// aborts the entire transaction (automatic rollback on drop) to prevent
+/// inconsistent state between aggregate counts and actual persisted records.
+pub fn persist(
+    ctx: &PipelineContext<'_>,
+    store: &mut store::MetadataStore,
+    parse_output: &ParseOutput,
+) -> Result<(), PipelineError> {
     let now = OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .map_err(|e| PipelineError::Internal(format!("timestamp format error: {e}")))?;
@@ -242,32 +249,35 @@ pub fn persist(ctx: &PipelineContext<'_>, parse_output: &ParseOutput) -> Result<
     let mut file_stats: Vec<FileStats> = Vec::with_capacity(parse_output.parsed_files.len());
 
     for parsed in &parse_output.parsed_files {
-        let valid_symbols = parsed
-            .output
-            .symbols
-            .iter()
-            .filter(|sym| {
-                let file_path_str = parsed.relative_path.to_string_lossy();
-                build_symbol_id(&file_path_str, &sym.qualified_name, sym.kind).is_ok()
-            })
-            .count() as u64;
+        let sym_count = parsed.output.symbols.len() as u64;
+
+        // Validate all symbol IDs upfront — any failure is fatal.
+        for sym in &parsed.output.symbols {
+            let file_path_str = parsed.relative_path.to_string_lossy();
+            build_symbol_id(&file_path_str, &sym.qualified_name, sym.kind).map_err(|e| {
+                PipelineError::Validation(format!(
+                    "invalid symbol ID for '{}' in {}: {e}",
+                    sym.name, file_path_str
+                ))
+            })?;
+        }
 
         let semantic = if parsed.output.quality_level == QualityLevel::Semantic {
-            valid_symbols
+            sym_count
         } else {
             0
         };
 
         file_stats.push(FileStats {
-            symbol_count: valid_symbols,
+            symbol_count: sym_count,
             semantic_count: semantic,
         });
 
         *language_counts.entry(parsed.language.clone()).or_insert(0) += 1;
-        total_symbol_count += valid_symbols;
+        total_symbol_count += sym_count;
     }
 
-    // -- Step 1: upsert repo record (no FK parent) --
+    // -- Validate repo record before opening transaction --
 
     let schema_version = current_index_schema_version();
     let repo_record = RepoRecord {
@@ -288,13 +298,16 @@ pub fn persist(ctx: &PipelineContext<'_>, parse_output: &ParseOutput) -> Result<
         )));
     }
 
-    ctx.store
-        .repos()
+    // -- Begin atomic transaction --
+
+    let tx = store.transaction().map_err(PipelineError::Persist)?;
+
+    // Step 1: upsert repo record (no FK parent)
+    tx.repos()
         .upsert(&repo_record)
         .map_err(PipelineError::Persist)?;
 
-    // -- Step 2: upsert file records (FK → repos) --
-
+    // Step 2: upsert file records (FK → repos)
     for (parsed, stats) in parse_output.parsed_files.iter().zip(file_stats.iter()) {
         let file_path_str = parsed.relative_path.to_string_lossy();
 
@@ -322,23 +335,19 @@ pub fn persist(ctx: &PipelineContext<'_>, parse_output: &ParseOutput) -> Result<
             updated_at: now.clone(),
         };
 
-        if let Err(e) = file_record.validate() {
-            warn!(
-                path = %file_path_str,
-                error = %e,
-                "skipping file record that failed validation"
-            );
-            continue;
-        }
+        file_record.validate().map_err(|e| {
+            PipelineError::Validation(format!(
+                "file record validation failed for '{}': {e}",
+                file_path_str
+            ))
+        })?;
 
-        ctx.store
-            .files()
+        tx.files()
             .upsert(&file_record)
             .map_err(PipelineError::Persist)?;
     }
 
-    // -- Step 3: upsert symbol records (FK → files) --
-
+    // Step 3: upsert symbol records (FK → files)
     for parsed in &parse_output.parsed_files {
         let file_path_str = parsed.relative_path.to_string_lossy();
         let default_confidence = match parsed.output.quality_level {
@@ -347,18 +356,14 @@ pub fn persist(ctx: &PipelineContext<'_>, parse_output: &ParseOutput) -> Result<
         };
 
         for sym in &parsed.output.symbols {
-            let symbol_id = match build_symbol_id(&file_path_str, &sym.qualified_name, sym.kind) {
-                Ok(id) => id,
-                Err(e) => {
-                    warn!(
-                        path = %file_path_str,
-                        symbol = %sym.name,
-                        error = %e,
-                        "skipping symbol with invalid ID"
-                    );
-                    continue;
-                }
-            };
+            // Symbol ID was pre-validated in pass 1; safe to unwrap.
+            let symbol_id = build_symbol_id(&file_path_str, &sym.qualified_name, sym.kind)
+                .map_err(|e| {
+                    PipelineError::Validation(format!(
+                        "invalid symbol ID for '{}' in {}: {e}",
+                        sym.name, file_path_str
+                    ))
+                })?;
 
             let confidence = sym.confidence_score.unwrap_or(default_confidence);
 
@@ -388,21 +393,21 @@ pub fn persist(ctx: &PipelineContext<'_>, parse_output: &ParseOutput) -> Result<
                 semantic_refs: None,
             };
 
-            if let Err(e) = record.validate() {
-                warn!(
-                    symbol_id = %record.id,
-                    error = %e,
-                    "skipping symbol that failed validation"
-                );
-                continue;
-            }
+            record.validate().map_err(|e| {
+                PipelineError::Validation(format!(
+                    "symbol record validation failed for '{}' in {}: {e}",
+                    sym.name, file_path_str
+                ))
+            })?;
 
-            ctx.store
-                .symbols()
+            tx.symbols()
                 .upsert(&record)
                 .map_err(PipelineError::Persist)?;
         }
     }
+
+    // -- Commit the transaction atomically --
+    tx.commit().map_err(PipelineError::Persist)?;
 
     info!(
         files_persisted = parse_output.parsed_files.len(),

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -145,18 +145,17 @@ fn setup_test_repo() -> TempDir {
 fn pipeline_end_to_end_smoke_test() {
     let repo_dir = setup_test_repo();
     let router = StubRouter::new();
-    let db = store::MetadataStore::open_in_memory().expect("open store");
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
 
     let ctx = PipelineContext {
         repo_id: "test-repo".to_string(),
         source_root: repo_dir.path().to_path_buf(),
         router: &router,
-        store: &db,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: Some("test-correlation-001".to_string()),
     };
 
-    let result = run(&ctx).expect("pipeline should succeed");
+    let result = run(&ctx, &mut db).expect("pipeline should succeed");
 
     // Discovery found at least the one .rs file.
     assert!(
@@ -219,13 +218,11 @@ fn pipeline_end_to_end_smoke_test() {
 fn discovery_stage_finds_files() {
     let repo_dir = setup_test_repo();
     let router = StubRouter::new();
-    let db = store::MetadataStore::open_in_memory().expect("open store");
 
     let ctx = PipelineContext {
         repo_id: "test-repo".to_string(),
         source_root: repo_dir.path().to_path_buf(),
         router: &router,
-        store: &db,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
     };
@@ -238,13 +235,11 @@ fn discovery_stage_finds_files() {
 #[test]
 fn discovery_stage_rejects_invalid_root() {
     let router = StubRouter::new();
-    let db = store::MetadataStore::open_in_memory().expect("open store");
 
     let ctx = PipelineContext {
         repo_id: "test-repo".to_string(),
         source_root: PathBuf::from("/nonexistent/path"),
         router: &router,
-        store: &db,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
     };
@@ -263,13 +258,11 @@ fn discovery_detects_extensionless_script_via_content() {
     .expect("write script");
 
     let router = StubRouter::new();
-    let db = store::MetadataStore::open_in_memory().expect("open store");
 
     let ctx = PipelineContext {
         repo_id: "test-repo".to_string(),
         source_root: dir.path().to_path_buf(),
         router: &router,
-        store: &db,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
     };
@@ -297,13 +290,11 @@ fn parse_stage_handles_no_adapter() {
     std::fs::write(repo_dir.path().join("script.py"), "print('hi')\n").expect("write py file");
 
     let router = StubRouter::new();
-    let db = store::MetadataStore::open_in_memory().expect("open store");
 
     let ctx = PipelineContext {
         repo_id: "test-repo".to_string(),
         source_root: repo_dir.path().to_path_buf(),
         router: &router,
-        store: &db,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
     };
@@ -332,13 +323,11 @@ fn parse_stage_uses_context_default_policy() {
     // SyntaxOnly (the global default for Rust), the router returns no
     // adapters and the file lands in file_errors instead of parsed_files.
     let router = PolicyGatingRouter::expecting(AdapterPolicy::SemanticPreferred);
-    let db = store::MetadataStore::open_in_memory().expect("open store");
 
     let ctx = PipelineContext {
         repo_id: "test-repo".to_string(),
         source_root: repo_dir.path().to_path_buf(),
         router: &router,
-        store: &db,
         default_policy: AdapterPolicy::SemanticPreferred,
         correlation_id: None,
     };

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -7,6 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
+use rusqlite::Transaction;
 
 pub mod blob_store;
 mod file_store;
@@ -131,5 +132,55 @@ impl MetadataStore {
     /// Returns the current schema version stored in the database.
     pub fn schema_version(&self) -> Result<u32, StoreError> {
         migrations::current_version(&self.conn)
+    }
+
+    /// Begins a SQLite transaction and returns a [`StoreTransaction`] guard.
+    ///
+    /// All writes performed through the transaction's accessors are buffered
+    /// until [`StoreTransaction::commit`] is called. If the guard is dropped
+    /// without committing, all changes are rolled back automatically.
+    pub fn transaction(&mut self) -> Result<StoreTransaction<'_>, StoreError> {
+        let tx = self.conn.transaction()?;
+        Ok(StoreTransaction { tx })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StoreTransaction
+// ---------------------------------------------------------------------------
+
+/// A transactional guard over the metadata store.
+///
+/// Provides the same `repos()` / `files()` / `symbols()` accessors as
+/// [`MetadataStore`], but all writes are part of a single SQLite transaction.
+/// Call [`commit`](Self::commit) to atomically persist all changes, or simply
+/// drop the guard to roll back.
+pub struct StoreTransaction<'conn> {
+    tx: Transaction<'conn>,
+}
+
+impl<'conn> StoreTransaction<'conn> {
+    /// Returns the repo store accessor within this transaction.
+    #[must_use]
+    pub fn repos(&self) -> RepoStore<'_> {
+        RepoStore::new(&self.tx)
+    }
+
+    /// Returns the file store accessor within this transaction.
+    #[must_use]
+    pub fn files(&self) -> FileStore<'_> {
+        FileStore::new(&self.tx)
+    }
+
+    /// Returns the symbol store accessor within this transaction.
+    #[must_use]
+    pub fn symbols(&self) -> SymbolStore<'_> {
+        SymbolStore::new(&self.tx)
+    }
+
+    /// Atomically commits all writes performed through this transaction.
+    pub fn commit(self) -> Result<(), StoreError> {
+        self.tx.commit()?;
+        Ok(())
     }
 }

--- a/crates/store/tests/sqlite_integration.rs
+++ b/crates/store/tests/sqlite_integration.rs
@@ -215,6 +215,131 @@ fn rollback_to_zero_and_reapply_on_disk() {
 }
 
 // ---------------------------------------------------------------------------
+// Transaction: atomic commit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn transaction_commit_persists_all_writes() {
+    let mut store = MetadataStore::open_in_memory().unwrap();
+
+    {
+        let tx = store.transaction().unwrap();
+        tx.repos().upsert(&test_repo()).unwrap();
+        tx.files().upsert(&test_file("src/lib.rs")).unwrap();
+        tx.symbols()
+            .upsert(&test_symbol("src/lib.rs", "Config", SymbolKind::Class))
+            .unwrap();
+        tx.commit().unwrap();
+    }
+
+    // All three records are visible after commit.
+    assert!(store.repos().get("integration-repo").unwrap().is_some());
+    assert!(store
+        .files()
+        .get("integration-repo", "src/lib.rs")
+        .unwrap()
+        .is_some());
+    assert!(store
+        .symbols()
+        .get("src/lib.rs::Config#class")
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn transaction_drop_without_commit_rolls_back() {
+    let mut store = MetadataStore::open_in_memory().unwrap();
+
+    // Pre-populate a repo so we can verify it survives the rollback.
+    store.repos().upsert(&test_repo()).unwrap();
+
+    {
+        let tx = store.transaction().unwrap();
+        tx.files().upsert(&test_file("src/lib.rs")).unwrap();
+        tx.symbols()
+            .upsert(&test_symbol("src/lib.rs", "Config", SymbolKind::Class))
+            .unwrap();
+        // Drop without commit — automatic rollback.
+    }
+
+    // Repo still exists (was committed before the transaction).
+    assert!(store.repos().get("integration-repo").unwrap().is_some());
+    // File and symbol were never committed.
+    assert!(store
+        .files()
+        .get("integration-repo", "src/lib.rs")
+        .unwrap()
+        .is_none());
+    assert!(store
+        .symbols()
+        .get("src/lib.rs::Config#class")
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn transaction_rollback_on_error_leaves_store_unchanged() {
+    let mut store = MetadataStore::open_in_memory().unwrap();
+
+    // Attempt a transaction that inserts a repo then hits a validation error
+    // on a symbol. The transaction is dropped, so all writes roll back.
+    let result: Result<(), store::StoreError> = (|| {
+        let tx = store.transaction()?;
+        tx.repos().upsert(&test_repo())?;
+        tx.files().upsert(&test_file("src/main.rs"))?;
+
+        // Symbol with empty name fails validation.
+        let mut bad_sym = test_symbol("src/main.rs", "main", SymbolKind::Function);
+        bad_sym.name = "".to_string();
+        tx.symbols().upsert(&bad_sym)?;
+
+        tx.commit()?;
+        Ok(())
+    })();
+
+    assert!(result.is_err());
+    // Nothing was persisted because the transaction was dropped.
+    assert!(store.repos().get("integration-repo").unwrap().is_none());
+}
+
+#[test]
+fn transaction_crash_retry_simulation() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("crash_sim.db");
+
+    // First attempt: open, begin transaction, write, then "crash" (drop without commit).
+    {
+        let mut store = MetadataStore::open(&db_path).unwrap();
+        let tx = store.transaction().unwrap();
+        tx.repos().upsert(&test_repo()).unwrap();
+        tx.files().upsert(&test_file("src/lib.rs")).unwrap();
+        // Simulate crash: drop tx without commit.
+        drop(tx);
+        // Verify nothing persisted in this session.
+        assert!(store.repos().get("integration-repo").unwrap().is_none());
+    }
+
+    // Second attempt (retry): reopen, transact, commit successfully.
+    {
+        let mut store = MetadataStore::open(&db_path).unwrap();
+        // Database is clean — no partial state from the "crash".
+        assert!(store.repos().get("integration-repo").unwrap().is_none());
+
+        let tx = store.transaction().unwrap();
+        tx.repos().upsert(&test_repo()).unwrap();
+        tx.files().upsert(&test_file("src/lib.rs")).unwrap();
+        tx.commit().unwrap();
+
+        assert!(store.repos().get("integration-repo").unwrap().is_some());
+        assert!(store
+            .files()
+            .get("integration-repo", "src/lib.rs")
+            .unwrap()
+            .is_some());
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Validation enforcement
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

  - Issue: Closes #30
  - Scope: Implement atomic staging-to-commit behavior for index persistence so index updates are all-or-nothing, with crash/retry-safe transaction semantics and integration coverage.

  ## Changes

  - Added transactional write API to store:
      - MetadataStore::transaction() -> StoreTransaction
      - StoreTransaction::{repos(), files(), symbols(), commit()}
      - Drop-without-commit rolls back automatically via SQLite transaction semantics.
  - Updated indexer orchestration to use explicit store transaction boundaries:
      - run now takes (&PipelineContext, &mut MetadataStore)
      - persist now takes (&PipelineContext, &mut MetadataStore, &ParseOutput)
      - persistence performs all repo/file/symbol writes inside one transaction.
  - Strengthened persistence validation semantics:
      - file and symbol record validation errors now return PipelineError::Validation (fatal), instead of warn-and-continue.
      - symbol ID construction failures are now fatal.
      - this guarantees no partial commit on invalid records.
  - Adjusted aggregate counting behavior:
      - pass-1 symbol counting now assumes invalid symbols are fatal; persisted counts and aggregate counts remain consistent.
  - Narrowed mutability scope:
      - removed store reference from PipelineContext.
      - context is immutable across discovery/parse; only persist receives mutable store access.
  - Updated indexer integration tests to new API signatures and context shape.
  - Added/expanded store integration tests for transaction atomicity and retry behavior:
      - commit persists all writes
      - drop without commit rolls back
      - validation error path rolls back entire transaction
      - crash/retry simulation verifies no partial state leakage

  ## Acceptance Criteria Mapping

  - [x] Deliverable implemented and integrated.
    Atomic transaction commit path is implemented and used by indexer persistence.
  - [x] Edge cases and failure behavior handled explicitly.
    Validation and symbol-ID errors now fail the run and trigger rollback; no partial index state.
  - [x] Deterministic behavior is test-covered where relevant.
    Transaction commit/rollback/retry paths are covered with deterministic assertions.
  - [x] CI checks pass.
    Workspace fmt, clippy, and tests pass.

  ## Test Evidence

  - [x] cargo fmt --all -- --check
  - [x] cargo clippy --all-targets --all-features -- -D warnings
  - [x] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
    Added/updated transaction atomicity integration tests in crates/store/tests/sqlite_integration.rs including crash/retry simulation around commit.

  ## Risk and Mitigation

  - Risk: Transaction boundary misuse could still permit partial state if future write paths bypass StoreTransaction.
  - Mitigation: Centralized persistence through persist(..., &mut MetadataStore, ...), fatal validation errors, and dedicated transaction lifecycle integration tests.

  ## Security/Observability Impact

  - Security: Improved consistency guarantees reduce risk of partially written query-visible state after failures/crashes.
  - Logs/Metrics/Tracing: Existing indexer stage logs remain; failure modes now surface as explicit PipelineError::Validation instead of silent skips.