### PR TITLE
Create CLI crate for local indexing and query commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cli"
+version = "0.1.0"
+dependencies = [
+ "adapter-api",
+ "adapter-syntax-treesitter",
+ "core-model",
+ "indexer",
+ "query-engine",
+ "store",
+ "tempfile",
+]
+
+[[package]]
 name = "core-model"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/adapter-api", "crates/adapter-syntax-treesitter", "crates/core-model", "crates/indexer", "crates/query-engine", "crates/repo-walker", "crates/store", "crates/workspace-placeholder"]
+members = ["crates/adapter-api", "crates/adapter-syntax-treesitter", "crates/cli", "crates/core-model", "crates/indexer", "crates/query-engine", "crates/repo-walker", "crates/store", "crates/workspace-placeholder"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "codeatlas"
+path = "src/main.rs"
+
+[dependencies]
+adapter-api.workspace = true
+adapter-syntax-treesitter.workspace = true
+core-model.workspace = true
+indexer.workspace = true
+query-engine.workspace = true
+store.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/cli/src/commands/get_symbol.rs
+++ b/crates/cli/src/commands/get_symbol.rs
@@ -1,0 +1,61 @@
+//! `codeatlas get-symbol` command — retrieves a single symbol by ID.
+
+use std::path::PathBuf;
+
+use query_engine::{QueryService, StoreQueryService};
+
+use crate::error::CliError;
+
+pub fn run(args: &[String]) -> Result<(), CliError> {
+    let (db_path, symbol_id) = parse_args(args)?;
+
+    let db = store::MetadataStore::open(&db_path)?;
+    let svc = StoreQueryService::new(&db);
+
+    let record = svc.get_symbol(&symbol_id)?;
+
+    println!("id: {}", record.id);
+    println!("name: {}", record.name);
+    println!("kind: {}", record.kind.as_str());
+    println!("qualified_name: {}", record.qualified_name);
+    println!("file: {}:{}", record.file_path, record.start_line);
+    println!("language: {}", record.language);
+    println!("signature: {}", record.signature);
+    println!("quality: {:?}", record.quality_level);
+    println!("confidence: {}", record.confidence_score);
+    if let Some(ref doc) = record.docstring {
+        println!("docstring: {doc}");
+    }
+
+    Ok(())
+}
+
+fn parse_args(args: &[String]) -> Result<(PathBuf, String), CliError> {
+    let mut db_path: Option<PathBuf> = None;
+    let mut symbol_id: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            arg if !arg.starts_with('-') && symbol_id.is_none() => {
+                symbol_id = Some(arg.to_string());
+            }
+            other => {
+                return Err(CliError::Usage(format!("unknown option: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let db_path = db_path.ok_or_else(|| CliError::Usage("--db <path> is required".into()))?;
+    let symbol_id = symbol_id.ok_or_else(|| CliError::Usage("symbol ID is required".into()))?;
+
+    Ok((db_path, symbol_id))
+}

--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -1,0 +1,102 @@
+//! `codeatlas index` command — indexes a repository.
+
+use std::path::PathBuf;
+
+use adapter_api::AdapterPolicy;
+use indexer::PipelineContext;
+
+use crate::error::CliError;
+use crate::router::TreeSitterRouter;
+
+struct IndexOpts {
+    source_root: PathBuf,
+    db_path: Option<PathBuf>,
+}
+
+fn parse_args(args: &[String]) -> Result<IndexOpts, CliError> {
+    let mut source_root: Option<PathBuf> = None;
+    let mut db_path: Option<PathBuf> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            arg if arg.starts_with('-') => {
+                return Err(CliError::Usage(format!("unknown option: {arg}")));
+            }
+            arg if source_root.is_none() => {
+                source_root = Some(PathBuf::from(arg));
+            }
+            other => {
+                return Err(CliError::Usage(format!("unexpected argument: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let source_root = source_root
+        .ok_or_else(|| CliError::Usage("usage: codeatlas index <path> [--db <path>]".into()))?;
+
+    Ok(IndexOpts {
+        source_root,
+        db_path,
+    })
+}
+
+pub fn run(args: &[String]) -> Result<(), CliError> {
+    let opts = parse_args(args)?;
+
+    let source_root = opts.source_root.canonicalize()?;
+    let db_path = opts
+        .db_path
+        .unwrap_or_else(|| source_root.join(".codeatlas").join("index.db"));
+    let blob_path = db_path
+        .parent()
+        .map_or_else(|| PathBuf::from(".codeatlas/blobs"), |p| p.join("blobs"));
+
+    // Derive repo_id from directory name.
+    let repo_id = source_root
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "repo".into());
+
+    // Ensure parent directories exist.
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut db = store::MetadataStore::open(&db_path)?;
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let router = TreeSitterRouter::new();
+
+    let ctx = PipelineContext {
+        repo_id,
+        source_root,
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    let result = indexer::run(&ctx, &mut db, &blob_store)?;
+
+    println!("files_discovered: {}", result.metrics.files_discovered);
+    println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_errored: {}", result.metrics.files_errored);
+    println!("symbols_extracted: {}", result.metrics.symbols_extracted);
+
+    if !result.file_errors.is_empty() {
+        eprintln!();
+        eprintln!("file errors:");
+        for err in &result.file_errors {
+            eprintln!("  {}: {}", err.path.display(), err.error);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod get_symbol;
+pub mod index;
+pub mod search_symbols;

--- a/crates/cli/src/commands/search_symbols.rs
+++ b/crates/cli/src/commands/search_symbols.rs
@@ -1,0 +1,145 @@
+//! `codeatlas search-symbols` command — ranked symbol search.
+
+use std::path::PathBuf;
+
+use core_model::SymbolKind;
+use query_engine::{QueryFilters, QueryService, StoreQueryService, SymbolQuery};
+
+use crate::error::CliError;
+
+pub fn run(args: &[String]) -> Result<(), CliError> {
+    let opts = parse_args(args)?;
+
+    let db = store::MetadataStore::open(&opts.db_path)?;
+    let svc = StoreQueryService::new(&db);
+
+    let query = SymbolQuery {
+        repo_id: opts.repo_id,
+        text: opts.query,
+        filters: QueryFilters {
+            kind: opts.kind,
+            language: opts.language,
+            quality_level: None,
+            file_path: None,
+        },
+        limit: opts.limit,
+        offset: 0,
+    };
+
+    let result = svc.search_symbols(&query)?;
+
+    println!("total_candidates: {}", result.meta.total_candidates);
+    println!("truncated: {}", result.meta.truncated);
+    println!("results:");
+
+    for scored in &result.items {
+        let s = &scored.record;
+        println!(
+            "  - id: {}\n    name: {}\n    kind: {}\n    file: {}:{}\n    score: {:.3}",
+            s.id,
+            s.name,
+            s.kind.as_str(),
+            s.file_path,
+            s.start_line,
+            scored.score,
+        );
+    }
+
+    Ok(())
+}
+
+struct SearchOpts {
+    db_path: PathBuf,
+    repo_id: String,
+    query: String,
+    kind: Option<SymbolKind>,
+    language: Option<String>,
+    limit: usize,
+}
+
+fn parse_args(args: &[String]) -> Result<SearchOpts, CliError> {
+    let mut db_path: Option<PathBuf> = None;
+    let mut repo_id: Option<String> = None;
+    let mut query: Option<String> = None;
+    let mut kind: Option<SymbolKind> = None;
+    let mut language: Option<String> = None;
+    let mut limit: usize = 20;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            "--repo" => {
+                i += 1;
+                repo_id = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--repo requires a value".into()))?
+                        .clone(),
+                );
+            }
+            "--kind" => {
+                i += 1;
+                let val = args
+                    .get(i)
+                    .ok_or_else(|| CliError::Usage("--kind requires a value".into()))?;
+                kind = Some(parse_symbol_kind(val)?);
+            }
+            "--language" => {
+                i += 1;
+                language = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--language requires a value".into()))?
+                        .clone(),
+                );
+            }
+            "--limit" => {
+                i += 1;
+                let val = args
+                    .get(i)
+                    .ok_or_else(|| CliError::Usage("--limit requires a value".into()))?;
+                limit = val
+                    .parse()
+                    .map_err(|_| CliError::Usage(format!("invalid limit: {val}")))?;
+            }
+            arg if !arg.starts_with('-') && query.is_none() => {
+                query = Some(arg.to_string());
+            }
+            other => {
+                return Err(CliError::Usage(format!("unknown option: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let db_path = db_path.ok_or_else(|| CliError::Usage("--db <path> is required".into()))?;
+    let repo_id = repo_id.ok_or_else(|| CliError::Usage("--repo <id> is required".into()))?;
+    let query = query.ok_or_else(|| CliError::Usage("search query text is required".into()))?;
+
+    Ok(SearchOpts {
+        db_path,
+        repo_id,
+        query,
+        kind,
+        language,
+        limit,
+    })
+}
+
+fn parse_symbol_kind(s: &str) -> Result<SymbolKind, CliError> {
+    match s.to_lowercase().as_str() {
+        "function" => Ok(SymbolKind::Function),
+        "class" => Ok(SymbolKind::Class),
+        "method" => Ok(SymbolKind::Method),
+        "type" => Ok(SymbolKind::Type),
+        "constant" => Ok(SymbolKind::Constant),
+        other => Err(CliError::Usage(format!(
+            "unknown symbol kind: {other} (expected: function, class, method, type, constant)"
+        ))),
+    }
+}

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,0 +1,61 @@
+//! CLI error types.
+
+use std::fmt;
+
+/// Unified error type for CLI commands.
+#[derive(Debug)]
+pub enum CliError {
+    Usage(String),
+    Index(indexer::PipelineError),
+    Query(query_engine::QueryError),
+    Store(store::StoreError),
+    Io(std::io::Error),
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Usage(msg) => write!(f, "{msg}"),
+            Self::Index(e) => write!(f, "indexing failed: {e}"),
+            Self::Query(e) => write!(f, "query failed: {e}"),
+            Self::Store(e) => write!(f, "store error: {e}"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for CliError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Index(e) => Some(e),
+            Self::Query(e) => Some(e),
+            Self::Store(e) => Some(e),
+            Self::Io(e) => Some(e),
+            Self::Usage(_) => None,
+        }
+    }
+}
+
+impl From<indexer::PipelineError> for CliError {
+    fn from(e: indexer::PipelineError) -> Self {
+        Self::Index(e)
+    }
+}
+
+impl From<query_engine::QueryError> for CliError {
+    fn from(e: query_engine::QueryError) -> Self {
+        Self::Query(e)
+    }
+}
+
+impl From<store::StoreError> for CliError {
+    fn from(e: store::StoreError) -> Self {
+        Self::Store(e)
+    }
+}
+
+impl From<std::io::Error> for CliError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,0 +1,46 @@
+//! CodeAtlas CLI — local indexing and query commands.
+
+use std::process;
+
+mod commands;
+mod error;
+mod router;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 2 {
+        print_usage();
+        process::exit(1);
+    }
+
+    let result = match args[1].as_str() {
+        "index" => commands::index::run(&args[2..]),
+        "search-symbols" => commands::search_symbols::run(&args[2..]),
+        "get-symbol" => commands::get_symbol::run(&args[2..]),
+        "help" | "--help" | "-h" => {
+            print_usage();
+            Ok(())
+        }
+        other => {
+            eprintln!("error: unknown command '{other}'");
+            print_usage();
+            process::exit(1);
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("error: {e}");
+        process::exit(1);
+    }
+}
+
+fn print_usage() {
+    eprintln!("Usage: codeatlas <command> [options]");
+    eprintln!();
+    eprintln!("Commands:");
+    eprintln!("  index             Index a repository");
+    eprintln!("  search-symbols    Search for symbols by name");
+    eprintln!("  get-symbol        Get a symbol by ID");
+    eprintln!("  help              Show this help message");
+}

--- a/crates/cli/src/router.rs
+++ b/crates/cli/src/router.rs
@@ -1,0 +1,29 @@
+//! Tree-sitter adapter router for CLI usage.
+
+use adapter_api::{AdapterPolicy, AdapterRouter, LanguageAdapter};
+use adapter_syntax_treesitter::{create_adapter, supported_languages, TreeSitterAdapter};
+
+/// Router backed by real tree-sitter adapters for all supported languages.
+pub struct TreeSitterRouter {
+    adapters: Vec<TreeSitterAdapter>,
+}
+
+impl TreeSitterRouter {
+    pub fn new() -> Self {
+        let adapters = supported_languages()
+            .iter()
+            .filter_map(|lang| create_adapter(lang))
+            .collect();
+        Self { adapters }
+    }
+}
+
+impl AdapterRouter for TreeSitterRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        self.adapters
+            .iter()
+            .filter(|a| a.language() == language)
+            .map(|a| a as &dyn LanguageAdapter)
+            .collect()
+    }
+}

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -1,0 +1,307 @@
+//! Integration tests for the CLI commands.
+//!
+//! These tests exercise the CLI binary end-to-end by invoking it as a subprocess.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn codeatlas_bin() -> PathBuf {
+    // Built by `cargo test`, available under target/debug
+    let mut path = std::env::current_exe()
+        .expect("current_exe")
+        .parent()
+        .expect("parent")
+        .parent()
+        .expect("target dir")
+        .to_path_buf();
+    path.push("codeatlas");
+    path
+}
+
+fn setup_test_repo() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let src = dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("lib.rs"),
+        "/// A greeting function.\npub fn greet() {}\npub fn helper() {}\n",
+    )
+    .expect("write lib.rs");
+    std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// Index command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn index_command_succeeds_on_valid_repo() {
+    let repo_dir = setup_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args(["index", repo_dir.path().to_str().unwrap(), "--db"])
+        .arg(&db_path)
+        .output()
+        .expect("run codeatlas index");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "index should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("files_discovered:"));
+    assert!(stdout.contains("files_parsed:"));
+    assert!(stdout.contains("symbols_extracted:"));
+}
+
+#[test]
+fn index_command_fails_on_missing_path() {
+    let output = Command::new(codeatlas_bin())
+        .args(["index"])
+        .output()
+        .expect("run codeatlas index");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("usage:") || stderr.contains("error:"));
+}
+
+#[test]
+fn index_command_fails_on_invalid_path() {
+    let output = Command::new(codeatlas_bin())
+        .args(["index", "/nonexistent/path/surely"])
+        .output()
+        .expect("run codeatlas index");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn index_command_fails_on_trailing_db_flag() {
+    let output = Command::new(codeatlas_bin())
+        .args(["index", "/tmp", "--db"])
+        .output()
+        .expect("run codeatlas index");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--db requires a value"),
+        "should report missing --db value, got: {stderr}"
+    );
+}
+
+#[test]
+fn index_command_fails_on_unknown_flag() {
+    let output = Command::new(codeatlas_bin())
+        .args(["index", "/tmp", "--verbose"])
+        .output()
+        .expect("run codeatlas index");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown option"),
+        "should report unknown option, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Search-symbols command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_symbols_finds_indexed_symbol() {
+    let repo_dir = setup_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("index.db");
+
+    // First, index the repo.
+    let index_output = Command::new(codeatlas_bin())
+        .args(["index", repo_dir.path().to_str().unwrap(), "--db"])
+        .arg(&db_path)
+        .output()
+        .expect("index");
+    assert!(index_output.status.success(), "index should succeed");
+
+    // Derive repo_id from directory name (same logic as CLI).
+    let repo_id = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Search for "greet".
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "search-symbols",
+            "greet",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("search-symbols");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "search should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("greet"),
+        "should find greet symbol.\nstdout: {stdout}"
+    );
+    assert!(stdout.contains("total_candidates:"));
+}
+
+#[test]
+fn search_symbols_fails_without_required_args() {
+    let output = Command::new(codeatlas_bin())
+        .args(["search-symbols"])
+        .output()
+        .expect("search-symbols");
+
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// Get-symbol command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_symbol_retrieves_indexed_symbol() {
+    let repo_dir = setup_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("index.db");
+
+    // Index the repo.
+    let index_output = Command::new(codeatlas_bin())
+        .args(["index", repo_dir.path().to_str().unwrap(), "--db"])
+        .arg(&db_path)
+        .output()
+        .expect("index");
+    assert!(index_output.status.success());
+
+    let repo_id = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // First search to get a symbol ID.
+    let search_output = Command::new(codeatlas_bin())
+        .args([
+            "search-symbols",
+            "greet",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("search");
+    assert!(search_output.status.success());
+
+    let stdout = String::from_utf8_lossy(&search_output.stdout);
+    // Extract the symbol ID from output like "  - id: src/lib.rs::greet#function"
+    let id_line = stdout
+        .lines()
+        .find(|l| l.contains("- id:"))
+        .expect("should have an id line");
+    let symbol_id = id_line.trim().strip_prefix("- id: ").unwrap().trim();
+
+    // Get the symbol by ID.
+    let output = Command::new(codeatlas_bin())
+        .args(["get-symbol", symbol_id, "--db", db_path.to_str().unwrap()])
+        .output()
+        .expect("get-symbol");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "get-symbol should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("name: greet"));
+    assert!(stdout.contains("kind: function"));
+}
+
+#[test]
+fn get_symbol_fails_on_unknown_id() {
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("index.db");
+
+    // Create an empty DB by indexing an empty repo.
+    let repo_dir = TempDir::new().expect("repo");
+    std::fs::write(repo_dir.path().join("dummy.rs"), "fn x() {}\n").expect("write");
+
+    let index_output = Command::new(codeatlas_bin())
+        .args(["index", repo_dir.path().to_str().unwrap(), "--db"])
+        .arg(&db_path)
+        .output()
+        .expect("index");
+    assert!(index_output.status.success());
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "get-symbol",
+            "nonexistent-id",
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("get-symbol");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not found"));
+}
+
+// ---------------------------------------------------------------------------
+// Help / unknown command
+// ---------------------------------------------------------------------------
+
+#[test]
+fn help_flag_shows_usage() {
+    let output = Command::new(codeatlas_bin())
+        .args(["--help"])
+        .output()
+        .expect("help");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Usage:"));
+}
+
+#[test]
+fn unknown_command_fails() {
+    let output = Command::new(codeatlas_bin())
+        .args(["nonexistent-command"])
+        .output()
+        .expect("unknown cmd");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn no_args_shows_usage() {
+    let output = Command::new(codeatlas_bin()).output().expect("no args");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Usage:"));
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #62
  - Scope: Add a new cli crate for local-first workflows with initial commands index, search-symbols, and get-symbol, using deterministic plain-text output by default.

  ## Changes

  - Created new crates/cli crate and added it to workspace members.
  - Added codeatlas binary entrypoint with command routing:
      - index
      - search-symbols
      - get-symbol
      - help
  - Implemented typed CLI error boundary:
      - CliError::Usage
      - CliError::Index(indexer::PipelineError)
      - CliError::Query(query_engine::QueryError)
      - CliError::Store(store::StoreError)
      - CliError::Io(std::io::Error)
  - Implemented index command:
      - Invokes indexer pipeline with tree-sitter router.
      - Supports --db <path> override.
      - Prints deterministic plain output metrics (files_discovered, files_parsed, files_errored, symbols_extracted).
      - Emits explicit usage/errors for malformed args.
  - Implemented search-symbols command:
      - Invokes query-engine symbol search.
      - Supports required --db, --repo, and query text plus optional --kind, --language, --limit.
      - Prints deterministic plain output with metadata + result blocks.
  - Implemented get-symbol command:
      - Invokes query-engine get_symbol.
      - Supports required --db and symbol ID.
      - Prints deterministic plain output of symbol fields.
  - Added adapter router for CLI indexing via adapter-syntax-treesitter.
  - Added integration test suite for CLI subprocess behavior:
      - Command success paths.
      - Missing/invalid argument failures.
      - Unknown command/help behavior.
      - End-to-end index + query flows (search-symbols, get-symbol).
  - Updated workspace manifests/lockfile:
      - Added crates/cli as workspace member.
      - Added cli package entry in Cargo.lock.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: cli crate exists and builds.
  - [x] Criterion 2: Commands invoke indexer/query-engine with typed errors.
  - [x] Criterion 3: CLI integration tests cover basic command success/failure.

  ## Test Evidence

  - [x] cargo fmt --all -- --check
  - [x] cargo clippy --all-targets --all-features -- -D warnings
  - [x] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - Added crates/cli/tests/cli_integration.rs (12 end-to-end CLI tests).

  ## Risk and Mitigation

  - Risk: CLI argument parsing regressions could cause unexpected behavior in local workflows.
  - Mitigation: Explicit usage/error paths are tested (missing args, unknown flags, malformed --db), and subprocess integration tests validate real binary behavior.

  ## Security/Observability Impact

  - Security: No new network surfaces; CLI operates on local filesystem paths and existing store/indexer boundaries.
  - Logs/Metrics/Tracing: No new telemetry pipeline added; CLI outputs deterministic plain text intended for local and script usage.
