### PR TITLE
Implement search_text fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,10 @@ dependencies = [
 name = "query-engine"
 version = "0.1.0"
 dependencies = [
+ "adapter-api",
+ "adapter-syntax-treesitter",
  "core-model",
+ "indexer",
  "store",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ repository = "https://github.com/developepper/CodeAtlas"
 
 [workspace.dependencies]
 adapter-api = { path = "crates/adapter-api" }
+adapter-syntax-treesitter = { path = "crates/adapter-syntax-treesitter" }
 core-model = { path = "crates/core-model" }
 globset = "0.4.16"
+indexer = { path = "crates/indexer" }
 ignore = "0.4.24"
 query-engine = { path = "crates/query-engine" }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/query-engine/Cargo.toml
+++ b/crates/query-engine/Cargo.toml
@@ -13,4 +13,7 @@ core-model.workspace = true
 store.workspace = true
 
 [dev-dependencies]
+adapter-api.workspace = true
+adapter-syntax-treesitter.workspace = true
+indexer.workspace = true
 tempfile.workspace = true

--- a/crates/query-engine/src/store_service.rs
+++ b/crates/query-engine/src/store_service.rs
@@ -162,12 +162,35 @@ impl QueryService for StoreQueryService<'_> {
     fn search_text(&self, query: &TextQuery) -> Result<QueryResult<TextMatch>, QueryError> {
         validate_query_text(&query.pattern)?;
 
-        // Full text search will be implemented in #35.
+        let (hits, total_candidates) = self.store.symbols().search_text_fts(
+            &query.repo_id,
+            &query.pattern,
+            query.limit,
+            query.offset,
+        )?;
+
+        let mut items = Vec::with_capacity(hits.len());
+        for (id, rank) in &hits {
+            if let Some(record) = self.store.symbols().get(id)? {
+                // Normalize FTS5 rank (negative, lower = better) to a 0..1 score.
+                let score = 1.0 / (1.0 + rank.abs() as f32);
+                items.push(TextMatch {
+                    file_path: record.file_path.clone(),
+                    line_number: record.start_line,
+                    line_content: record.signature.clone(),
+                    symbol: Some(record),
+                    score,
+                });
+            }
+        }
+
+        let truncated = total_candidates > query.limit + query.offset;
+
         Ok(QueryResult {
-            items: vec![],
+            items,
             meta: QueryMeta {
-                total_candidates: 0,
-                truncated: false,
+                total_candidates,
+                truncated,
             },
         })
     }

--- a/crates/query-engine/tests/search_text_integration.rs
+++ b/crates/query-engine/tests/search_text_integration.rs
@@ -1,0 +1,631 @@
+//! Integration tests for `search_text` FTS5-backed full-text search.
+
+use std::collections::BTreeMap;
+
+use core_model::{FileRecord, QualityLevel, QualityMix, RepoRecord, SymbolKind, SymbolRecord};
+use query_engine::{QueryError, QueryFilters, QueryService, StoreQueryService, TextQuery};
+use store::MetadataStore;
+
+fn seed_store() -> MetadataStore {
+    let store = MetadataStore::open_in_memory().unwrap();
+
+    store
+        .repos()
+        .upsert(&RepoRecord {
+            repo_id: "repo-1".into(),
+            display_name: "Test".into(),
+            source_root: "/tmp/test".into(),
+            indexed_at: "2026-03-09T00:00:00Z".into(),
+            index_version: "1.0.0".into(),
+            language_counts: BTreeMap::from([("rust".into(), 2)]),
+            file_count: 2,
+            symbol_count: 5,
+            git_head: None,
+        })
+        .unwrap();
+
+    for path in ["src/lib.rs", "src/server.rs"] {
+        store
+            .files()
+            .upsert(&FileRecord {
+                repo_id: "repo-1".into(),
+                file_path: path.into(),
+                language: "rust".into(),
+                file_hash: format!("sha256:{path}"),
+                summary: "source file".into(),
+                symbol_count: 0,
+                quality_mix: QualityMix {
+                    semantic_percent: 0.0,
+                    syntax_percent: 100.0,
+                },
+                updated_at: "2026-03-09T00:00:00Z".into(),
+            })
+            .unwrap();
+    }
+
+    let symbols = vec![
+        make_symbol(
+            "parse_config",
+            SymbolKind::Function,
+            "src/lib.rs",
+            "fn parse_config(path: &str) -> Config",
+            Some("Parses a TOML configuration file."),
+            Some(vec!["config".into(), "toml".into(), "parser".into()]),
+        ),
+        make_symbol(
+            "validate_input",
+            SymbolKind::Function,
+            "src/lib.rs",
+            "fn validate_input(data: &[u8]) -> Result<(), Error>",
+            Some("Validates user input bytes."),
+            Some(vec!["validation".into(), "input".into()]),
+        ),
+        make_symbol(
+            "HttpServer",
+            SymbolKind::Class,
+            "src/server.rs",
+            "struct HttpServer",
+            Some("An HTTP server implementation."),
+            Some(vec!["http".into(), "server".into(), "networking".into()]),
+        ),
+        make_symbol(
+            "handle_request",
+            SymbolKind::Function,
+            "src/server.rs",
+            "fn handle_request(req: Request) -> Response",
+            Some("Handles incoming HTTP requests."),
+            Some(vec!["http".into(), "handler".into(), "request".into()]),
+        ),
+        make_symbol(
+            "Status",
+            SymbolKind::Type,
+            "src/lib.rs",
+            "enum Status",
+            None,
+            None,
+        ),
+    ];
+
+    for sym in &symbols {
+        store.symbols().upsert(sym).unwrap();
+    }
+
+    store
+}
+
+fn make_symbol(
+    name: &str,
+    kind: SymbolKind,
+    file_path: &str,
+    signature: &str,
+    docstring: Option<&str>,
+    keywords: Option<Vec<String>>,
+) -> SymbolRecord {
+    let qualified_name = format!("crate::{name}");
+    SymbolRecord {
+        id: core_model::build_symbol_id(file_path, &qualified_name, kind).expect("build id"),
+        repo_id: "repo-1".into(),
+        file_path: file_path.into(),
+        language: "rust".into(),
+        kind,
+        name: name.into(),
+        qualified_name,
+        signature: signature.into(),
+        start_line: 1,
+        end_line: 10,
+        start_byte: 0,
+        byte_length: 100,
+        content_hash: format!("hash-{name}"),
+        quality_level: QualityLevel::Syntax,
+        confidence_score: 0.8,
+        source_adapter: "syntax-treesitter-v1".into(),
+        indexed_at: "2026-03-09T00:00:00Z".into(),
+        docstring: docstring.map(String::from),
+        summary: None,
+        parent_symbol_id: None,
+        keywords,
+        decorators_or_attributes: None,
+        semantic_refs: None,
+    }
+}
+
+fn query(pattern: &str) -> TextQuery {
+    TextQuery {
+        repo_id: "repo-1".into(),
+        pattern: pattern.into(),
+        filters: QueryFilters::default(),
+        limit: 10,
+        offset: 0,
+    }
+}
+
+// ── Basic matching ─────────────────────────────────────────────────────
+
+#[test]
+fn search_text_matches_by_name() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("parse_config")).unwrap();
+    assert!(!result.items.is_empty());
+    assert!(result
+        .items
+        .iter()
+        .any(|m| m.symbol.as_ref().unwrap().name == "parse_config"));
+}
+
+#[test]
+fn search_text_matches_by_docstring() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("TOML configuration")).unwrap();
+    assert!(!result.items.is_empty());
+    assert!(result
+        .items
+        .iter()
+        .any(|m| m.symbol.as_ref().unwrap().name == "parse_config"));
+}
+
+#[test]
+fn search_text_matches_by_keyword() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("networking")).unwrap();
+    assert!(!result.items.is_empty());
+    assert!(result
+        .items
+        .iter()
+        .any(|m| m.symbol.as_ref().unwrap().name == "HttpServer"));
+}
+
+#[test]
+fn search_text_matches_by_signature() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("Request Response")).unwrap();
+    assert!(!result.items.is_empty());
+}
+
+#[test]
+fn search_text_matches_by_qualified_name() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("crate validate_input")).unwrap();
+    assert!(!result.items.is_empty());
+    assert!(result
+        .items
+        .iter()
+        .any(|m| m.symbol.as_ref().unwrap().name == "validate_input"));
+}
+
+// ── Edge cases ─────────────────────────────────────────────────────────
+
+#[test]
+fn search_text_empty_query_rejected() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let err = svc
+        .search_text(&TextQuery {
+            repo_id: "repo-1".into(),
+            pattern: "   ".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap_err();
+
+    assert!(matches!(err, QueryError::EmptyQuery));
+}
+
+#[test]
+fn search_text_no_match_returns_empty() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc
+        .search_text(&query("xyzzy_completely_unrelated"))
+        .unwrap();
+    assert!(result.items.is_empty());
+    assert_eq!(result.meta.total_candidates, 0);
+    assert!(!result.meta.truncated);
+}
+
+#[test]
+fn search_text_wrong_repo_returns_empty() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc
+        .search_text(&TextQuery {
+            repo_id: "nonexistent".into(),
+            pattern: "parse_config".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(result.items.is_empty());
+}
+
+// ── Result shape ───────────────────────────────────────────────────────
+
+#[test]
+fn search_text_results_carry_symbol_record() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("HttpServer")).unwrap();
+    assert!(!result.items.is_empty());
+
+    let hit = &result.items[0];
+    let sym = hit.symbol.as_ref().expect("should carry symbol");
+    assert_eq!(sym.name, "HttpServer");
+    assert_eq!(sym.kind, SymbolKind::Class);
+    assert_eq!(hit.file_path, "src/server.rs");
+    assert!(hit.score > 0.0);
+    assert!(hit.score <= 1.0);
+}
+
+#[test]
+fn search_text_results_include_line_number() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("parse_config")).unwrap();
+    assert!(!result.items.is_empty());
+    // line_number comes from start_line of the symbol.
+    assert!(result.items[0].line_number >= 1);
+}
+
+#[test]
+fn search_text_results_include_signature_as_line_content() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("parse_config")).unwrap();
+    let hit = result
+        .items
+        .iter()
+        .find(|m| m.symbol.as_ref().unwrap().name == "parse_config")
+        .unwrap();
+    assert!(hit.line_content.contains("parse_config"));
+}
+
+// ── Truncation & pagination ────────────────────────────────────────────
+
+#[test]
+fn search_text_truncation_metadata() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    // "http" appears in keywords of both HttpServer and handle_request.
+    let result = svc
+        .search_text(&TextQuery {
+            repo_id: "repo-1".into(),
+            pattern: "http".into(),
+            filters: QueryFilters::default(),
+            limit: 1,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert_eq!(result.items.len(), 1);
+    assert!(result.meta.truncated);
+    assert!(result.meta.total_candidates >= 2);
+}
+
+#[test]
+fn search_text_offset_pagination() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let full = svc.search_text(&query("http")).unwrap();
+
+    let page2 = svc
+        .search_text(&TextQuery {
+            repo_id: "repo-1".into(),
+            pattern: "http".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 1,
+        })
+        .unwrap();
+
+    assert_eq!(page2.items.len(), full.items.len() - 1);
+}
+
+// ── Determinism ────────────────────────────────────────────────────────
+
+#[test]
+fn search_text_deterministic_ordering() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let r1 = svc.search_text(&query("http")).unwrap();
+    let r2 = svc.search_text(&query("http")).unwrap();
+
+    let ids1: Vec<&str> = r1
+        .items
+        .iter()
+        .map(|m| m.symbol.as_ref().unwrap().id.as_str())
+        .collect();
+    let ids2: Vec<&str> = r2
+        .items
+        .iter()
+        .map(|m| m.symbol.as_ref().unwrap().id.as_str())
+        .collect();
+    assert_eq!(ids1, ids2);
+}
+
+// ── FTS index stays in sync ────────────────────────────────────────────
+
+#[test]
+fn fts_index_updated_on_symbol_insert() {
+    let store = MetadataStore::open_in_memory().unwrap();
+
+    store
+        .repos()
+        .upsert(&RepoRecord {
+            repo_id: "r".into(),
+            display_name: "R".into(),
+            source_root: "/r".into(),
+            indexed_at: "2026-03-09T00:00:00Z".into(),
+            index_version: "1.0.0".into(),
+            language_counts: BTreeMap::new(),
+            file_count: 1,
+            symbol_count: 0,
+            git_head: None,
+        })
+        .unwrap();
+
+    store
+        .files()
+        .upsert(&FileRecord {
+            repo_id: "r".into(),
+            file_path: "a.rs".into(),
+            language: "rust".into(),
+            file_hash: "h".into(),
+            summary: "s".into(),
+            symbol_count: 0,
+            quality_mix: QualityMix {
+                semantic_percent: 0.0,
+                syntax_percent: 100.0,
+            },
+            updated_at: "2026-03-09T00:00:00Z".into(),
+        })
+        .unwrap();
+
+    let svc = StoreQueryService::new(&store);
+
+    // Before insert: no results.
+    let before = svc.search_text(&TextQuery {
+        repo_id: "r".into(),
+        pattern: "unique_function_name".into(),
+        filters: QueryFilters::default(),
+        limit: 10,
+        offset: 0,
+    });
+    assert!(before.unwrap().items.is_empty());
+
+    // Insert symbol.
+    let qualified_name = "crate::unique_function_name".to_string();
+    store
+        .symbols()
+        .upsert(&SymbolRecord {
+            id: core_model::build_symbol_id("a.rs", &qualified_name, SymbolKind::Function)
+                .expect("build id"),
+            repo_id: "r".into(),
+            file_path: "a.rs".into(),
+            language: "rust".into(),
+            kind: SymbolKind::Function,
+            name: "unique_function_name".into(),
+            qualified_name,
+            signature: "fn unique_function_name()".into(),
+            start_line: 1,
+            end_line: 10,
+            start_byte: 0,
+            byte_length: 100,
+            content_hash: "hash-unique".into(),
+            quality_level: QualityLevel::Syntax,
+            confidence_score: 0.8,
+            source_adapter: "syntax-treesitter-v1".into(),
+            indexed_at: "2026-03-09T00:00:00Z".into(),
+            docstring: None,
+            summary: None,
+            parent_symbol_id: None,
+            keywords: None,
+            decorators_or_attributes: None,
+            semantic_refs: None,
+        })
+        .unwrap();
+
+    // After insert: found.
+    let after = svc
+        .search_text(&TextQuery {
+            repo_id: "r".into(),
+            pattern: "unique_function_name".into(),
+            filters: QueryFilters::default(),
+            limit: 10,
+            offset: 0,
+        })
+        .unwrap();
+    assert_eq!(after.items.len(), 1);
+    assert_eq!(
+        after.items[0].symbol.as_ref().unwrap().name,
+        "unique_function_name"
+    );
+}
+
+#[test]
+fn fts_index_updated_on_symbol_delete() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    // Confirm match exists before delete.
+    let before = svc.search_text(&query("parse_config")).unwrap();
+    assert!(!before.items.is_empty());
+
+    // Delete via file cascade.
+    store.files().delete("repo-1", "src/lib.rs").unwrap();
+
+    // After delete: no more match.
+    let after = svc.search_text(&query("parse_config")).unwrap();
+    assert!(after.items.is_empty());
+}
+
+// ── Query normalization ───────────────────────────────────────────────
+
+#[test]
+fn search_text_malformed_fts_syntax_does_not_error() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    // FTS5 operators and special chars are normalized, not passed raw.
+    // This must not produce an FTS5 syntax error.
+    let result = svc.search_text(&query("\"parse_config\" OR foo*"));
+    assert!(result.is_ok());
+
+    // A query with only the target term plus stripped syntax should still match.
+    let result = svc.search_text(&query("parse_config*")).unwrap();
+    assert!(result
+        .items
+        .iter()
+        .any(|m| m.symbol.as_ref().unwrap().name == "parse_config"));
+}
+
+#[test]
+fn search_text_only_special_chars_returns_empty() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    let result = svc.search_text(&query("*** ---")).unwrap();
+    assert!(result.items.is_empty());
+}
+
+#[test]
+fn search_text_bare_fts_operator_does_not_error() {
+    let store = seed_store();
+    let svc = StoreQueryService::new(&store);
+
+    // Bare FTS5 operators are lowercased to plain terms, not syntax errors.
+    for op in ["OR", "AND", "NOT", "NEAR", "AND NOT"] {
+        let result = svc.search_text(&query(op));
+        assert!(result.is_ok(), "operator '{op}' should not cause an error");
+    }
+}
+
+// ── Pipeline end-to-end ───────────────────────────────────────────────
+
+mod pipeline {
+    use adapter_api::{AdapterPolicy, AdapterRouter, LanguageAdapter};
+    use adapter_syntax_treesitter::{create_adapter, supported_languages, TreeSitterAdapter};
+    use indexer::{run, PipelineContext};
+    use query_engine::{QueryFilters, QueryService, StoreQueryService, TextQuery};
+    use store::MetadataStore;
+    use tempfile::TempDir;
+
+    struct TreeSitterRouter {
+        adapters: Vec<TreeSitterAdapter>,
+    }
+
+    impl TreeSitterRouter {
+        fn new() -> Self {
+            let adapters = supported_languages()
+                .iter()
+                .filter_map(|lang| create_adapter(lang))
+                .collect();
+            Self { adapters }
+        }
+    }
+
+    impl AdapterRouter for TreeSitterRouter {
+        fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+            self.adapters
+                .iter()
+                .filter(|a| a.language() == language)
+                .map(|a| a as &dyn LanguageAdapter)
+                .collect()
+        }
+    }
+
+    #[test]
+    fn pipeline_indexed_symbols_searchable_via_fts() {
+        // 1. Create a fixture repo with Rust source files.
+        let repo_dir = TempDir::new().expect("create repo dir");
+        let src = repo_dir.path().join("src");
+        std::fs::create_dir_all(&src).expect("create src dir");
+        std::fs::write(
+            src.join("lib.rs"),
+            r#"
+/// Parses a TOML configuration file.
+fn parse_config(path: &str) -> String {
+    String::new()
+}
+
+/// An HTTP server implementation.
+struct HttpServer {
+    port: u16,
+}
+"#,
+        )
+        .expect("write lib.rs");
+
+        let blob_dir = TempDir::new().expect("create blob dir");
+        let blob_store =
+            store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+
+        // 2. Index via the full pipeline.
+        let mut db = MetadataStore::open_in_memory().expect("open store");
+        let router = TreeSitterRouter::new();
+        let ctx = PipelineContext {
+            repo_id: "pipeline-test".to_string(),
+            source_root: repo_dir.path().to_path_buf(),
+            router: &router,
+            default_policy: AdapterPolicy::SyntaxOnly,
+            correlation_id: None,
+        };
+        let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+        assert!(result.metrics.symbols_extracted >= 2);
+
+        // 3. Query via search_text and verify FTS index was populated.
+        let svc = StoreQueryService::new(&db);
+
+        let config_results = svc
+            .search_text(&TextQuery {
+                repo_id: "pipeline-test".into(),
+                pattern: "parse_config".into(),
+                filters: QueryFilters::default(),
+                limit: 10,
+                offset: 0,
+            })
+            .unwrap();
+        assert!(
+            !config_results.items.is_empty(),
+            "parse_config should be findable via FTS after pipeline indexing"
+        );
+        assert!(config_results
+            .items
+            .iter()
+            .any(|m| m.symbol.as_ref().unwrap().name == "parse_config"));
+
+        let server_results = svc
+            .search_text(&TextQuery {
+                repo_id: "pipeline-test".into(),
+                pattern: "HttpServer".into(),
+                filters: QueryFilters::default(),
+                limit: 10,
+                offset: 0,
+            })
+            .unwrap();
+        assert!(
+            !server_results.items.is_empty(),
+            "HttpServer should be findable via FTS after pipeline indexing"
+        );
+    }
+}

--- a/crates/store/src/migrations.rs
+++ b/crates/store/src/migrations.rs
@@ -9,10 +9,10 @@ use rusqlite::Connection;
 use crate::StoreError;
 
 /// Current schema version (latest migration number).
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// All migrations in order. Each entry is `(version, up_sql, down_sql)`.
-const MIGRATIONS: &[(u32, &str, &str)] = &[(1, V1_UP, V1_DOWN)];
+const MIGRATIONS: &[(u32, &str, &str)] = &[(1, V1_UP, V1_DOWN), (2, V2_UP, V2_DOWN)];
 
 // ---------------------------------------------------------------------------
 // V1: baseline schema
@@ -88,6 +88,52 @@ DROP INDEX IF EXISTS idx_symbols_repo_file;
 DROP TABLE IF EXISTS symbols;
 DROP TABLE IF EXISTS files;
 DROP TABLE IF EXISTS repos;
+"#;
+
+// ---------------------------------------------------------------------------
+// V2: FTS5 full-text search index on symbols
+// ---------------------------------------------------------------------------
+
+const V2_UP: &str = r#"
+CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(
+    id UNINDEXED,
+    name,
+    qualified_name,
+    signature,
+    docstring,
+    summary,
+    keywords,
+    content='symbols',
+    content_rowid='rowid'
+);
+
+-- Populate from existing data.
+INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild');
+
+-- Keep FTS in sync on insert/update/delete.
+CREATE TRIGGER IF NOT EXISTS symbols_ai AFTER INSERT ON symbols BEGIN
+    INSERT INTO symbols_fts(rowid, id, name, qualified_name, signature, docstring, summary, keywords)
+    VALUES (new.rowid, new.id, new.name, new.qualified_name, new.signature, new.docstring, new.summary, new.keywords);
+END;
+
+CREATE TRIGGER IF NOT EXISTS symbols_ad AFTER DELETE ON symbols BEGIN
+    INSERT INTO symbols_fts(symbols_fts, rowid, id, name, qualified_name, signature, docstring, summary, keywords)
+    VALUES ('delete', old.rowid, old.id, old.name, old.qualified_name, old.signature, old.docstring, old.summary, old.keywords);
+END;
+
+CREATE TRIGGER IF NOT EXISTS symbols_au AFTER UPDATE ON symbols BEGIN
+    INSERT INTO symbols_fts(symbols_fts, rowid, id, name, qualified_name, signature, docstring, summary, keywords)
+    VALUES ('delete', old.rowid, old.id, old.name, old.qualified_name, old.signature, old.docstring, old.summary, old.keywords);
+    INSERT INTO symbols_fts(rowid, id, name, qualified_name, signature, docstring, summary, keywords)
+    VALUES (new.rowid, new.id, new.name, new.qualified_name, new.signature, new.docstring, new.summary, new.keywords);
+END;
+"#;
+
+const V2_DOWN: &str = r#"
+DROP TRIGGER IF EXISTS symbols_au;
+DROP TRIGGER IF EXISTS symbols_ad;
+DROP TRIGGER IF EXISTS symbols_ai;
+DROP TABLE IF EXISTS symbols_fts;
 "#;
 
 // ---------------------------------------------------------------------------

--- a/crates/store/src/symbol_store.rs
+++ b/crates/store/src/symbol_store.rs
@@ -271,6 +271,57 @@ impl<'a> SymbolStore<'a> {
         Ok(rows)
     }
 
+    /// Searches symbols via FTS5 full-text index, filtered by repo.
+    ///
+    /// Returns `(symbol_id, fts_rank)` pairs ordered by relevance then ID for
+    /// deterministic tie-breaking. The caller joins with full symbol records.
+    ///
+    /// The raw query string is normalized to plain FTS5 terms (implicit AND)
+    /// before being passed to MATCH, stripping any FTS5 special syntax.
+    pub fn search_text_fts(
+        &self,
+        repo_id: &str,
+        query: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<(Vec<(String, f64)>, usize), StoreError> {
+        let normalized = normalize_fts_query(query);
+        if normalized.is_empty() {
+            return Ok((Vec::new(), 0));
+        }
+
+        // Count total matches first.
+        let total: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM symbols_fts
+             JOIN symbols ON symbols.id = symbols_fts.id
+             WHERE symbols_fts MATCH ?1 AND symbols.repo_id = ?2",
+            params![&normalized, repo_id],
+            |row| row.get(0),
+        )?;
+
+        let mut stmt = self.conn.prepare(
+            "SELECT symbols_fts.id, rank
+             FROM symbols_fts
+             JOIN symbols ON symbols.id = symbols_fts.id
+             WHERE symbols_fts MATCH ?1 AND symbols.repo_id = ?2
+             ORDER BY rank, symbols_fts.id
+             LIMIT ?3 OFFSET ?4",
+        )?;
+
+        let rows = stmt
+            .query_map(
+                params![&normalized, repo_id, limit as i64, offset as i64],
+                |row| {
+                    let id: String = row.get(0)?;
+                    let rank: f64 = row.get(1)?;
+                    Ok((id, rank))
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok((rows, total as usize))
+    }
+
     /// Returns the total number of symbol records for a repository.
     pub fn count_for_repo(&self, repo_id: &str) -> Result<u64, StoreError> {
         let count: i64 = self.conn.query_row(
@@ -306,6 +357,33 @@ fn parse_symbol_kind(s: &str) -> SymbolKind {
 
 fn json_read_err(col: usize, e: serde_json::Error) -> rusqlite::Error {
     rusqlite::Error::FromSqlConversionFailure(col, rusqlite::types::Type::Text, Box::new(e))
+}
+
+/// FTS5 reserved operator keywords that must be lowercased to be treated
+/// as plain search terms rather than query syntax.
+const FTS5_OPERATORS: &[&str] = &["AND", "OR", "NOT", "NEAR"];
+
+/// Normalizes raw user input into a safe FTS5 query string.
+///
+/// Strips special characters, lowercases FTS5 reserved operators so they are
+/// treated as plain terms, and joins with spaces (implicit AND in FTS5).
+/// Returns an empty string if no valid tokens remain.
+fn normalize_fts_query(raw: &str) -> String {
+    raw.split_whitespace()
+        .map(|token| {
+            let cleaned: String = token
+                .chars()
+                .filter(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if FTS5_OPERATORS.contains(&cleaned.as_str()) {
+                cleaned.to_lowercase()
+            } else {
+                cleaned
+            }
+        })
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Extension trait to make `query_row` return `Option` on no rows.
@@ -572,6 +650,37 @@ mod tests {
 
         let err = store.symbols().upsert(&sym).unwrap_err();
         assert!(err.to_string().contains("validation"), "{err}");
+    }
+
+    #[test]
+    fn normalize_fts_strips_special_chars() {
+        assert_eq!(normalize_fts_query("\"exact phrase\""), "exact phrase");
+        assert_eq!(normalize_fts_query("foo*"), "foo");
+        assert_eq!(normalize_fts_query("col:name"), "colname");
+    }
+
+    #[test]
+    fn normalize_fts_lowercases_reserved_operators() {
+        assert_eq!(normalize_fts_query("foo AND bar"), "foo and bar");
+        assert_eq!(normalize_fts_query("foo OR bar"), "foo or bar");
+        assert_eq!(normalize_fts_query("NOT foo"), "not foo");
+        assert_eq!(normalize_fts_query("NEAR foo"), "near foo");
+        // Standalone operator becomes a plain lowercase term.
+        assert_eq!(normalize_fts_query("OR"), "or");
+        assert_eq!(normalize_fts_query("AND NOT"), "and not");
+    }
+
+    #[test]
+    fn normalize_fts_preserves_plain_tokens() {
+        assert_eq!(normalize_fts_query("parse_config"), "parse_config");
+        assert_eq!(normalize_fts_query("http server"), "http server");
+    }
+
+    #[test]
+    fn normalize_fts_empty_after_stripping() {
+        assert_eq!(normalize_fts_query("***"), "");
+        assert_eq!(normalize_fts_query("\"\""), "");
+        assert_eq!(normalize_fts_query("  "), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  - Issue: Closes #35
  - Scope: Implement search_text fallback using SQLite FTS5, add query normalization, enforce deterministic ordering/tie-breaking, and add integration coverage including full indexing pipeline to query flow.

  ## Changes

  - Implemented search_text in StoreQueryService:
      - Replaced placeholder response with real FTS-backed retrieval.
      - Maps FTS hits to TextMatch items with symbol provenance.
      - Computes stable truncation metadata from total candidates and pagination.
  - Added FTS5 persistence layer in store:
      - New schema migration v2 with symbols_fts virtual table.
      - Added triggers to keep FTS index synced on symbol insert/update/delete.
      - Backfill support via INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild').
  - Added FTS query support in SymbolStore:
      - New search_text_fts(repo_id, query, limit, offset) API.
      - Deterministic SQL ordering: ORDER BY rank, symbols_fts.id.
      - Returns (id, rank) pairs plus total match count.
  - Added query normalization:
      - Introduced normalize_fts_query to strip FTS syntax chars and normalize reserved operators (AND/OR/NOT/NEAR) into safe plain terms.
      - Handles malformed/operator-only input without surfacing FTS parser errors.
  - Added/updated test coverage:
      - New integration suite crates/query-engine/tests/search_text_integration.rs (20 tests).
      - Covers name/docstring/keyword/signature/qualified-name matches, empty query rejection, no-match behavior, deterministic ordering, truncation/pagination, FTS index sync on insert/delete, malformed syntax
        normalization, and bare-operator safety.
      - Added pipeline end-to-end test that runs indexing (indexer::run) and verifies symbols are searchable via search_text afterward.
      - Added symbol-store unit tests for normalization semantics.
  - Dependency wiring for integration tests:
      - Added adapter-api, adapter-syntax-treesitter, and indexer as query-engine dev-dependencies.
      - Added corresponding workspace dependencies and lockfile updates.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: FTS5 index built/updated during indexing.
  - [x] Criterion 2: search_text returns ranked matches with deterministic tie-breaking.
  - [x] Criterion 3: Query rejects empty/whitespace-only input.
  - [x] Criterion 4: Integration tests cover indexing + query end-to-end.

  ## Test Evidence

  - [x] cargo fmt --all -- --check
  - [x] cargo clippy --all-targets --all-features -- -D warnings
  - [x] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - Added search_text integration suite (20 tests) including pipeline end-to-end indexing/query verification.

  ## Risk and Mitigation

  - Risk: FTS query behavior can be sensitive to raw syntax and reserved tokens.
  - Mitigation: Centralized normalization (normalize_fts_query) plus explicit unit/integration tests for malformed syntax and operator-only inputs; deterministic ordering guaranteed in SQL.

  ## Security/Observability Impact

  - Security: No new external attack surface; user query text is normalized before FTS MATCH, reducing parser-error injection/invalid syntax paths.
  - Logs/Metrics/Tracing: No new telemetry added in this PR.