### PR TITLE
Implement search_symbols with deterministic ranking and tie handling

### DIFF
--- a/crates/query-engine/src/lib.rs
+++ b/crates/query-engine/src/lib.rs
@@ -2,6 +2,11 @@ use std::fmt;
 
 use core_model::{FileRecord, QualityLevel, RepoRecord, SymbolKind, SymbolRecord};
 
+pub mod ranking;
+pub mod store_service;
+
+pub use store_service::StoreQueryService;
+
 // ── Error ──────────────────────────────────────────────────────────────
 
 #[derive(Debug)]

--- a/crates/query-engine/src/ranking.rs
+++ b/crates/query-engine/src/ranking.rs
@@ -1,0 +1,352 @@
+//! Deterministic ranking pipeline for symbol search.
+//!
+//! Implements the scoring signals from spec section 9.2:
+//! - Exact name match
+//! - Token overlap (name, qualified_name, signature, summary, keywords)
+//! - Confidence boost for semantic quality
+//!
+//! Tie-breaking uses the symbol ID for deterministic ordering.
+
+use core_model::{QualityLevel, SymbolRecord};
+
+use crate::ScoredSymbol;
+
+/// Computes the ranking score for a candidate symbol against a query string.
+///
+/// Returns a score in `[0.0, 1.0]` or `None` if the candidate does not match
+/// the query at all (no token overlap).
+pub fn score_symbol(query: &str, record: &SymbolRecord) -> Option<f32> {
+    let query_tokens = tokenize(query);
+    if query_tokens.is_empty() {
+        return None;
+    }
+
+    let name_lower = record.name.to_lowercase();
+    let query_lower = query.to_lowercase();
+
+    // Signal 1: Exact name match (0.0 or 0.4).
+    let exact_match = if name_lower == query_lower { 0.4 } else { 0.0 };
+
+    // Signal 2: Token overlap across searchable fields.
+    let candidate_tokens = symbol_tokens(record);
+    let overlap = token_overlap(&query_tokens, &candidate_tokens);
+
+    // If no overlap at all, this candidate is not a match.
+    if overlap == 0.0 && exact_match == 0.0 {
+        return None;
+    }
+
+    // Signal 3: Signature relevance — bonus if query appears in the signature.
+    let sig_lower = record.signature.to_lowercase();
+    let sig_bonus = if sig_lower.contains(&query_lower) {
+        0.05
+    } else {
+        0.0
+    };
+
+    // Signal 4: Confidence boost for semantic quality.
+    let confidence_boost = match record.quality_level {
+        QualityLevel::Semantic => record.confidence_score * 0.1,
+        QualityLevel::Syntax => 0.0,
+    };
+
+    // Weighted combination, clamped to [0.0, 1.0].
+    let raw = exact_match + overlap * 0.45 + sig_bonus + confidence_boost;
+    Some(raw.min(1.0))
+}
+
+/// Sorts scored symbols deterministically: score descending, then ID ascending.
+pub fn sort_scored(results: &mut [ScoredSymbol]) {
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.record.id.cmp(&b.record.id))
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tokenization
+// ---------------------------------------------------------------------------
+
+/// Tokenizes a query string. Keeps all non-empty tokens including single-char
+/// ones so that queries like `"x"` can match symbol names.
+fn tokenize(text: &str) -> Vec<String> {
+    split_identifiers(text)
+        .into_iter()
+        .map(|t| t.to_lowercase())
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+/// Tokenizes symbol fields for candidate matching. Filters out single-char
+/// fragments that arise from splitting identifiers (e.g. generic `T`) to
+/// reduce noise in overlap scoring.
+fn symbol_tokens(record: &SymbolRecord) -> Vec<String> {
+    let mut parts = Vec::new();
+    parts.push(record.name.clone());
+    parts.push(record.qualified_name.clone());
+    parts.push(record.signature.clone());
+    if let Some(ref summary) = record.summary {
+        parts.push(summary.clone());
+    }
+    if let Some(ref docstring) = record.docstring {
+        parts.push(docstring.clone());
+    }
+    if let Some(ref keywords) = record.keywords {
+        parts.extend(keywords.iter().cloned());
+    }
+
+    parts
+        .iter()
+        .flat_map(|p| split_identifiers(p))
+        .map(|t| t.to_lowercase())
+        .filter(|t| t.len() > 1)
+        .collect()
+}
+
+/// Splits text on word boundaries: snake_case, camelCase, PascalCase,
+/// whitespace, punctuation.
+fn split_identifiers(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+
+    for ch in text.chars() {
+        if ch == '_' || ch == ':' || ch == '(' || ch == ')' || ch == ',' || ch.is_whitespace() {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+        } else if ch.is_uppercase() && !current.is_empty() {
+            // camelCase boundary.
+            tokens.push(std::mem::take(&mut current));
+            current.push(ch);
+        } else {
+            current.push(ch);
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    tokens
+}
+
+/// Computes the fraction of query tokens found in the candidate token set.
+fn token_overlap(query_tokens: &[String], candidate_tokens: &[String]) -> f32 {
+    if query_tokens.is_empty() {
+        return 0.0;
+    }
+    let matched = query_tokens
+        .iter()
+        .filter(|qt| candidate_tokens.iter().any(|ct| ct.contains(qt.as_str())))
+        .count();
+    matched as f32 / query_tokens.len() as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_model::{build_symbol_id, SymbolKind};
+
+    fn make_symbol(name: &str, kind: SymbolKind) -> SymbolRecord {
+        let file_path = "src/lib.rs";
+        let qualified_name = format!("crate::{name}");
+        SymbolRecord {
+            id: build_symbol_id(file_path, &qualified_name, kind).expect("build id"),
+            repo_id: "repo-1".into(),
+            file_path: file_path.into(),
+            language: "rust".into(),
+            kind,
+            name: name.into(),
+            qualified_name,
+            signature: format!("fn {name}()"),
+            start_line: 1,
+            end_line: 5,
+            start_byte: 0,
+            byte_length: 50,
+            content_hash: "hash".into(),
+            quality_level: QualityLevel::Syntax,
+            confidence_score: 0.8,
+            source_adapter: "syntax-treesitter-v1".into(),
+            indexed_at: "2026-03-09T00:00:00Z".into(),
+            docstring: None,
+            summary: None,
+            parent_symbol_id: None,
+            keywords: None,
+            decorators_or_attributes: None,
+            semantic_refs: None,
+        }
+    }
+
+    #[test]
+    fn exact_name_match_scores_highest() {
+        let sym = make_symbol("run", SymbolKind::Function);
+        let score = score_symbol("run", &sym).expect("should match");
+        // Exact match bonus (0.4) + token overlap (1.0 * 0.45) + sig bonus (0.05) = 0.9.
+        assert!(score > 0.8, "exact match score should be high: {score}");
+    }
+
+    #[test]
+    fn partial_name_match_scores_lower_than_exact() {
+        let sym = make_symbol("run_server", SymbolKind::Function);
+        let exact_score = score_symbol("run_server", &sym).expect("should match");
+        let partial_score = score_symbol("run", &sym).expect("should match");
+        assert!(
+            exact_score > partial_score,
+            "exact ({exact_score}) should beat partial ({partial_score})"
+        );
+    }
+
+    #[test]
+    fn no_overlap_returns_none() {
+        let sym = make_symbol("run", SymbolKind::Function);
+        assert!(score_symbol("xyz_unrelated", &sym).is_none());
+    }
+
+    #[test]
+    fn semantic_quality_boosts_score() {
+        let mut syntax_sym = make_symbol("process", SymbolKind::Function);
+        syntax_sym.quality_level = QualityLevel::Syntax;
+
+        let mut semantic_sym = syntax_sym.clone();
+        semantic_sym.quality_level = QualityLevel::Semantic;
+        semantic_sym.confidence_score = 0.95;
+
+        let syntax_score = score_symbol("process", &syntax_sym).expect("match");
+        let semantic_score = score_symbol("process", &semantic_sym).expect("match");
+        assert!(
+            semantic_score > syntax_score,
+            "semantic ({semantic_score}) should beat syntax ({syntax_score})"
+        );
+    }
+
+    #[test]
+    fn keyword_match_contributes_to_score() {
+        let mut sym = make_symbol("handle_request", SymbolKind::Function);
+        sym.keywords = Some(vec!["http".into(), "server".into()]);
+
+        let without_kw_score = score_symbol(
+            "server",
+            &make_symbol("handle_request", SymbolKind::Function),
+        );
+        let with_kw_score = score_symbol("server", &sym);
+
+        // Without keywords, "server" doesn't match at all.
+        assert!(without_kw_score.is_none());
+        // With keywords, it should match.
+        assert!(with_kw_score.is_some());
+    }
+
+    #[test]
+    fn sort_scored_is_deterministic() {
+        let sym_a = make_symbol("alpha", SymbolKind::Function);
+        let sym_b = make_symbol("beta", SymbolKind::Function);
+        let mut items = vec![
+            ScoredSymbol {
+                record: sym_b.clone(),
+                score: 0.5,
+            },
+            ScoredSymbol {
+                record: sym_a.clone(),
+                score: 0.5,
+            },
+        ];
+        sort_scored(&mut items);
+
+        let mut items2 = vec![
+            ScoredSymbol {
+                record: sym_a,
+                score: 0.5,
+            },
+            ScoredSymbol {
+                record: sym_b,
+                score: 0.5,
+            },
+        ];
+        sort_scored(&mut items2);
+
+        let ids1: Vec<&str> = items.iter().map(|s| s.record.id.as_str()).collect();
+        let ids2: Vec<&str> = items2.iter().map(|s| s.record.id.as_str()).collect();
+        assert_eq!(ids1, ids2);
+    }
+
+    #[test]
+    fn sort_scored_higher_score_first() {
+        let sym_a = make_symbol("alpha", SymbolKind::Function);
+        let sym_b = make_symbol("beta", SymbolKind::Function);
+        let mut items = vec![
+            ScoredSymbol {
+                record: sym_a,
+                score: 0.3,
+            },
+            ScoredSymbol {
+                record: sym_b,
+                score: 0.9,
+            },
+        ];
+        sort_scored(&mut items);
+
+        assert_eq!(items[0].record.name, "beta");
+        assert_eq!(items[1].record.name, "alpha");
+    }
+
+    #[test]
+    fn tokenize_splits_snake_case() {
+        let tokens = tokenize("run_server");
+        assert!(tokens.contains(&"run".to_string()));
+        assert!(tokens.contains(&"server".to_string()));
+    }
+
+    #[test]
+    fn tokenize_splits_camel_case() {
+        let tokens = tokenize("runServer");
+        assert!(tokens.contains(&"run".to_string()));
+        assert!(tokens.contains(&"server".to_string()));
+    }
+
+    #[test]
+    fn single_char_query_matches_exact_name() {
+        let sym = make_symbol("x", SymbolKind::Function);
+        let score = score_symbol("x", &sym);
+        assert!(
+            score.is_some(),
+            "single-char query should match symbol named 'x'"
+        );
+        assert!(score.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn single_char_query_matches_via_substring() {
+        let sym = make_symbol("max", SymbolKind::Function);
+        let score = score_symbol("x", &sym);
+        // "x" appears as a substring of "max" in candidate tokens.
+        assert!(
+            score.is_some(),
+            "single-char query should match via substring"
+        );
+    }
+
+    #[test]
+    fn single_char_query_no_match() {
+        let sym = make_symbol("run", SymbolKind::Function);
+        let score = score_symbol("z", &sym);
+        assert!(
+            score.is_none(),
+            "single-char query 'z' should not match 'run'"
+        );
+    }
+
+    #[test]
+    fn score_clamped_to_one() {
+        let mut sym = make_symbol("x", SymbolKind::Function);
+        sym.quality_level = QualityLevel::Semantic;
+        sym.confidence_score = 1.0;
+        sym.keywords = Some(vec!["x".into()]);
+        sym.summary = Some("x".into());
+        sym.docstring = Some("x".into());
+        // Even with max signals, score should not exceed 1.0.
+        if let Some(score) = score_symbol("x", &sym) {
+            assert!(score <= 1.0, "score should be clamped: {score}");
+        }
+    }
+}

--- a/crates/query-engine/src/store_service.rs
+++ b/crates/query-engine/src/store_service.rs
@@ -1,0 +1,174 @@
+//! [`QueryService`] implementation backed by [`MetadataStore`].
+
+use store::MetadataStore;
+
+use crate::ranking::{score_symbol, sort_scored};
+use crate::{
+    validate_query_text, FileContent, FileContentRequest, FileOutline, FileOutlineRequest,
+    FileTreeEntry, FileTreeRequest, QueryError, QueryMeta, QueryResult, QueryService, RepoOutline,
+    RepoOutlineRequest, ScoredSymbol, SymbolQuery, TextMatch, TextQuery,
+};
+use core_model::SymbolRecord;
+
+/// Production [`QueryService`] implementation backed by a [`MetadataStore`].
+pub struct StoreQueryService<'a> {
+    store: &'a MetadataStore,
+}
+
+impl<'a> StoreQueryService<'a> {
+    pub fn new(store: &'a MetadataStore) -> Self {
+        Self { store }
+    }
+}
+
+impl QueryService for StoreQueryService<'_> {
+    fn search_symbols(&self, query: &SymbolQuery) -> Result<QueryResult<ScoredSymbol>, QueryError> {
+        validate_query_text(&query.text)?;
+
+        let candidates = self.store.symbols().search_candidates(
+            &query.repo_id,
+            query.filters.kind,
+            query.filters.language.as_deref(),
+            query.filters.quality_level,
+            query.filters.file_path.as_deref(),
+        )?;
+
+        let mut scored: Vec<ScoredSymbol> = candidates
+            .into_iter()
+            .filter_map(|record| {
+                score_symbol(&query.text, &record).map(|score| ScoredSymbol { record, score })
+            })
+            .collect();
+
+        let total_candidates = scored.len();
+        sort_scored(&mut scored);
+
+        let truncated = total_candidates > query.limit;
+        let items: Vec<ScoredSymbol> = scored
+            .into_iter()
+            .skip(query.offset)
+            .take(query.limit)
+            .collect();
+
+        Ok(QueryResult {
+            items,
+            meta: QueryMeta {
+                total_candidates,
+                truncated,
+            },
+        })
+    }
+
+    fn get_symbol(&self, id: &str) -> Result<SymbolRecord, QueryError> {
+        self.store
+            .symbols()
+            .get(id)?
+            .ok_or_else(|| QueryError::NotFound { id: id.into() })
+    }
+
+    fn get_symbols(&self, ids: &[&str]) -> Result<Vec<SymbolRecord>, QueryError> {
+        let mut results = Vec::new();
+        for id in ids {
+            if let Some(record) = self.store.symbols().get(id)? {
+                results.push(record);
+            }
+        }
+        Ok(results)
+    }
+
+    fn get_file_outline(&self, request: &FileOutlineRequest) -> Result<FileOutline, QueryError> {
+        let file = self
+            .store
+            .files()
+            .get(&request.repo_id, &request.file_path)?
+            .ok_or_else(|| QueryError::NotFound {
+                id: request.file_path.clone(),
+            })?;
+
+        let symbol_ids = self
+            .store
+            .symbols()
+            .list_ids_for_file(&request.repo_id, &request.file_path)?;
+
+        let mut symbols = Vec::with_capacity(symbol_ids.len());
+        for id in &symbol_ids {
+            if let Some(record) = self.store.symbols().get(id)? {
+                symbols.push(record);
+            }
+        }
+
+        Ok(FileOutline { file, symbols })
+    }
+
+    fn get_file_content(&self, request: &FileContentRequest) -> Result<FileContent, QueryError> {
+        let file = self
+            .store
+            .files()
+            .get(&request.repo_id, &request.file_path)?
+            .ok_or_else(|| QueryError::NotFound {
+                id: request.file_path.clone(),
+            })?;
+
+        // File content retrieval is delegated to BlobStore in production.
+        // For now, return a placeholder indicating content is not yet wired.
+        Ok(FileContent {
+            file,
+            content: String::new(),
+        })
+    }
+
+    fn get_file_tree(&self, request: &FileTreeRequest) -> Result<Vec<FileTreeEntry>, QueryError> {
+        let paths = self.store.files().list_paths(&request.repo_id)?;
+
+        let mut entries = Vec::new();
+        for path in paths {
+            if let Some(ref prefix) = request.path_prefix {
+                if !path.starts_with(prefix) {
+                    continue;
+                }
+            }
+            if let Some(file) = self.store.files().get(&request.repo_id, &path)? {
+                entries.push(FileTreeEntry {
+                    path: file.file_path,
+                    language: file.language,
+                    symbol_count: file.symbol_count,
+                });
+            }
+        }
+
+        Ok(entries)
+    }
+
+    fn get_repo_outline(&self, request: &RepoOutlineRequest) -> Result<RepoOutline, QueryError> {
+        let repo =
+            self.store
+                .repos()
+                .get(&request.repo_id)?
+                .ok_or_else(|| QueryError::NotFound {
+                    id: request.repo_id.clone(),
+                })?;
+
+        let file_entries = self.get_file_tree(&FileTreeRequest {
+            repo_id: request.repo_id.clone(),
+            path_prefix: None,
+        })?;
+
+        Ok(RepoOutline {
+            repo,
+            files: file_entries,
+        })
+    }
+
+    fn search_text(&self, query: &TextQuery) -> Result<QueryResult<TextMatch>, QueryError> {
+        validate_query_text(&query.pattern)?;
+
+        // Full text search will be implemented in #35.
+        Ok(QueryResult {
+            items: vec![],
+            meta: QueryMeta {
+                total_candidates: 0,
+                truncated: false,
+            },
+        })
+    }
+}

--- a/crates/query-engine/tests/search_symbols_integration.rs
+++ b/crates/query-engine/tests/search_symbols_integration.rs
@@ -1,0 +1,464 @@
+//! Integration tests for `search_symbols` backed by a seeded MetadataStore.
+
+use std::collections::BTreeMap;
+
+use core_model::{FileRecord, QualityLevel, QualityMix, RepoRecord, SymbolKind, SymbolRecord};
+use query_engine::{QueryError, QueryFilters, QueryService, StoreQueryService, SymbolQuery};
+use store::MetadataStore;
+
+fn seed_store() -> MetadataStore {
+    let store = MetadataStore::open_in_memory().unwrap();
+
+    store
+        .repos()
+        .upsert(&RepoRecord {
+            repo_id: "repo-1".into(),
+            display_name: "Test".into(),
+            source_root: "/tmp/test".into(),
+            indexed_at: "2026-03-09T00:00:00Z".into(),
+            index_version: "1.0.0".into(),
+            language_counts: BTreeMap::from([("rust".into(), 3)]),
+            file_count: 2,
+            symbol_count: 5,
+            git_head: None,
+        })
+        .unwrap();
+
+    for path in ["src/lib.rs", "src/server.rs"] {
+        store
+            .files()
+            .upsert(&FileRecord {
+                repo_id: "repo-1".into(),
+                file_path: path.into(),
+                language: "rust".into(),
+                file_hash: "sha256:abc".into(),
+                summary: "source file".into(),
+                symbol_count: 0,
+                quality_mix: QualityMix {
+                    semantic_percent: 0.0,
+                    syntax_percent: 100.0,
+                },
+                updated_at: "2026-03-09T00:00:00Z".into(),
+            })
+            .unwrap();
+    }
+
+    let symbols = vec![
+        make_symbol(
+            "run",
+            SymbolKind::Function,
+            "src/lib.rs",
+            "fn run()",
+            QualityLevel::Syntax,
+            0.8,
+            None,
+        ),
+        make_symbol(
+            "run_server",
+            SymbolKind::Function,
+            "src/server.rs",
+            "fn run_server(port: u16)",
+            QualityLevel::Syntax,
+            0.7,
+            None,
+        ),
+        make_symbol(
+            "RunConfig",
+            SymbolKind::Class,
+            "src/lib.rs",
+            "struct RunConfig",
+            QualityLevel::Semantic,
+            0.95,
+            Some(vec!["config".into(), "server".into()]),
+        ),
+        make_symbol(
+            "handle_request",
+            SymbolKind::Function,
+            "src/server.rs",
+            "fn handle_request(req: Request) -> Response",
+            QualityLevel::Semantic,
+            0.9,
+            Some(vec!["http".into(), "handler".into()]),
+        ),
+        make_symbol(
+            "Status",
+            SymbolKind::Type,
+            "src/lib.rs",
+            "enum Status",
+            QualityLevel::Syntax,
+            0.75,
+            None,
+        ),
+    ];
+
+    for sym in &symbols {
+        store.symbols().upsert(sym).unwrap();
+    }
+
+    store
+}
+
+fn make_symbol(
+    name: &str,
+    kind: SymbolKind,
+    file_path: &str,
+    signature: &str,
+    quality_level: QualityLevel,
+    confidence: f32,
+    keywords: Option<Vec<String>>,
+) -> SymbolRecord {
+    let qualified_name = format!("crate::{name}");
+    SymbolRecord {
+        id: core_model::build_symbol_id(file_path, &qualified_name, kind).expect("build id"),
+        repo_id: "repo-1".into(),
+        file_path: file_path.into(),
+        language: "rust".into(),
+        kind,
+        name: name.into(),
+        qualified_name,
+        signature: signature.into(),
+        start_line: 1,
+        end_line: 10,
+        start_byte: 0,
+        byte_length: 100,
+        content_hash: format!("hash-{name}"),
+        quality_level,
+        confidence_score: confidence,
+        source_adapter: "syntax-treesitter-v1".into(),
+        indexed_at: "2026-03-09T00:00:00Z".into(),
+        docstring: None,
+        summary: None,
+        parent_symbol_id: None,
+        keywords,
+        decorators_or_attributes: None,
+        semantic_refs: None,
+    }
+}
+
+#[test]
+fn empty_query_is_rejected() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let err = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "   ".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap_err();
+    assert!(matches!(err, QueryError::EmptyQuery));
+}
+
+#[test]
+fn exact_name_match_ranks_first() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(!result.items.is_empty());
+    // The exact match "run" should be first.
+    assert_eq!(result.items[0].record.name, "run");
+    // "run_server" and "RunConfig" should also appear (token overlap).
+    assert!(result.items.len() >= 2);
+}
+
+#[test]
+fn exact_match_scores_higher_than_partial() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    let exact = result
+        .items
+        .iter()
+        .find(|s| s.record.name == "run")
+        .unwrap();
+    let partial = result
+        .items
+        .iter()
+        .find(|s| s.record.name == "run_server")
+        .unwrap();
+    assert!(
+        exact.score > partial.score,
+        "exact ({}) should beat partial ({})",
+        exact.score,
+        partial.score
+    );
+}
+
+#[test]
+fn filter_by_kind() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters {
+                kind: Some(SymbolKind::Class),
+                ..QueryFilters::default()
+            },
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(result
+        .items
+        .iter()
+        .all(|s| s.record.kind == SymbolKind::Class));
+}
+
+#[test]
+fn filter_by_file_path() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters {
+                file_path: Some("src/server.rs".into()),
+                ..QueryFilters::default()
+            },
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(result
+        .items
+        .iter()
+        .all(|s| s.record.file_path == "src/server.rs"));
+}
+
+#[test]
+fn filter_by_quality_level() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters {
+                quality_level: Some(QualityLevel::Semantic),
+                ..QueryFilters::default()
+            },
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(result
+        .items
+        .iter()
+        .all(|s| s.record.quality_level == QualityLevel::Semantic));
+}
+
+#[test]
+fn truncation_metadata_when_limit_exceeded() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters::default(),
+            limit: 1,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert_eq!(result.items.len(), 1);
+    assert!(result.meta.truncated);
+    assert!(result.meta.total_candidates > 1);
+}
+
+#[test]
+fn no_truncation_when_all_fit() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "Status".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(!result.meta.truncated);
+}
+
+#[test]
+fn deterministic_ordering_on_ties() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let query = SymbolQuery {
+        repo_id: "repo-1".into(),
+        text: "run".into(),
+        filters: QueryFilters::default(),
+        limit: 10,
+        offset: 0,
+    };
+
+    let r1 = svc.search_symbols(&query).unwrap();
+    let r2 = svc.search_symbols(&query).unwrap();
+
+    let ids1: Vec<&str> = r1.items.iter().map(|s| s.record.id.as_str()).collect();
+    let ids2: Vec<&str> = r2.items.iter().map(|s| s.record.id.as_str()).collect();
+    assert_eq!(ids1, ids2);
+}
+
+#[test]
+fn no_match_returns_empty() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "zzz_nonexistent_xyz".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(result.items.is_empty());
+    assert!(!result.meta.truncated);
+    assert_eq!(result.meta.total_candidates, 0);
+}
+
+#[test]
+fn wrong_repo_returns_empty() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "nonexistent-repo".into(),
+            text: "run".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(result.items.is_empty());
+}
+
+#[test]
+fn keyword_match_surfaces_symbol() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "http".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    // "handle_request" has keyword "http".
+    assert!(
+        result
+            .items
+            .iter()
+            .any(|s| s.record.name == "handle_request"),
+        "keyword match should surface handle_request"
+    );
+}
+
+#[test]
+fn results_carry_quality_and_confidence() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    for item in &result.items {
+        assert!(item.score > 0.0);
+        assert!(item.record.confidence_score >= 0.0);
+        assert!(item.record.confidence_score <= 1.0);
+        assert!(!item.record.source_adapter.is_empty());
+    }
+}
+
+#[test]
+fn semantic_quality_boosts_ranking() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "config".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    // RunConfig has keyword "config" and is semantic quality.
+    if !result.items.is_empty() {
+        let run_config = result.items.iter().find(|s| s.record.name == "RunConfig");
+        assert!(run_config.is_some(), "RunConfig should match via keyword");
+    }
+}
+
+#[test]
+fn offset_skips_results() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let full = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    let offset = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "repo-1".into(),
+            text: "run".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 1,
+        })
+        .unwrap();
+
+    assert_eq!(offset.items.len(), full.items.len() - 1);
+    if full.items.len() > 1 {
+        assert_eq!(offset.items[0].record.id, full.items[1].record.id);
+    }
+}

--- a/crates/store/src/symbol_store.rs
+++ b/crates/store/src/symbol_store.rs
@@ -170,6 +170,107 @@ impl<'a> SymbolStore<'a> {
         Ok(changed as u64)
     }
 
+    /// Retrieves candidate symbols for a repository, filtered by optional criteria.
+    ///
+    /// Results are returned in deterministic order (by `id`). Ranking is the
+    /// caller's responsibility.
+    pub fn search_candidates(
+        &self,
+        repo_id: &str,
+        kind: Option<SymbolKind>,
+        language: Option<&str>,
+        quality_level: Option<QualityLevel>,
+        file_path: Option<&str>,
+    ) -> Result<Vec<SymbolRecord>, StoreError> {
+        let mut sql = String::from(
+            "SELECT id, repo_id, file_path, language, kind, name, qualified_name,
+                    signature, start_line, end_line, start_byte, byte_length,
+                    content_hash, quality_level, confidence_score, source_adapter,
+                    indexed_at, docstring, summary, parent_symbol_id,
+                    keywords, decorators_or_attributes, semantic_refs
+             FROM symbols WHERE repo_id = ?1",
+        );
+
+        let mut param_index = 2u32;
+        let mut param_strings: Vec<String> = Vec::new();
+
+        if let Some(k) = kind {
+            sql.push_str(&format!(" AND kind = ?{param_index}"));
+            param_strings.push(k.as_str().to_string());
+            param_index += 1;
+        }
+        if let Some(lang) = language {
+            sql.push_str(&format!(" AND language = ?{param_index}"));
+            param_strings.push(lang.to_string());
+            param_index += 1;
+        }
+        if let Some(ql) = quality_level {
+            sql.push_str(&format!(" AND quality_level = ?{param_index}"));
+            param_strings.push(quality_level_str(ql).to_string());
+            param_index += 1;
+        }
+        if let Some(fp) = file_path {
+            sql.push_str(&format!(" AND file_path = ?{param_index}"));
+            param_strings.push(fp.to_string());
+        }
+
+        sql.push_str(" ORDER BY id");
+
+        let mut stmt = self.conn.prepare(&sql)?;
+
+        // Build parameter slice: repo_id + any dynamic filters.
+        let mut params_vec: Vec<&dyn rusqlite::types::ToSql> = Vec::new();
+        let repo_id_owned = repo_id.to_string();
+        params_vec.push(&repo_id_owned);
+        for p in &param_strings {
+            params_vec.push(p);
+        }
+
+        let rows = stmt
+            .query_map(params_vec.as_slice(), |row| {
+                let kind_str: String = row.get(4)?;
+                let quality_str: String = row.get(13)?;
+                let keywords_json: Option<String> = row.get(20)?;
+                let decorators_json: Option<String> = row.get(21)?;
+                let refs_json: Option<String> = row.get(22)?;
+
+                Ok(SymbolRecord {
+                    id: row.get(0)?,
+                    repo_id: row.get(1)?,
+                    file_path: row.get(2)?,
+                    language: row.get(3)?,
+                    kind: parse_symbol_kind(&kind_str),
+                    name: row.get(5)?,
+                    qualified_name: row.get(6)?,
+                    signature: row.get(7)?,
+                    start_line: row.get::<_, i32>(8)? as u32,
+                    end_line: row.get::<_, i32>(9)? as u32,
+                    start_byte: row.get::<_, i64>(10)? as u64,
+                    byte_length: row.get::<_, i64>(11)? as u64,
+                    content_hash: row.get(12)?,
+                    quality_level: parse_quality_level(&quality_str),
+                    confidence_score: row.get(14)?,
+                    source_adapter: row.get(15)?,
+                    indexed_at: row.get(16)?,
+                    docstring: row.get(17)?,
+                    summary: row.get(18)?,
+                    parent_symbol_id: row.get(19)?,
+                    keywords: keywords_json
+                        .map(|j| serde_json::from_str(&j).map_err(|e| json_read_err(20, e)))
+                        .transpose()?,
+                    decorators_or_attributes: decorators_json
+                        .map(|j| serde_json::from_str(&j).map_err(|e| json_read_err(21, e)))
+                        .transpose()?,
+                    semantic_refs: refs_json
+                        .map(|j| serde_json::from_str(&j).map_err(|e| json_read_err(22, e)))
+                        .transpose()?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
+
     /// Returns the total number of symbol records for a repository.
     pub fn count_for_repo(&self, repo_id: &str) -> Result<u64, StoreError> {
         let count: i64 = self.conn.query_row(


### PR DESCRIPTION
## Summary

  - Issue: Closes #32
  - Scope: Implement deterministic search_symbols candidate retrieval + ranking/tie handling in query-engine and add required unit/integration coverage.

  ## Changes

  - Added production StoreQueryService implementation in query-engine:
      - search_symbols now validates query text, retrieves candidates from MetadataStore, ranks results, applies deterministic sorting, and returns truncation metadata.
  - Added deterministic ranking module:
      - Scoring signals include exact name match, token overlap, signature relevance, and semantic confidence boost.
      - Deterministic tie-breaker: score descending, then symbol ID ascending.
  - Added SymbolStore::search_candidates(...) in store:
      - Supports optional filters (kind, language, quality_level, file_path).
      - Returns deterministic candidate ordering (ORDER BY id).
  - Exported new query-engine surface:
      - pub mod ranking;
      - pub mod store_service;
      - pub use store_service::StoreQueryService;
  - Fixed single-character query behavior:
      - Query tokenization now keeps single-char query tokens.
      - Symbol tokenization still filters single-char identifier fragments to reduce noise.
  - Added tests:
      - Ranking unit tests (exact/partial/no-match, deterministic sorting, semantic boost, clamp, single-char query cases).
      - Integration tests with seeded metadata store (exact/fuzzy behavior, tie determinism, filters, truncation metadata, offset behavior, quality/confidence/provenance fields).

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: search_symbols returns deterministic ordering for ties.
  - [x] Criterion 2: Empty/whitespace query is rejected with structured error.
  - [x] Criterion 3: Tests cover exact match, fuzzy match, tie behavior, and truncation metadata.

  ## Test Evidence

  - [x] cargo fmt --all -- --check
  - [x] cargo clippy --all-targets --all-features -- -D warnings
  - [x] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - Added unit tests for ranking/sorting, including single-character query behavior.
      - Added integration test suite crates/query-engine/tests/search_symbols_integration.rs with seeded metadata store.

  ## Risk and Mitigation

  - Risk: Ranking weight choices may affect perceived relevance for some edge queries.
  - Mitigation: Deterministic ordering + explicit scoring tests + seeded integration tests ensure reproducibility; weights remain localized in ranking.rs for iterative tuning.

  ## Security/Observability Impact

  - Security: No new external I/O or auth boundary changes; query validation remains explicit for empty/whitespace input.
  - Logs/Metrics/Tracing: No new telemetry added in this change.