### PR TITLE
Wire indexer pipeline end-to-end (discovery -> adapters -> persistence)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ name = "indexer"
 version = "0.1.0"
 dependencies = [
  "adapter-api",
+ "adapter-syntax-treesitter",
  "core-model",
  "repo-walker",
  "store",

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -14,4 +14,5 @@ time.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+adapter-syntax-treesitter = { path = "../adapter-syntax-treesitter" }
 tempfile.workspace = true

--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -1,5 +1,7 @@
 //! Top-level pipeline orchestration.
 
+use std::collections::HashSet;
+
 use tracing::info;
 
 use crate::context::PipelineContext;
@@ -24,15 +26,16 @@ pub struct IndexResult {
 
 /// Runs the full indexing pipeline: discovery → parse → persist.
 ///
-/// The metadata store is passed separately from the pipeline context so that
-/// only the persist stage borrows it mutably, while discovery and parse
-/// operate with an immutable context.
+/// The metadata store and blob store are passed separately from the pipeline
+/// context so that only the persist stage borrows them, while discovery and
+/// parse operate with an immutable context.
 ///
 /// Returns an [`IndexResult`] with aggregate metrics and any per-file
 /// errors encountered during parsing.
 pub fn run(
     ctx: &PipelineContext<'_>,
     store: &mut store::MetadataStore,
+    blob_store: &store::BlobStore,
 ) -> Result<IndexResult, PipelineError> {
     info!(repo_id = %ctx.repo_id, "pipeline started");
 
@@ -48,13 +51,18 @@ pub fn run(
         .map(|f| f.output.symbols.len())
         .sum();
 
-    // Stage 3: Persist
-    stage::persist(ctx, store, &parse_output)?;
+    // Stage 3: Persist (blobs first, then metadata in a transaction)
+    stage::persist(ctx, store, blob_store, &parse_output)?;
 
     let metrics = IndexMetrics {
         files_discovered: discovery.metrics.files_discovered,
         files_parsed: parse_output.parsed_files.len(),
-        files_errored: parse_output.file_errors.len(),
+        files_errored: parse_output
+            .file_errors
+            .iter()
+            .map(|e| &e.path)
+            .collect::<HashSet<_>>()
+            .len(),
         symbols_extracted,
     };
 

--- a/crates/indexer/src/stage.rs
+++ b/crates/indexer/src/stage.rs
@@ -102,12 +102,19 @@ pub struct ParsedFile {
     pub language: String,
     pub output: AdapterOutput,
     pub content_hash: String,
+    /// Raw file content, carried through for blob storage.
+    pub content: Vec<u8>,
 }
 
 /// Per-file error captured during the parse stage (non-fatal).
+///
+/// Carries the failing adapter's identity when available, so callers can
+/// trace failures back to a specific adapter.
 #[derive(Debug)]
 pub struct FileError {
     pub path: PathBuf,
+    /// The adapter that produced the error, if applicable.
+    pub adapter_id: Option<String>,
     pub error: String,
 }
 
@@ -140,6 +147,7 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
             );
             file_errors.push(FileError {
                 path: file.relative_path.clone(),
+                adapter_id: None,
                 error: format!("no adapter for language '{}'", file.language),
             });
             continue;
@@ -153,7 +161,10 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
         };
 
         // Try adapters in priority order; use the first that succeeds.
+        // Non-fatal errors are recorded but do not prevent lower-priority
+        // adapters from being tried.
         let mut succeeded = false;
+        let mut per_file_errors: Vec<FileError> = Vec::new();
         for adapter in &adapters {
             match adapter.index_file(&idx_ctx, &source_file) {
                 Ok(output) => {
@@ -163,6 +174,7 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
                         language: file.language.clone(),
                         output,
                         content_hash,
+                        content: file.content.clone(),
                     });
                     succeeded = true;
                     break;
@@ -173,26 +185,28 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
                         path = %file.relative_path.display(),
                         adapter = adapter.adapter_id(),
                         error = %e,
-                        "adapter failed"
+                        "adapter failed, trying next"
                     );
-                    file_errors.push(FileError {
+                    per_file_errors.push(FileError {
                         path: file.relative_path.clone(),
+                        adapter_id: Some(adapter.adapter_id().to_string()),
                         error: e.to_string(),
                     });
-                    break;
+                    continue;
                 }
             }
         }
 
-        if !succeeded
-            && file_errors
-                .last()
-                .map_or(true, |e| e.path != file.relative_path)
-        {
-            file_errors.push(FileError {
-                path: file.relative_path.clone(),
-                error: "all adapters returned unsupported".to_string(),
-            });
+        if !succeeded {
+            if per_file_errors.is_empty() {
+                file_errors.push(FileError {
+                    path: file.relative_path.clone(),
+                    adapter_id: None,
+                    error: "all adapters returned unsupported".to_string(),
+                });
+            } else {
+                file_errors.append(&mut per_file_errors);
+            }
         }
     }
 
@@ -220,16 +234,20 @@ fn file_content_hash(content: &[u8]) -> String {
 // Persist stage
 // ---------------------------------------------------------------------------
 
-/// Persists parsed results to the metadata store inside a single SQLite
-/// transaction. All repo, file, and symbol writes are atomic: either
-/// everything commits or nothing does.
+/// Persists parsed results to the metadata and blob stores.
 ///
-/// Respects FK ordering: repo → files → symbols. Any validation failure
-/// aborts the entire transaction (automatic rollback on drop) to prevent
-/// inconsistent state between aggregate counts and actual persisted records.
+/// Content blobs are written first (idempotent, content-addressed) so they
+/// are available before the metadata transaction opens. Metadata writes
+/// (repo → files → symbols) happen inside a single SQLite transaction:
+/// either everything commits or nothing does.
+///
+/// Any validation failure aborts the entire transaction (automatic rollback
+/// on drop) to prevent inconsistent state between aggregate counts and
+/// actual persisted records.
 pub fn persist(
     ctx: &PipelineContext<'_>,
     store: &mut store::MetadataStore,
+    blob_store: &store::BlobStore,
     parse_output: &ParseOutput,
 ) -> Result<(), PipelineError> {
     let now = OffsetDateTime::now_utc()
@@ -298,7 +316,18 @@ pub fn persist(
         )));
     }
 
-    // -- Begin atomic transaction --
+    // -- Write content blobs (idempotent, before metadata transaction) --
+
+    for parsed in &parse_output.parsed_files {
+        blob_store.put(&parsed.content).map_err(|e| {
+            PipelineError::Persist(store::StoreError::Blob {
+                path: Some(parsed.relative_path.clone()),
+                reason: format!("failed to write blob: {e}"),
+            })
+        })?;
+    }
+
+    // -- Begin atomic metadata transaction --
 
     let tx = store.transaction().map_err(PipelineError::Persist)?;
 

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -1,7 +1,8 @@
 //! Integration tests for the indexer pipeline.
 //!
 //! These tests exercise the full discovery → parse → persist flow against
-//! real temp-dir repositories with an in-memory SQLite store.
+//! real temp-dir repositories with an in-memory SQLite store and a
+//! temporary blob store.
 
 use std::path::PathBuf;
 
@@ -9,6 +10,7 @@ use adapter_api::{
     AdapterCapabilities, AdapterError, AdapterOutput, AdapterPolicy, AdapterRouter,
     ExtractedSymbol, IndexContext, LanguageAdapter, SourceFile, SourceSpan,
 };
+use adapter_syntax_treesitter::{create_adapter, supported_languages, TreeSitterAdapter};
 use core_model::{QualityLevel, SymbolKind};
 use indexer::{run, stage, PipelineContext, PipelineError};
 use tempfile::TempDir;
@@ -125,6 +127,32 @@ impl AdapterRouter for StubRouter {
     }
 }
 
+/// Router backed by real tree-sitter adapters. Returns adapters for all
+/// languages supported by `adapter-syntax-treesitter`.
+struct TreeSitterRouter {
+    adapters: Vec<TreeSitterAdapter>,
+}
+
+impl TreeSitterRouter {
+    fn new() -> Self {
+        let adapters = supported_languages()
+            .iter()
+            .filter_map(|lang| create_adapter(lang))
+            .collect();
+        Self { adapters }
+    }
+}
+
+impl AdapterRouter for TreeSitterRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        self.adapters
+            .iter()
+            .filter(|a| a.language() == language)
+            .map(|a| a as &dyn LanguageAdapter)
+            .collect()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -137,13 +165,19 @@ fn setup_test_repo() -> TempDir {
     dir
 }
 
+fn setup_blob_store(dir: &TempDir) -> store::BlobStore {
+    store::BlobStore::open(&dir.path().join("blobs")).expect("open blob store")
+}
+
 // ---------------------------------------------------------------------------
-// End-to-end pipeline smoke test
+// End-to-end pipeline smoke test (stub adapter)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn pipeline_end_to_end_smoke_test() {
     let repo_dir = setup_test_repo();
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
     let router = StubRouter::new();
     let mut db = store::MetadataStore::open_in_memory().expect("open store");
 
@@ -155,7 +189,7 @@ fn pipeline_end_to_end_smoke_test() {
         correlation_id: Some("test-correlation-001".to_string()),
     };
 
-    let result = run(&ctx, &mut db).expect("pipeline should succeed");
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
 
     // Discovery found at least the one .rs file.
     assert!(
@@ -208,6 +242,346 @@ fn pipeline_end_to_end_smoke_test() {
     assert_eq!(symbol.name, "main");
     assert_eq!(symbol.kind, SymbolKind::Function);
     assert_eq!(symbol.repo_id, "test-repo");
+
+    // Verify blob was written and is retrievable by content hash.
+    let content = std::fs::read(repo_dir.path().join("src/main.rs")).expect("read source");
+    let hash = store::content_hash(&content);
+    assert!(blob_store.exists(&hash).expect("blob exists check"));
+    let blob = blob_store
+        .get(&hash)
+        .expect("get blob")
+        .expect("blob present");
+    assert_eq!(blob, content);
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end with real tree-sitter adapter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pipeline_end_to_end_with_treesitter_adapter() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+
+    // Write a non-trivial Rust file with multiple symbol types.
+    std::fs::write(
+        src.join("lib.rs"),
+        r#"/// A configuration holder.
+pub struct Config {
+    pub name: String,
+}
+
+impl Config {
+    /// Creates a new Config.
+    pub fn new(name: &str) -> Self {
+        Self { name: name.to_string() }
+    }
+}
+
+/// Top-level helper function.
+pub fn greet(config: &Config) -> String {
+    format!("Hello, {}!", config.name)
+}
+"#,
+    )
+    .expect("write lib.rs");
+
+    std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "treesitter-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    // Both .rs files were parsed.
+    assert_eq!(result.metrics.files_parsed, 2);
+    assert!(result.file_errors.is_empty(), "no file errors expected");
+
+    // Verify repo aggregates.
+    let repo = db
+        .repos()
+        .get("treesitter-repo")
+        .expect("query repo")
+        .expect("repo record");
+    assert_eq!(repo.file_count, 2);
+    assert!(
+        repo.symbol_count >= 3,
+        "expected at least Config, new, greet"
+    );
+
+    // Verify lib.rs file record.
+    let lib_file = db
+        .files()
+        .get("treesitter-repo", "src/lib.rs")
+        .expect("query file")
+        .expect("lib.rs record");
+    assert_eq!(lib_file.language, "rust");
+    assert!(lib_file.symbol_count >= 3);
+
+    // Verify symbol records have correct provenance.
+    let symbol_ids = db
+        .symbols()
+        .list_ids_for_file("treesitter-repo", "src/lib.rs")
+        .expect("list symbols");
+    assert!(symbol_ids.len() >= 3);
+
+    // Verify source_adapter provenance on a symbol.
+    let first_sym = db
+        .symbols()
+        .get(&symbol_ids[0])
+        .expect("get symbol")
+        .expect("symbol exists");
+    assert!(
+        first_sym.source_adapter.contains("syntax-treesitter"),
+        "source_adapter should identify tree-sitter: {}",
+        first_sym.source_adapter
+    );
+    assert_eq!(first_sym.quality_level, QualityLevel::Syntax);
+
+    // Verify blobs were written for both files.
+    let lib_content = std::fs::read(src.join("lib.rs")).expect("read lib.rs");
+    let lib_hash = store::content_hash(&lib_content);
+    assert!(blob_store.exists(&lib_hash).expect("blob exists"));
+
+    let main_content = std::fs::read(src.join("main.rs")).expect("read main.rs");
+    let main_hash = store::content_hash(&main_content);
+    assert!(blob_store.exists(&main_hash).expect("blob exists"));
+}
+
+#[test]
+fn pipeline_treesitter_unsupported_language_reports_error_with_provenance() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+
+    // Write a Rust file (supported) and a Python file (unsupported by tree-sitter router).
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write rs");
+    std::fs::write(repo_dir.path().join("script.py"), "print('hi')\n").expect("write py");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "mixed-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    // Rust file parsed successfully.
+    assert_eq!(result.metrics.files_parsed, 1);
+
+    // Python file recorded as an error (no adapter available).
+    let py_errors: Vec<_> = result
+        .file_errors
+        .iter()
+        .filter(|e| e.path.to_string_lossy().contains("script.py"))
+        .collect();
+    assert!(
+        !py_errors.is_empty(),
+        "expected error for unsupported Python file"
+    );
+    assert!(
+        py_errors[0].error.contains("no adapter"),
+        "error should indicate no adapter: {}",
+        py_errors[0].error
+    );
+    // No adapter was tried, so adapter_id should be None.
+    assert!(
+        py_errors[0].adapter_id.is_none(),
+        "adapter_id should be None when no adapters available"
+    );
+
+    // Repo still persisted with the successful file.
+    let repo = db
+        .repos()
+        .get("mixed-repo")
+        .expect("query repo")
+        .expect("repo record");
+    assert_eq!(repo.file_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Adapter fallback and error provenance
+// ---------------------------------------------------------------------------
+
+/// An adapter that always fails with an Internal error.
+struct FailingAdapter;
+
+impl LanguageAdapter for FailingAdapter {
+    fn adapter_id(&self) -> &str {
+        "failing-adapter"
+    }
+
+    fn language(&self) -> &str {
+        "rust"
+    }
+
+    fn capabilities(&self) -> &AdapterCapabilities {
+        const CAPS: AdapterCapabilities = AdapterCapabilities {
+            quality_level: QualityLevel::Syntax,
+            default_confidence: 0.7,
+            supports_type_refs: false,
+            supports_call_refs: false,
+            supports_container_refs: false,
+            supports_doc_extraction: false,
+        };
+        &CAPS
+    }
+
+    fn index_file(
+        &self,
+        _ctx: &IndexContext,
+        _file: &SourceFile,
+    ) -> Result<AdapterOutput, AdapterError> {
+        Err(AdapterError::Parse {
+            path: _file.relative_path.clone(),
+            reason: "simulated failure".to_string(),
+        })
+    }
+}
+
+/// Router that returns a failing adapter first, then the stub adapter.
+/// Verifies the pipeline falls through to the second adapter on error.
+struct FallbackRouter {
+    failing: FailingAdapter,
+    fallback: StubAdapter,
+}
+
+impl FallbackRouter {
+    fn new() -> Self {
+        Self {
+            failing: FailingAdapter,
+            fallback: StubAdapter,
+        }
+    }
+}
+
+impl AdapterRouter for FallbackRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        if language == "rust" {
+            vec![&self.failing, &self.fallback]
+        } else {
+            vec![]
+        }
+    }
+}
+
+#[test]
+fn adapter_fallback_continues_past_failing_adapter() {
+    let repo_dir = setup_test_repo();
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = FallbackRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "fallback-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    // The file should have been parsed by the fallback adapter.
+    assert_eq!(
+        result.metrics.files_parsed, 1,
+        "fallback adapter should have succeeded"
+    );
+
+    // No file errors — the failing adapter's error should not prevent success.
+    assert!(
+        result.file_errors.is_empty(),
+        "file should have been parsed by fallback adapter, got errors: {:?}",
+        result.file_errors
+    );
+
+    // Verify the symbol was persisted.
+    let repo = db
+        .repos()
+        .get("fallback-repo")
+        .expect("query repo")
+        .expect("repo record");
+    assert!(repo.symbol_count >= 1);
+}
+
+/// Router that only returns the failing adapter — no fallback.
+struct FailOnlyRouter {
+    failing: FailingAdapter,
+}
+
+impl FailOnlyRouter {
+    fn new() -> Self {
+        Self {
+            failing: FailingAdapter,
+        }
+    }
+}
+
+impl AdapterRouter for FailOnlyRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        if language == "rust" {
+            vec![&self.failing]
+        } else {
+            vec![]
+        }
+    }
+}
+
+#[test]
+fn adapter_error_carries_adapter_id_provenance() {
+    let repo_dir = setup_test_repo();
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = FailOnlyRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "fail-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    // No files parsed.
+    assert_eq!(result.metrics.files_parsed, 0);
+
+    // Error carries the adapter ID for provenance.
+    let rs_errors: Vec<_> = result
+        .file_errors
+        .iter()
+        .filter(|e| e.path.to_string_lossy().contains("main.rs"))
+        .collect();
+    assert!(!rs_errors.is_empty(), "expected error for main.rs");
+    assert_eq!(
+        rs_errors[0].adapter_id.as_deref(),
+        Some("failing-adapter"),
+        "error should carry the failing adapter's ID"
+    );
+    assert!(
+        rs_errors[0].error.contains("simulated failure"),
+        "error message should contain adapter error: {}",
+        rs_errors[0].error
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  - Issue: Closes #68
  - Scope: Wire indexer pipeline end-to-end from discovery -> adapter execution -> persistence, including adapter-failure isolation/provenance and integration coverage.

  ## Changes

  - Connected `indexer::run` persist stage to accept/use `BlobStore` alongside `MetadataStore`.
  - Extended parse output to carry file content through to persistence for blob writes.
  - Updated persist stage to write content blobs, then commit metadata atomically (repo -> files -> symbols).
  - Added/expanded integration coverage for:
    - end-to-end success path on fixture repo
    - end-to-end path with real tree-sitter adapter
    - unsupported-language failure reporting with provenance
    - adapter fallback behavior (continue after adapter failure)
    - adapter-id provenance on parse failures
  - Updated error reporting to include adapter provenance (`FileError.adapter_id`).
  - Updated `files_errored` metric to count distinct failed file paths (not per-adapter error events).
  - Added `adapter-syntax-treesitter` as an `indexer` dev-dependency for integration tests.

  ## Acceptance Criteria Mapping

  - [x] End-to-end indexing works on fixture repos:
    - Covered by `pipeline_end_to_end_smoke_test` and `pipeline_end_to_end_with_treesitter_adapter`.
  - [x] Adapter failures are isolated and reported with provenance:
    - Isolated fallback behavior covered by `adapter_fallback_continues_past_failing_adapter`.
    - Provenance covered by `adapter_error_carries_adapter_id_provenance` and `adapter_id` on `FileError`.
  - [x] Integration tests cover discovery -> parse -> persist success/failure:
    - Success and failure paths covered across expanded `pipeline_integration.rs`.

  ## Test Evidence

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --all --all-features`
  - [x] Additional tests/benchmarks (if required by issue)
    - Added targeted integration tests for fallback and provenance behavior.

  ## Risk and Mitigation

  - Risk: Parse stage now records per-adapter failure entries for a file when no adapter succeeds; this can affect downstream error-consumer assumptions.
  - Mitigation: `files_errored` metric now dedupes by file path, and integration tests validate fallback/provenance semantics.

  ## Security/Observability Impact

  - Security: No new code-execution surface; pipeline still processes repository content as data only.
  - Logs/Metrics/Tracing: Improved parse-stage observability with adapter-attributed failures and corrected `files_errored` aggregation semantics.