### PR TITLE
Add repository/file/symbol aggregate updates

### DIFF
--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -52,7 +52,7 @@ pub fn run(
         .sum();
 
     // Stage 3: Persist (blobs first, then metadata in a transaction)
-    stage::persist(ctx, store, blob_store, &parse_output)?;
+    stage::persist(ctx, store, blob_store, &discovery, &parse_output)?;
 
     let metrics = IndexMetrics {
         files_discovered: discovery.metrics.files_discovered,

--- a/crates/indexer/src/stage.rs
+++ b/crates/indexer/src/stage.rs
@@ -241,6 +241,17 @@ fn file_content_hash(content: &[u8]) -> String {
 /// (repo → files → symbols) happen inside a single SQLite transaction:
 /// either everything commits or nothing does.
 ///
+/// Stale data cleanup: files no longer present in the current **discovery**
+/// are deleted (cascading to their symbols). The discovery output — not the
+/// parse output — drives stale detection so that files which were discovered
+/// but failed parsing (e.g. transient adapter errors) are preserved rather
+/// than incorrectly purged. Symbols removed from a file since the last
+/// index are cleaned up before upserting the new set.
+///
+/// Repo-level aggregates (`file_count`, `symbol_count`, `language_counts`)
+/// are recomputed from actual database state after all upserts and deletes,
+/// ensuring consistency across re-indexes.
+///
 /// Any validation failure aborts the entire transaction (automatic rollback
 /// on drop) to prevent inconsistent state between aggregate counts and
 /// actual persisted records.
@@ -248,16 +259,14 @@ pub fn persist(
     ctx: &PipelineContext<'_>,
     store: &mut store::MetadataStore,
     blob_store: &store::BlobStore,
+    discovery: &DiscoveryOutput,
     parse_output: &ParseOutput,
 ) -> Result<(), PipelineError> {
     let now = OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .map_err(|e| PipelineError::Internal(format!("timestamp format error: {e}")))?;
 
-    // -- Pass 1: collect per-file stats for repo + file records --
-
-    let mut language_counts: BTreeMap<String, u64> = BTreeMap::new();
-    let mut total_symbol_count: u64 = 0;
+    // -- Pass 1: collect per-file stats and validate symbol IDs upfront --
 
     struct FileStats {
         symbol_count: u64,
@@ -290,27 +299,25 @@ pub fn persist(
             symbol_count: sym_count,
             semantic_count: semantic,
         });
-
-        *language_counts.entry(parsed.language.clone()).or_insert(0) += 1;
-        total_symbol_count += sym_count;
     }
 
-    // -- Validate repo record before opening transaction --
+    // -- Validate a provisional repo record before opening transaction --
 
     let schema_version = current_index_schema_version();
-    let repo_record = RepoRecord {
+    let provisional_repo = RepoRecord {
         repo_id: ctx.repo_id.clone(),
         display_name: ctx.repo_id.clone(),
         source_root: ctx.source_root.to_string_lossy().to_string(),
         indexed_at: now.clone(),
         index_version: schema_version.to_string(),
-        language_counts,
-        file_count: parse_output.parsed_files.len() as u64,
-        symbol_count: total_symbol_count,
+        // Placeholder aggregates — will be recomputed from DB after writes.
+        language_counts: BTreeMap::new(),
+        file_count: 0,
+        symbol_count: 0,
         git_head: None,
     };
 
-    if let Err(e) = repo_record.validate() {
+    if let Err(e) = provisional_repo.validate() {
         return Err(PipelineError::Validation(format!(
             "repo record validation failed: {e}"
         )));
@@ -331,12 +338,42 @@ pub fn persist(
 
     let tx = store.transaction().map_err(PipelineError::Persist)?;
 
-    // Step 1: upsert repo record (no FK parent)
+    // Step 1: ensure repo record exists without cascade-deleting children.
+    // Uses INSERT OR IGNORE + UPDATE to avoid ON DELETE CASCADE that
+    // INSERT OR REPLACE would trigger on an existing repo.
     tx.repos()
-        .upsert(&repo_record)
+        .ensure_and_update(&provisional_repo)
         .map_err(PipelineError::Persist)?;
 
-    // Step 2: upsert file records (FK → repos)
+    // Step 2: remove stale files (cascade deletes their symbols).
+    // Use the discovery output (all files found on disk) rather than parse
+    // output (only successfully parsed files) so that adapter failures do
+    // not cause previously indexed metadata to be incorrectly purged.
+    let current_paths: Vec<&str> = discovery
+        .files
+        .iter()
+        .map(|f| {
+            f.relative_path.to_str().ok_or_else(|| {
+                PipelineError::Internal(format!(
+                    "non-UTF8 file path: {}",
+                    f.relative_path.display()
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let stale_deleted = tx
+        .files()
+        .delete_except(&ctx.repo_id, &current_paths)
+        .map_err(PipelineError::Persist)?;
+    if stale_deleted > 0 {
+        info!(
+            stale_files_removed = stale_deleted,
+            "cleaned up stale file records"
+        );
+    }
+
+    // Step 3: upsert file records and their symbols
     for (parsed, stats) in parse_output.parsed_files.iter().zip(file_stats.iter()) {
         let file_path_str = parsed.relative_path.to_string_lossy();
 
@@ -374,18 +411,21 @@ pub fn persist(
         tx.files()
             .upsert(&file_record)
             .map_err(PipelineError::Persist)?;
-    }
 
-    // Step 3: upsert symbol records (FK → files)
-    for parsed in &parse_output.parsed_files {
-        let file_path_str = parsed.relative_path.to_string_lossy();
+        // Remove stale symbols for this file before upserting new ones.
+        // This handles symbols that were removed or renamed since the
+        // last index without relying on ID stability.
+        tx.symbols()
+            .delete_for_file(&ctx.repo_id, &file_path_str)
+            .map_err(PipelineError::Persist)?;
+
         let default_confidence = match parsed.output.quality_level {
             QualityLevel::Semantic => 0.9,
             QualityLevel::Syntax => 0.7,
         };
 
         for sym in &parsed.output.symbols {
-            // Symbol ID was pre-validated in pass 1; safe to unwrap.
+            // Symbol ID was pre-validated in pass 1.
             let symbol_id = build_symbol_id(&file_path_str, &sym.qualified_name, sym.kind)
                 .map_err(|e| {
                     PipelineError::Validation(format!(
@@ -435,12 +475,32 @@ pub fn persist(
         }
     }
 
+    // Step 4: recompute repo aggregates from actual DB state.
+    // Uses a targeted UPDATE (not INSERT OR REPLACE) to avoid triggering
+    // ON DELETE CASCADE which would wipe the file/symbol records we just wrote.
+    let file_count = tx
+        .files()
+        .count(&ctx.repo_id)
+        .map_err(PipelineError::Persist)?;
+    let symbol_count = tx
+        .symbols()
+        .count_for_repo(&ctx.repo_id)
+        .map_err(PipelineError::Persist)?;
+    let language_counts = tx
+        .files()
+        .aggregate_language_counts(&ctx.repo_id)
+        .map_err(PipelineError::Persist)?;
+
+    tx.repos()
+        .update_aggregates(&ctx.repo_id, file_count, symbol_count, &language_counts)
+        .map_err(PipelineError::Persist)?;
+
     // -- Commit the transaction atomically --
     tx.commit().map_err(PipelineError::Persist)?;
 
     info!(
-        files_persisted = parse_output.parsed_files.len(),
-        symbols_persisted = total_symbol_count,
+        files_persisted = file_count,
+        symbols_persisted = symbol_count,
         "persist stage complete"
     );
 

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -722,6 +722,338 @@ fn parse_stage_uses_context_default_policy() {
 }
 
 // ---------------------------------------------------------------------------
+// Re-index aggregate consistency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reindex_removes_stale_files_and_recomputes_aggregates() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+
+    // Initial index: two Rust files.
+    std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+    std::fs::write(src.join("lib.rs"), "pub fn greet() {}\n").expect("write lib.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "aggregate-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // First run: both files indexed.
+    let r1 = run(&ctx, &mut db, &blob_store).expect("first run");
+    assert_eq!(r1.metrics.files_parsed, 2);
+
+    let repo = db
+        .repos()
+        .get("aggregate-repo")
+        .expect("query repo")
+        .expect("repo exists");
+    assert_eq!(repo.file_count, 2);
+    let first_symbol_count = repo.symbol_count;
+    assert!(first_symbol_count >= 2, "at least main + greet");
+
+    // Remove lib.rs and re-index.
+    std::fs::remove_file(src.join("lib.rs")).expect("remove lib.rs");
+    let r2 = run(&ctx, &mut db, &blob_store).expect("second run");
+    assert_eq!(r2.metrics.files_parsed, 1);
+
+    // Verify stale file was removed.
+    assert!(
+        db.files()
+            .get("aggregate-repo", "src/lib.rs")
+            .expect("query")
+            .is_none(),
+        "stale file src/lib.rs should have been removed"
+    );
+
+    // Verify stale symbols were removed.
+    let lib_symbols = db
+        .symbols()
+        .list_ids_for_file("aggregate-repo", "src/lib.rs")
+        .expect("query");
+    assert!(
+        lib_symbols.is_empty(),
+        "symbols for removed file should be gone"
+    );
+
+    // Verify repo aggregates were recomputed from DB state.
+    let repo = db
+        .repos()
+        .get("aggregate-repo")
+        .expect("query repo")
+        .expect("repo exists");
+    assert_eq!(repo.file_count, 1, "file_count should reflect only main.rs");
+    assert!(
+        repo.symbol_count < first_symbol_count,
+        "symbol_count should have decreased after removing lib.rs"
+    );
+    assert_eq!(
+        repo.language_counts.get("rust"),
+        Some(&1),
+        "language_counts should reflect 1 rust file"
+    );
+
+    // Remaining file should still be present and correct.
+    let main_file = db
+        .files()
+        .get("aggregate-repo", "src/main.rs")
+        .expect("query")
+        .expect("main.rs should still exist");
+    assert_eq!(main_file.language, "rust");
+}
+
+#[test]
+fn reindex_cleans_up_removed_symbols_within_file() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+
+    // Initial content: two functions.
+    std::fs::write(src.join("lib.rs"), "pub fn alpha() {}\npub fn beta() {}\n")
+        .expect("write lib.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "symbol-cleanup-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // First run.
+    run(&ctx, &mut db, &blob_store).expect("first run");
+    let syms = db
+        .symbols()
+        .list_ids_for_file("symbol-cleanup-repo", "src/lib.rs")
+        .expect("list symbols");
+    assert!(syms.len() >= 2, "expected at least alpha + beta");
+
+    // Remove beta, keep alpha.
+    std::fs::write(src.join("lib.rs"), "pub fn alpha() {}\n").expect("rewrite lib.rs");
+
+    // Second run.
+    run(&ctx, &mut db, &blob_store).expect("second run");
+    let syms = db
+        .symbols()
+        .list_ids_for_file("symbol-cleanup-repo", "src/lib.rs")
+        .expect("list symbols");
+
+    // Only alpha should remain.
+    assert_eq!(syms.len(), 1, "only alpha should remain, got: {syms:?}");
+    assert!(
+        syms[0].contains("alpha"),
+        "remaining symbol should be alpha: {}",
+        syms[0]
+    );
+
+    // Repo aggregate should reflect the reduced count.
+    let repo = db
+        .repos()
+        .get("symbol-cleanup-repo")
+        .expect("query repo")
+        .expect("repo exists");
+    assert_eq!(repo.file_count, 1);
+    assert_eq!(repo.symbol_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Adapter failure isolation
+// ---------------------------------------------------------------------------
+
+/// An adapter that fails only for files whose path contains a substring.
+struct PathSelectiveFailAdapter {
+    fail_substring: &'static str,
+}
+
+impl LanguageAdapter for PathSelectiveFailAdapter {
+    fn adapter_id(&self) -> &str {
+        "path-selective-fail"
+    }
+
+    fn language(&self) -> &str {
+        "rust"
+    }
+
+    fn capabilities(&self) -> &AdapterCapabilities {
+        const CAPS: AdapterCapabilities = AdapterCapabilities {
+            quality_level: QualityLevel::Syntax,
+            default_confidence: 0.7,
+            supports_type_refs: false,
+            supports_call_refs: false,
+            supports_container_refs: false,
+            supports_doc_extraction: false,
+        };
+        &CAPS
+    }
+
+    fn index_file(
+        &self,
+        _ctx: &IndexContext,
+        file: &SourceFile,
+    ) -> Result<AdapterOutput, AdapterError> {
+        if file
+            .relative_path
+            .to_string_lossy()
+            .contains(self.fail_substring)
+        {
+            return Err(AdapterError::Parse {
+                path: file.relative_path.clone(),
+                reason: "simulated selective failure".to_string(),
+            });
+        }
+        Ok(AdapterOutput {
+            symbols: vec![ExtractedSymbol {
+                name: "stub_fn".to_string(),
+                qualified_name: "stub_fn".to_string(),
+                kind: SymbolKind::Function,
+                span: SourceSpan {
+                    start_line: 1,
+                    end_line: 1,
+                    start_byte: 0,
+                    byte_length: 10,
+                },
+                signature: "fn stub_fn()".to_string(),
+                confidence_score: None,
+                docstring: None,
+                parent_qualified_name: None,
+            }],
+            source_adapter: "path-selective-fail".to_string(),
+            quality_level: QualityLevel::Syntax,
+        })
+    }
+}
+
+/// Router that uses PathSelectiveFailAdapter as the only adapter.
+struct SelectiveFailOnlyRouter {
+    adapter: PathSelectiveFailAdapter,
+}
+
+impl SelectiveFailOnlyRouter {
+    fn failing_on(substring: &'static str) -> Self {
+        Self {
+            adapter: PathSelectiveFailAdapter {
+                fail_substring: substring,
+            },
+        }
+    }
+}
+
+impl AdapterRouter for SelectiveFailOnlyRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        if language == "rust" {
+            vec![&self.adapter]
+        } else {
+            vec![]
+        }
+    }
+}
+
+#[test]
+fn reindex_with_adapter_failure_preserves_previously_indexed_file() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+
+    std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+    std::fs::write(src.join("lib.rs"), "pub fn helper() {}\n").expect("write lib.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    // First run: use the tree-sitter router — both files index successfully.
+    let ts_router = TreeSitterRouter::new();
+    let ctx1 = PipelineContext {
+        repo_id: "fail-isolation-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &ts_router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    let r1 = run(&ctx1, &mut db, &blob_store).expect("first run");
+    assert_eq!(r1.metrics.files_parsed, 2);
+
+    // Verify both files are in the DB.
+    assert!(
+        db.files()
+            .get("fail-isolation-repo", "src/main.rs")
+            .unwrap()
+            .is_some(),
+        "main.rs should be indexed"
+    );
+    assert!(
+        db.files()
+            .get("fail-isolation-repo", "src/lib.rs")
+            .unwrap()
+            .is_some(),
+        "lib.rs should be indexed"
+    );
+    let lib_symbols_before = db
+        .symbols()
+        .list_ids_for_file("fail-isolation-repo", "src/lib.rs")
+        .unwrap();
+    assert!(!lib_symbols_before.is_empty(), "lib.rs should have symbols");
+
+    // Second run: use a router that fails on lib.rs.
+    let fail_router = SelectiveFailOnlyRouter::failing_on("lib.rs");
+    let ctx2 = PipelineContext {
+        repo_id: "fail-isolation-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &fail_router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    let r2 = run(&ctx2, &mut db, &blob_store).expect("second run");
+    // Only main.rs should parse; lib.rs fails.
+    assert_eq!(r2.metrics.files_parsed, 1);
+    assert!(r2.metrics.files_errored >= 1);
+
+    // lib.rs file record should still exist (not purged by stale cleanup).
+    assert!(
+        db.files()
+            .get("fail-isolation-repo", "src/lib.rs")
+            .unwrap()
+            .is_some(),
+        "lib.rs metadata should be preserved despite adapter failure"
+    );
+
+    // lib.rs symbols from the first run should still be present.
+    let lib_symbols_after = db
+        .symbols()
+        .list_ids_for_file("fail-isolation-repo", "src/lib.rs")
+        .unwrap();
+    assert_eq!(
+        lib_symbols_before, lib_symbols_after,
+        "lib.rs symbols should be unchanged after failed re-index"
+    );
+
+    // main.rs should still be present and updated.
+    assert!(
+        db.files()
+            .get("fail-isolation-repo", "src/main.rs")
+            .unwrap()
+            .is_some(),
+        "main.rs should still be indexed"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Error display coverage
 // ---------------------------------------------------------------------------
 

--- a/crates/store/src/file_store.rs
+++ b/crates/store/src/file_store.rs
@@ -93,6 +93,75 @@ impl<'a> FileStore<'a> {
             .collect::<Result<Vec<String>, _>>()?;
         Ok(paths)
     }
+
+    /// Deletes all file records for a repository whose paths are **not** in
+    /// `keep_paths`. Cascading foreign keys remove associated symbols.
+    ///
+    /// Returns the number of file records deleted.
+    pub fn delete_except(&self, repo_id: &str, keep_paths: &[&str]) -> Result<u64, StoreError> {
+        if keep_paths.is_empty() {
+            let changed = self
+                .conn
+                .execute("DELETE FROM files WHERE repo_id = ?1", params![repo_id])?;
+            return Ok(changed as u64);
+        }
+
+        // Build a parameterised IN-list. SQLite limits are generous (32766
+        // for recent versions), but this is fine for typical repos.
+        let placeholders: String = keep_paths
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("?{}", i + 2))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let sql =
+            format!("DELETE FROM files WHERE repo_id = ?1 AND file_path NOT IN ({placeholders})");
+
+        let mut stmt = self.conn.prepare(&sql)?;
+
+        // Bind repo_id at index 1, then each keep_path starting at index 2.
+        let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> =
+            Vec::with_capacity(1 + keep_paths.len());
+        param_values.push(Box::new(repo_id.to_string()));
+        for path in keep_paths {
+            param_values.push(Box::new(path.to_string()));
+        }
+
+        let refs: Vec<&dyn rusqlite::types::ToSql> =
+            param_values.iter().map(|p| p.as_ref()).collect();
+        let changed = stmt.execute(refs.as_slice())?;
+        Ok(changed as u64)
+    }
+
+    /// Returns the total number of file records for a repository.
+    pub fn count(&self, repo_id: &str) -> Result<u64, StoreError> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM files WHERE repo_id = ?1",
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        Ok(count as u64)
+    }
+
+    /// Returns per-language file counts for a repository.
+    pub fn aggregate_language_counts(
+        &self,
+        repo_id: &str,
+    ) -> Result<std::collections::BTreeMap<String, u64>, StoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT language, COUNT(*) FROM files WHERE repo_id = ?1 GROUP BY language ORDER BY language",
+        )?;
+        let mut counts = std::collections::BTreeMap::new();
+        let rows = stmt.query_map(params![repo_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            let (lang, count) = row?;
+            counts.insert(lang, count as u64);
+        }
+        Ok(counts)
+    }
 }
 
 /// Extension trait to make `query_row` return `Option` on no rows.
@@ -254,5 +323,93 @@ mod tests {
 
         let err = store.files().upsert(&file).unwrap_err();
         assert!(err.to_string().contains("validation"), "{err}");
+    }
+
+    #[test]
+    fn delete_except_removes_stale_files() {
+        let store = setup_store_with_repo();
+        let mut f1 = test_file();
+        f1.file_path = "src/main.rs".to_string();
+        let mut f2 = test_file();
+        f2.file_path = "src/lib.rs".to_string();
+        let mut f3 = test_file();
+        f3.file_path = "src/old.rs".to_string();
+
+        store.files().upsert(&f1).unwrap();
+        store.files().upsert(&f2).unwrap();
+        store.files().upsert(&f3).unwrap();
+
+        // Keep only main.rs and lib.rs — old.rs should be deleted.
+        let deleted = store
+            .files()
+            .delete_except("test-repo", &["src/main.rs", "src/lib.rs"])
+            .unwrap();
+        assert_eq!(deleted, 1);
+
+        let paths = store.files().list_paths("test-repo").unwrap();
+        assert_eq!(paths, vec!["src/lib.rs", "src/main.rs"]);
+    }
+
+    #[test]
+    fn delete_except_with_empty_keep_removes_all() {
+        let store = setup_store_with_repo();
+        store.files().upsert(&test_file()).unwrap();
+
+        let deleted = store.files().delete_except("test-repo", &[]).unwrap();
+        assert_eq!(deleted, 1);
+        assert!(store.files().list_paths("test-repo").unwrap().is_empty());
+    }
+
+    #[test]
+    fn delete_except_returns_zero_when_all_kept() {
+        let store = setup_store_with_repo();
+        store.files().upsert(&test_file()).unwrap();
+
+        let deleted = store
+            .files()
+            .delete_except("test-repo", &["src/main.rs"])
+            .unwrap();
+        assert_eq!(deleted, 0);
+    }
+
+    #[test]
+    fn count_returns_file_count() {
+        let store = setup_store_with_repo();
+        assert_eq!(store.files().count("test-repo").unwrap(), 0);
+
+        store.files().upsert(&test_file()).unwrap();
+        assert_eq!(store.files().count("test-repo").unwrap(), 1);
+
+        let mut f2 = test_file();
+        f2.file_path = "src/lib.rs".to_string();
+        store.files().upsert(&f2).unwrap();
+        assert_eq!(store.files().count("test-repo").unwrap(), 2);
+    }
+
+    #[test]
+    fn aggregate_language_counts_groups_by_language() {
+        let store = setup_store_with_repo();
+
+        let mut f1 = test_file();
+        f1.file_path = "src/main.rs".to_string();
+        f1.language = "rust".to_string();
+        let mut f2 = test_file();
+        f2.file_path = "src/lib.rs".to_string();
+        f2.language = "rust".to_string();
+        let mut f3 = test_file();
+        f3.file_path = "app.ts".to_string();
+        f3.language = "typescript".to_string();
+
+        store.files().upsert(&f1).unwrap();
+        store.files().upsert(&f2).unwrap();
+        store.files().upsert(&f3).unwrap();
+
+        let counts = store
+            .files()
+            .aggregate_language_counts("test-repo")
+            .unwrap();
+        assert_eq!(counts.get("rust"), Some(&2));
+        assert_eq!(counts.get("typescript"), Some(&1));
+        assert_eq!(counts.len(), 2);
     }
 }

--- a/crates/store/src/repo_store.rs
+++ b/crates/store/src/repo_store.rs
@@ -95,6 +95,84 @@ impl<'a> RepoStore<'a> {
         Ok(changed > 0)
     }
 
+    /// Ensures a repo record exists and updates its non-aggregate metadata.
+    ///
+    /// Uses `INSERT OR IGNORE` followed by `UPDATE` so that existing child
+    /// rows (files, symbols) are never cascade-deleted. On a fresh repo the
+    /// INSERT creates the row; on a re-index the IGNORE is a no-op and the
+    /// UPDATE refreshes the metadata fields.
+    pub fn ensure_and_update(&self, record: &RepoRecord) -> Result<(), StoreError> {
+        record
+            .validate()
+            .map_err(|e| StoreError::Validation(e.to_string()))?;
+
+        let language_counts_json = serde_json::to_string(&record.language_counts)
+            .map_err(|e| StoreError::Validation(e.to_string()))?;
+
+        // Create row if it doesn't exist yet.
+        self.conn.execute(
+            "INSERT OR IGNORE INTO repos
+                (repo_id, display_name, source_root, indexed_at, index_version,
+                 language_counts, file_count, symbol_count, git_head)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                record.repo_id,
+                record.display_name,
+                record.source_root,
+                record.indexed_at,
+                record.index_version,
+                language_counts_json,
+                record.file_count,
+                record.symbol_count,
+                record.git_head,
+            ],
+        )?;
+
+        // Update non-aggregate fields on the existing row.
+        self.conn.execute(
+            "UPDATE repos SET display_name = ?2, source_root = ?3,
+                 indexed_at = ?4, index_version = ?5, git_head = ?6
+             WHERE repo_id = ?1",
+            params![
+                record.repo_id,
+                record.display_name,
+                record.source_root,
+                record.indexed_at,
+                record.index_version,
+                record.git_head,
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    /// Updates only the aggregate fields (`file_count`, `symbol_count`,
+    /// `language_counts`) on an existing repo record. Unlike `upsert`, this
+    /// uses a plain `UPDATE` so it does not trigger `ON DELETE CASCADE`.
+    pub fn update_aggregates(
+        &self,
+        repo_id: &str,
+        file_count: u64,
+        symbol_count: u64,
+        language_counts: &std::collections::BTreeMap<String, u64>,
+    ) -> Result<(), StoreError> {
+        let language_counts_json = serde_json::to_string(language_counts)
+            .map_err(|e| StoreError::Validation(e.to_string()))?;
+
+        let changed = self.conn.execute(
+            "UPDATE repos SET file_count = ?2, symbol_count = ?3, language_counts = ?4
+             WHERE repo_id = ?1",
+            params![repo_id, file_count, symbol_count, language_counts_json],
+        )?;
+
+        if changed == 0 {
+            return Err(StoreError::Validation(format!(
+                "repo '{repo_id}' not found for aggregate update"
+            )));
+        }
+        Ok(())
+    }
+
     /// Lists all repository IDs.
     pub fn list_ids(&self) -> Result<Vec<String>, StoreError> {
         let mut stmt = self
@@ -234,5 +312,58 @@ mod tests {
 
         let err = store.repos().upsert(&repo).unwrap_err();
         assert!(err.to_string().contains("validation"), "{err}");
+    }
+
+    #[test]
+    fn update_aggregates_modifies_counts_without_cascade() {
+        let store = MetadataStore::open_in_memory().unwrap();
+        store.repos().upsert(&test_repo()).unwrap();
+
+        // Insert a file to verify cascade is NOT triggered.
+        store
+            .files()
+            .upsert(&core_model::FileRecord {
+                repo_id: "test-repo".to_string(),
+                file_path: "src/main.rs".to_string(),
+                language: "rust".to_string(),
+                file_hash: "sha256:abc".to_string(),
+                summary: "test".to_string(),
+                symbol_count: 5,
+                quality_mix: core_model::QualityMix {
+                    semantic_percent: 0.0,
+                    syntax_percent: 100.0,
+                },
+                updated_at: "2025-01-15T10:30:00Z".to_string(),
+            })
+            .unwrap();
+
+        let mut new_counts = BTreeMap::new();
+        new_counts.insert("rust".to_string(), 3);
+        store
+            .repos()
+            .update_aggregates("test-repo", 3, 42, &new_counts)
+            .unwrap();
+
+        let loaded = store.repos().get("test-repo").unwrap().unwrap();
+        assert_eq!(loaded.file_count, 3);
+        assert_eq!(loaded.symbol_count, 42);
+        assert_eq!(loaded.language_counts, new_counts);
+
+        // File should still exist (no cascade).
+        assert!(store
+            .files()
+            .get("test-repo", "src/main.rs")
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn update_aggregates_fails_for_missing_repo() {
+        let store = MetadataStore::open_in_memory().unwrap();
+        let err = store
+            .repos()
+            .update_aggregates("nonexistent", 0, 0, &BTreeMap::new())
+            .unwrap_err();
+        assert!(err.to_string().contains("not found"), "{err}");
     }
 }

--- a/crates/store/src/symbol_store.rs
+++ b/crates/store/src/symbol_store.rs
@@ -169,6 +169,16 @@ impl<'a> SymbolStore<'a> {
         )?;
         Ok(changed as u64)
     }
+
+    /// Returns the total number of symbol records for a repository.
+    pub fn count_for_repo(&self, repo_id: &str) -> Result<u64, StoreError> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM symbols WHERE repo_id = ?1",
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        Ok(count as u64)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -461,5 +471,24 @@ mod tests {
 
         let err = store.symbols().upsert(&sym).unwrap_err();
         assert!(err.to_string().contains("validation"), "{err}");
+    }
+
+    #[test]
+    fn count_for_repo_returns_total_symbols() {
+        let store = setup_store();
+        assert_eq!(store.symbols().count_for_repo("test-repo").unwrap(), 0);
+
+        store.symbols().upsert(&test_symbol()).unwrap();
+        assert_eq!(store.symbols().count_for_repo("test-repo").unwrap(), 1);
+
+        let mut s2 = test_symbol();
+        s2.id = "src/main.rs::helper#function".to_string();
+        s2.name = "helper".to_string();
+        s2.qualified_name = "helper".to_string();
+        store.symbols().upsert(&s2).unwrap();
+        assert_eq!(store.symbols().count_for_repo("test-repo").unwrap(), 2);
+
+        // Different repo should not be counted.
+        assert_eq!(store.symbols().count_for_repo("other-repo").unwrap(), 0);
     }
 }


### PR DESCRIPTION
## Summary

  - Issue: Closes #31
  - Scope: Implement aggregate-consistent reindex behavior for repo/file/symbol metadata, including stale cleanup, aggregate recomputation, and explicit failure handling.

  ## Changes

  - Updated indexer persistence flow to keep aggregate metadata consistent across re-indexes:
      - persist() now accepts &DiscoveryOutput in addition to &ParseOutput.
      - Stale file cleanup is driven by discovery paths (files currently on disk), not just successfully parsed files.
      - Symbol cleanup for reindexed files runs before symbol upsert to remove removed/renamed symbols.
      - Repo aggregates (file_count, symbol_count, language_counts) are recomputed from DB state and written after file/symbol writes.
  - Added explicit non-UTF8 path handling in stale cleanup path selection:
      - Replaced silent fallback (unwrap_or("")) with explicit PipelineError::Internal(...).
  - Hardened repo write semantics to avoid accidental cascade behavior:
      - Added RepoStore::ensure_and_update() (INSERT OR IGNORE + UPDATE) for initial repo record write in persist.
      - Persist flow uses ensure_and_update for initial repo metadata and update_aggregates for final aggregate write.
  - Added/extended store APIs used by aggregate recomputation:
      - FileStore::delete_except(...)
      - FileStore::count(...)
      - FileStore::aggregate_language_counts(...)
      - SymbolStore::delete_for_file(...)
      - SymbolStore::count_for_repo(...)
  - Added integration/store test coverage for reindex aggregate correctness and failure isolation scenarios.

  ## Acceptance Criteria Mapping

  - [x] Deliverable implemented and integrated.
      - Aggregate update path implemented in indexer persist + store APIs.
  - [x] Edge cases and failure behavior handled explicitly.
      - Adapter-failure isolation during stale cleanup.
      - Explicit error on non-UTF8 discovery path in destructive cleanup path.
  - [x] Deterministic behavior is test-covered where relevant.
      - Aggregate recompute and symbol cleanup covered with deterministic assertions.
  - [x] CI checks pass.
      - fmt, clippy, and full workspace tests pass.

  ## Test Evidence

  - [x] cargo fmt --all -- --check
  - [x] cargo clippy --all-targets --all-features -- -D warnings
  - [x] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - Integration: reindex_removes_stale_files_and_recomputes_aggregates
      - Integration: reindex_cleans_up_removed_symbols_within_file
      - Integration: reindex_with_adapter_failure_preserves_previously_indexed_file
      - Store unit tests for delete_except, aggregate counts, symbol/repo count/update behavior

  ## Risk and Mitigation

  - Risk: Reindex flow is now more stateful (cleanup + recompute + aggregate update), increasing chance of regressions in ordering.
  - Mitigation: Single-transaction ordering preserved; explicit cleanup/recompute tests added for stale files, stale symbols, and adapter-failure isolation.

  ## Security/Observability Impact

  - Security: Removes silent fallback in destructive cleanup path; non-UTF8 file paths now fail explicitly.
  - Logs/Metrics/Tracing: Existing stage logs continue; stale cleanup emits stale_files_removed when applicable.
