### PR TITLE
Create server-mcp crate and tool registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "server-mcp"
+version = "0.1.0"
+dependencies = [
+ "core-model",
+ "query-engine",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/adapter-api", "crates/adapter-syntax-treesitter", "crates/cli", "crates/core-model", "crates/indexer", "crates/query-engine", "crates/repo-walker", "crates/store", "crates/workspace-placeholder"]
+members = ["crates/adapter-api", "crates/adapter-syntax-treesitter", "crates/cli", "crates/core-model", "crates/indexer", "crates/query-engine", "crates/repo-walker", "crates/server-mcp", "crates/store", "crates/workspace-placeholder"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/server-mcp/Cargo.toml
+++ b/crates/server-mcp/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "server-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+[dependencies]
+core-model.workspace = true
+query-engine.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+query-engine = { workspace = true, features = ["test-support"] }

--- a/crates/server-mcp/src/lib.rs
+++ b/crates/server-mcp/src/lib.rs
@@ -1,0 +1,12 @@
+//! MCP tool server for CodeAtlas.
+//!
+//! Provides a tool registry that maps MCP tool names to query-engine
+//! endpoints, returning structured success/error payloads with `_meta`
+//! envelope per spec §10.1.
+
+pub mod registry;
+pub mod tools;
+pub mod types;
+
+pub use registry::ToolRegistry;
+pub use types::{McpError, McpMeta, McpResponse, ToolResult};

--- a/crates/server-mcp/src/registry.rs
+++ b/crates/server-mcp/src/registry.rs
@@ -1,0 +1,97 @@
+//! MCP tool registry — dispatches tool calls by name to query-engine handlers.
+
+use std::time::Instant;
+
+use query_engine::QueryService;
+use serde_json::Value;
+
+use crate::tools;
+use crate::types::{McpError, McpMeta, McpResponse};
+
+/// Tool names recognized by the registry.
+pub const TOOL_NAMES: &[&str] = &[
+    "search_symbols",
+    "get_symbol",
+    "get_symbols",
+    "get_file_outline",
+    "get_file_content",
+    "get_file_tree",
+    "get_repo_outline",
+    "search_text",
+];
+
+/// Central dispatcher that routes MCP tool calls to query-engine handlers.
+///
+/// Holds a reference to a [`QueryService`] implementation and dispatches
+/// incoming requests by tool name.
+pub struct ToolRegistry<'a> {
+    svc: &'a dyn QueryService,
+}
+
+impl<'a> ToolRegistry<'a> {
+    pub fn new(svc: &'a dyn QueryService) -> Self {
+        Self { svc }
+    }
+
+    /// Returns the list of registered tool names.
+    pub fn tool_names(&self) -> &'static [&'static str] {
+        TOOL_NAMES
+    }
+
+    /// Dispatch a tool call by name with the given JSON parameters.
+    ///
+    /// Returns an [`McpResponse`] with either a success payload or a
+    /// structured error. Unknown tool names produce an error response.
+    /// Every response includes `_meta` with timing, truncation, and quality stats.
+    pub fn call(&self, tool_name: &str, params: Value) -> McpResponse {
+        let start = Instant::now();
+
+        let result = match tool_name {
+            "search_symbols" => tools::search_symbols(self.svc, params),
+            "get_symbol" => tools::get_symbol(self.svc, params),
+            "get_symbols" => tools::get_symbols(self.svc, params),
+            "get_file_outline" => tools::get_file_outline(self.svc, params),
+            "get_file_content" => tools::get_file_content(self.svc, params),
+            "get_file_tree" => tools::get_file_tree(self.svc, params),
+            "get_repo_outline" => tools::get_repo_outline(self.svc, params),
+            "search_text" => tools::search_text(self.svc, params),
+            _ => {
+                let meta = McpMeta {
+                    timing_ms: start.elapsed().as_millis() as u64,
+                    ..McpMeta::default()
+                };
+                return McpResponse::error(
+                    McpError::unknown_tool(format!("unknown tool: {tool_name}")),
+                    meta,
+                );
+            }
+        };
+
+        let timing_ms = start.elapsed().as_millis() as u64;
+
+        match result {
+            Ok(output) => {
+                let truncated = output
+                    .payload
+                    .get("truncated")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                let meta = McpMeta {
+                    timing_ms,
+                    truncated,
+                    quality_stats: output.quality_stats,
+                    ..McpMeta::default()
+                };
+                McpResponse::success(output.payload, meta)
+            }
+            Err(err) => {
+                let meta = McpMeta {
+                    timing_ms,
+                    ..McpMeta::default()
+                };
+                McpResponse::error(err, meta)
+            }
+        }
+    }
+}

--- a/crates/server-mcp/src/tools.rs
+++ b/crates/server-mcp/src/tools.rs
@@ -1,0 +1,404 @@
+//! Individual MCP tool handler implementations.
+//!
+//! Each function takes a `&dyn QueryService` and a JSON params value,
+//! deserializes the request, calls the query engine, and returns a
+//! serialized payload or typed error.
+
+use core_model::SymbolKind;
+use query_engine::{
+    FileContentRequest, FileOutlineRequest, FileTreeRequest, QueryFilters, QueryService,
+    RepoOutlineRequest, SymbolQuery, TextQuery,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::types::{McpError, QualityStats, ToolOutput, ToolResult};
+
+// ── Request param types ────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct SearchSymbolsParams {
+    pub repo_id: String,
+    pub query: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    #[serde(default)]
+    pub offset: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GetSymbolParams {
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GetSymbolsParams {
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FileOutlineParams {
+    pub repo_id: String,
+    pub file_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FileContentParams {
+    pub repo_id: String,
+    pub file_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FileTreeParams {
+    pub repo_id: String,
+    #[serde(default)]
+    pub path_prefix: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoOutlineParams {
+    pub repo_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchTextParams {
+    pub repo_id: String,
+    pub pattern: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    #[serde(default)]
+    pub offset: usize,
+}
+
+fn default_limit() -> usize {
+    20
+}
+
+// ── Response serialization helpers ─────────────────────────────────────
+
+#[derive(Serialize)]
+struct SymbolPayload {
+    id: String,
+    name: String,
+    kind: String,
+    qualified_name: String,
+    file_path: String,
+    language: String,
+    signature: String,
+    start_line: u32,
+    end_line: u32,
+    quality_level: String,
+    confidence_score: f32,
+    source_adapter: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    docstring: Option<String>,
+}
+
+impl From<&core_model::SymbolRecord> for SymbolPayload {
+    fn from(r: &core_model::SymbolRecord) -> Self {
+        Self {
+            id: r.id.clone(),
+            name: r.name.clone(),
+            kind: r.kind.as_str().to_string(),
+            qualified_name: r.qualified_name.clone(),
+            file_path: r.file_path.clone(),
+            language: r.language.clone(),
+            signature: r.signature.clone(),
+            start_line: r.start_line,
+            end_line: r.end_line,
+            quality_level: format!("{:?}", r.quality_level).to_lowercase(),
+            confidence_score: r.confidence_score,
+            source_adapter: r.source_adapter.clone(),
+            docstring: r.docstring.clone(),
+        }
+    }
+}
+
+/// Serialize a `SymbolPayload` to JSON, returning an `McpError::Internal` on failure.
+fn serialize_symbol(record: &core_model::SymbolRecord) -> Result<serde_json::Value, McpError> {
+    serde_json::to_value(SymbolPayload::from(record))
+        .map_err(|e| McpError::internal(format!("failed to serialize symbol: {e}")))
+}
+
+// ── Quality stats computation ─────────────────────────────────────────
+
+/// Compute quality mix from a slice of symbol records.
+fn compute_quality_stats(records: &[&core_model::SymbolRecord]) -> QualityStats {
+    if records.is_empty() {
+        return QualityStats::default();
+    }
+    let total = records.len() as f64;
+    let semantic = records
+        .iter()
+        .filter(|r| r.quality_level == core_model::QualityLevel::Semantic)
+        .count() as f64;
+    QualityStats {
+        semantic_percent: (semantic / total) * 100.0,
+        syntax_percent: ((total - semantic) / total) * 100.0,
+    }
+}
+
+// ── Tool handlers ──────────────────────────────────────────────────────
+
+pub fn search_symbols(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: SearchSymbolsParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let kind = p.kind.as_deref().map(parse_symbol_kind).transpose()?;
+
+    let query = SymbolQuery {
+        repo_id: p.repo_id,
+        text: p.query,
+        filters: QueryFilters {
+            kind,
+            language: p.language,
+            quality_level: None,
+            file_path: None,
+        },
+        limit: p.limit,
+        offset: p.offset,
+    };
+
+    let result = svc.search_symbols(&query)?;
+
+    let refs: Vec<&core_model::SymbolRecord> = result.items.iter().map(|s| &s.record).collect();
+    let quality_stats = compute_quality_stats(&refs);
+
+    let mut items: Vec<serde_json::Value> = Vec::with_capacity(result.items.len());
+    for scored in &result.items {
+        let mut val = serialize_symbol(&scored.record)?;
+        let obj = val
+            .as_object_mut()
+            .ok_or_else(|| McpError::internal("serialized symbol is not an object"))?;
+        obj.insert("score".into(), json!(scored.score));
+        items.push(val);
+    }
+
+    Ok(ToolOutput {
+        payload: json!({
+            "items": items,
+            "total_candidates": result.meta.total_candidates,
+            "truncated": result.meta.truncated,
+        }),
+        quality_stats,
+    })
+}
+
+pub fn get_symbol(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: GetSymbolParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let record = svc.get_symbol(&p.id)?;
+    let quality_stats = compute_quality_stats(&[&record]);
+    Ok(ToolOutput {
+        payload: serialize_symbol(&record)?,
+        quality_stats,
+    })
+}
+
+pub fn get_symbols(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: GetSymbolsParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let id_refs: Vec<&str> = p.ids.iter().map(|s| s.as_str()).collect();
+    let records = svc.get_symbols(&id_refs)?;
+
+    let refs: Vec<&core_model::SymbolRecord> = records.iter().collect();
+    let quality_stats = compute_quality_stats(&refs);
+
+    let mut items: Vec<serde_json::Value> = Vec::with_capacity(records.len());
+    for r in &records {
+        items.push(serialize_symbol(r)?);
+    }
+
+    Ok(ToolOutput {
+        payload: json!({ "items": items }),
+        quality_stats,
+    })
+}
+
+pub fn get_file_outline(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: FileOutlineParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let outline = svc.get_file_outline(&FileOutlineRequest {
+        repo_id: p.repo_id,
+        file_path: p.file_path,
+    })?;
+
+    let refs: Vec<&core_model::SymbolRecord> = outline.symbols.iter().collect();
+    let quality_stats = compute_quality_stats(&refs);
+
+    let mut symbols: Vec<serde_json::Value> = Vec::with_capacity(outline.symbols.len());
+    for s in &outline.symbols {
+        symbols.push(serialize_symbol(s)?);
+    }
+
+    Ok(ToolOutput {
+        payload: json!({
+            "file": {
+                "file_path": outline.file.file_path,
+                "language": outline.file.language,
+                "symbol_count": outline.file.symbol_count,
+            },
+            "symbols": symbols,
+        }),
+        quality_stats,
+    })
+}
+
+pub fn get_file_content(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: FileContentParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let content = svc.get_file_content(&FileContentRequest {
+        repo_id: p.repo_id,
+        file_path: p.file_path,
+    })?;
+
+    Ok(ToolOutput {
+        payload: json!({
+            "file": {
+                "file_path": content.file.file_path,
+                "language": content.file.language,
+                "symbol_count": content.file.symbol_count,
+            },
+            "content": content.content,
+        }),
+        quality_stats: QualityStats::default(),
+    })
+}
+
+pub fn get_file_tree(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: FileTreeParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let entries = svc.get_file_tree(&FileTreeRequest {
+        repo_id: p.repo_id,
+        path_prefix: p.path_prefix,
+    })?;
+
+    let items: Vec<serde_json::Value> = entries
+        .iter()
+        .map(|e| {
+            json!({
+                "path": e.path,
+                "language": e.language,
+                "symbol_count": e.symbol_count,
+            })
+        })
+        .collect();
+
+    Ok(ToolOutput {
+        payload: json!({ "entries": items }),
+        quality_stats: QualityStats::default(),
+    })
+}
+
+pub fn get_repo_outline(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: RepoOutlineParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let outline = svc.get_repo_outline(&RepoOutlineRequest { repo_id: p.repo_id })?;
+
+    let files: Vec<serde_json::Value> = outline
+        .files
+        .iter()
+        .map(|e| {
+            json!({
+                "path": e.path,
+                "language": e.language,
+                "symbol_count": e.symbol_count,
+            })
+        })
+        .collect();
+
+    Ok(ToolOutput {
+        payload: json!({
+            "repo": {
+                "repo_id": outline.repo.repo_id,
+                "display_name": outline.repo.display_name,
+                "file_count": outline.repo.file_count,
+                "symbol_count": outline.repo.symbol_count,
+                "language_counts": outline.repo.language_counts,
+            },
+            "files": files,
+        }),
+        quality_stats: QualityStats::default(),
+    })
+}
+
+pub fn search_text(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: SearchTextParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let kind = p.kind.as_deref().map(parse_symbol_kind).transpose()?;
+
+    let query = TextQuery {
+        repo_id: p.repo_id,
+        pattern: p.pattern,
+        filters: QueryFilters {
+            kind,
+            language: p.language,
+            quality_level: None,
+            file_path: None,
+        },
+        limit: p.limit,
+        offset: p.offset,
+    };
+
+    let result = svc.search_text(&query)?;
+
+    let symbol_refs: Vec<&core_model::SymbolRecord> = result
+        .items
+        .iter()
+        .filter_map(|m| m.symbol.as_ref())
+        .collect();
+    let quality_stats = compute_quality_stats(&symbol_refs);
+
+    let items: Vec<serde_json::Value> = result
+        .items
+        .iter()
+        .map(|m| {
+            json!({
+                "file_path": m.file_path,
+                "line_number": m.line_number,
+                "line_content": m.line_content,
+                "score": m.score,
+                "symbol": m.symbol.as_ref().map(SymbolPayload::from),
+            })
+        })
+        .collect();
+
+    Ok(ToolOutput {
+        payload: json!({
+            "items": items,
+            "total_candidates": result.meta.total_candidates,
+            "truncated": result.meta.truncated,
+        }),
+        quality_stats,
+    })
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+fn parse_symbol_kind(s: &str) -> Result<SymbolKind, McpError> {
+    match s.to_lowercase().as_str() {
+        "function" => Ok(SymbolKind::Function),
+        "class" => Ok(SymbolKind::Class),
+        "method" => Ok(SymbolKind::Method),
+        "type" => Ok(SymbolKind::Type),
+        "constant" => Ok(SymbolKind::Constant),
+        other => Err(McpError::invalid_params(format!(
+            "unknown symbol kind: {other}"
+        ))),
+    }
+}

--- a/crates/server-mcp/src/types.rs
+++ b/crates/server-mcp/src/types.rs
@@ -1,0 +1,171 @@
+//! MCP request/response envelope types.
+
+use serde::{Deserialize, Serialize};
+
+/// Unified MCP tool response envelope.
+///
+/// Every tool returns this structure with either a `"success"` or `"error"` status.
+/// The `_meta` field carries timing, truncation, and quality metadata per spec §10.1.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpResponse {
+    pub status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<McpError>,
+    pub _meta: McpMeta,
+}
+
+/// Envelope metadata returned with every MCP tool response (spec §10.1).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpMeta {
+    /// Wall-clock time for the tool call in milliseconds.
+    pub timing_ms: u64,
+    /// Whether the result set was truncated by a limit.
+    pub truncated: bool,
+    /// Semantic/syntax quality mix of the returned results.
+    pub quality_stats: QualityStats,
+    /// Schema version of the index that served the query.
+    pub index_version: String,
+}
+
+/// Quality mix statistics for MCP result sets.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QualityStats {
+    pub semantic_percent: f64,
+    pub syntax_percent: f64,
+}
+
+impl Default for QualityStats {
+    fn default() -> Self {
+        Self {
+            semantic_percent: 0.0,
+            syntax_percent: 100.0,
+        }
+    }
+}
+
+impl Default for McpMeta {
+    fn default() -> Self {
+        Self {
+            timing_ms: 0,
+            truncated: false,
+            quality_stats: QualityStats::default(),
+            index_version: core_model::schema_version::current_index_schema_version().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    Success,
+    Error,
+}
+
+/// Structured error payload for MCP tool responses.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpError {
+    pub code: ErrorCode,
+    pub message: String,
+    pub retryable: bool,
+}
+
+/// Error codes for MCP tool failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    InvalidParams,
+    NotFound,
+    StoreError,
+    UnknownTool,
+    Internal,
+}
+
+/// Output returned by tool handlers to the registry.
+///
+/// Carries both the serialized JSON payload and the computed quality mix
+/// from the actual records returned, so the registry can populate `_meta`
+/// with accurate `quality_stats`.
+pub struct ToolOutput {
+    pub payload: serde_json::Value,
+    pub quality_stats: QualityStats,
+}
+
+/// Convenience result type for tool handlers.
+pub type ToolResult = Result<ToolOutput, McpError>;
+
+impl McpResponse {
+    /// Create a success response with the given payload and metadata.
+    pub fn success(payload: serde_json::Value, meta: McpMeta) -> Self {
+        Self {
+            status: Status::Success,
+            payload: Some(payload),
+            error: None,
+            _meta: meta,
+        }
+    }
+
+    /// Create an error response with the given error and metadata.
+    pub fn error(err: McpError, meta: McpMeta) -> Self {
+        Self {
+            status: Status::Error,
+            payload: None,
+            error: Some(err),
+            _meta: meta,
+        }
+    }
+}
+
+impl McpError {
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::InvalidParams,
+            message: message.into(),
+            retryable: false,
+        }
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::NotFound,
+            message: message.into(),
+            retryable: false,
+        }
+    }
+
+    pub fn store_error(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::StoreError,
+            message: message.into(),
+            retryable: true,
+        }
+    }
+
+    pub fn unknown_tool(name: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::UnknownTool,
+            message: name.into(),
+            retryable: false,
+        }
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self {
+            code: ErrorCode::Internal,
+            message: message.into(),
+            retryable: false,
+        }
+    }
+}
+
+/// Maps a [`query_engine::QueryError`] to an [`McpError`].
+impl From<query_engine::QueryError> for McpError {
+    fn from(e: query_engine::QueryError) -> Self {
+        match &e {
+            query_engine::QueryError::EmptyQuery => McpError::invalid_params(e.to_string()),
+            query_engine::QueryError::NotFound { .. } => McpError::not_found(e.to_string()),
+            query_engine::QueryError::Store(_) => McpError::store_error(e.to_string()),
+        }
+    }
+}

--- a/crates/server-mcp/tests/registry_integration.rs
+++ b/crates/server-mcp/tests/registry_integration.rs
@@ -1,0 +1,444 @@
+//! Integration tests for the MCP tool registry.
+//!
+//! Uses the in-memory StubQueryService from query-engine's test-support
+//! feature to exercise all tool handlers end-to-end.
+
+use query_engine::test_support::StubQueryService;
+use serde_json::json;
+
+use server_mcp::types::{ErrorCode, Status};
+use server_mcp::{McpResponse, ToolRegistry};
+
+fn call(tool: &str, params: serde_json::Value) -> McpResponse {
+    let svc = StubQueryService::new();
+    let reg = ToolRegistry::new(&svc);
+    reg.call(tool, params)
+}
+
+// ---------------------------------------------------------------------------
+// Registry basics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn registry_lists_all_eight_tools() {
+    let svc = StubQueryService::new();
+    let reg = ToolRegistry::new(&svc);
+    let names = reg.tool_names();
+    assert_eq!(names.len(), 8);
+    assert!(names.contains(&"search_symbols"));
+    assert!(names.contains(&"get_symbol"));
+    assert!(names.contains(&"get_symbols"));
+    assert!(names.contains(&"get_file_outline"));
+    assert!(names.contains(&"get_file_content"));
+    assert!(names.contains(&"get_file_tree"));
+    assert!(names.contains(&"get_repo_outline"));
+    assert!(names.contains(&"search_text"));
+}
+
+#[test]
+fn unknown_tool_returns_error() {
+    let resp = call("nonexistent_tool", json!({}));
+    assert_eq!(resp.status, Status::Error);
+    let err = resp.error.unwrap();
+    assert_eq!(err.code, ErrorCode::UnknownTool);
+    assert!(!err.retryable);
+}
+
+// ---------------------------------------------------------------------------
+// _meta envelope contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn success_response_carries_meta_with_timing() {
+    let resp = call("get_file_tree", json!({ "repo_id": "repo-1" }));
+    assert_eq!(resp.status, Status::Success);
+    // timing_ms is populated (may be 0 for fast in-memory calls, but field exists)
+    let _ = resp._meta.timing_ms;
+    assert!(!resp._meta.index_version.is_empty());
+}
+
+#[test]
+fn error_response_carries_meta() {
+    let resp = call("get_symbol", json!({ "id": "missing" }));
+    assert_eq!(resp.status, Status::Error);
+    assert!(!resp._meta.index_version.is_empty());
+}
+
+#[test]
+fn meta_truncated_reflects_payload_truncation() {
+    // With limit=1 and 2 matches, truncated should be true.
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "alpha", "limit": 1 }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    assert!(resp._meta.truncated);
+
+    // With large limit, truncated should be false.
+    let resp2 = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "beta", "limit": 100 }),
+    );
+    assert!(!resp2._meta.truncated);
+}
+
+#[test]
+fn meta_quality_stats_defaults_to_syntax_for_non_symbol_tools() {
+    let resp = call("get_file_tree", json!({ "repo_id": "repo-1" }));
+    assert!((resp._meta.quality_stats.syntax_percent - 100.0).abs() < f64::EPSILON);
+    assert!((resp._meta.quality_stats.semantic_percent - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn meta_quality_stats_computed_from_symbol_results() {
+    // StubQueryService symbols all have QualityLevel::Syntax,
+    // so search_symbols should report 100% syntax.
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "alpha" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    assert!((resp._meta.quality_stats.syntax_percent - 100.0).abs() < f64::EPSILON);
+    assert!((resp._meta.quality_stats.semantic_percent - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn meta_quality_stats_computed_for_get_symbol() {
+    let svc = StubQueryService::new();
+    let id = svc.symbols[0].id.clone();
+    let reg = ToolRegistry::new(&svc);
+    let resp = reg.call("get_symbol", json!({ "id": id }));
+    assert_eq!(resp.status, Status::Success);
+    assert!((resp._meta.quality_stats.syntax_percent - 100.0).abs() < f64::EPSILON);
+    assert!((resp._meta.quality_stats.semantic_percent - 0.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn meta_index_version_is_semver() {
+    let resp = call("get_file_tree", json!({ "repo_id": "repo-1" }));
+    let parts: Vec<&str> = resp._meta.index_version.split('.').collect();
+    assert_eq!(parts.len(), 3, "index_version should be semver");
+}
+
+#[test]
+fn unknown_tool_error_also_carries_meta() {
+    let resp = call("bad_tool", json!({}));
+    assert_eq!(resp.status, Status::Error);
+    assert!(!resp._meta.index_version.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// search_symbols
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_symbols_returns_matching_results() {
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "alpha" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    let items = payload["items"].as_array().unwrap();
+    assert!(!items.is_empty());
+    assert!(payload["total_candidates"].as_u64().unwrap() > 0);
+}
+
+#[test]
+fn search_symbols_empty_query_returns_error() {
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "  " }),
+    );
+    assert_eq!(resp.status, Status::Error);
+    let err = resp.error.unwrap();
+    assert_eq!(err.code, ErrorCode::InvalidParams);
+    assert!(!err.retryable);
+}
+
+#[test]
+fn search_symbols_invalid_params_returns_error() {
+    let resp = call("search_symbols", json!({}));
+    assert_eq!(resp.status, Status::Error);
+    assert_eq!(resp.error.unwrap().code, ErrorCode::InvalidParams);
+}
+
+#[test]
+fn search_symbols_with_kind_filter() {
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "alpha", "kind": "type" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let items = resp.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["kind"], "type");
+}
+
+#[test]
+fn search_symbols_invalid_kind_returns_error() {
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "alpha", "kind": "widget" }),
+    );
+    assert_eq!(resp.status, Status::Error);
+    assert_eq!(resp.error.unwrap().code, ErrorCode::InvalidParams);
+}
+
+#[test]
+fn search_symbols_carries_score() {
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "beta" }),
+    );
+    let items = resp.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert!(!items.is_empty());
+    assert!(items[0]["score"].as_f64().unwrap() > 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// get_symbol
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_symbol_returns_record() {
+    let svc = StubQueryService::new();
+    let id = svc.symbols[0].id.clone();
+    let reg = ToolRegistry::new(&svc);
+    let resp = reg.call("get_symbol", json!({ "id": id }));
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["id"], id);
+    assert_eq!(payload["name"], "alpha");
+}
+
+#[test]
+fn get_symbol_not_found() {
+    let resp = call("get_symbol", json!({ "id": "nonexistent" }));
+    assert_eq!(resp.status, Status::Error);
+    assert_eq!(resp.error.unwrap().code, ErrorCode::NotFound);
+}
+
+// ---------------------------------------------------------------------------
+// get_symbols
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_symbols_returns_found_records() {
+    let svc = StubQueryService::new();
+    let ids: Vec<String> = svc.symbols.iter().take(2).map(|s| s.id.clone()).collect();
+    let reg = ToolRegistry::new(&svc);
+    let resp = reg.call("get_symbols", json!({ "ids": ids }));
+    assert_eq!(resp.status, Status::Success);
+    let items = resp.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert_eq!(items.len(), 2);
+}
+
+#[test]
+fn get_symbols_skips_missing() {
+    let svc = StubQueryService::new();
+    let ids = vec![svc.symbols[0].id.clone(), "missing".to_string()];
+    let reg = ToolRegistry::new(&svc);
+    let resp = reg.call("get_symbols", json!({ "ids": ids }));
+    assert_eq!(resp.status, Status::Success);
+    let items = resp.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert_eq!(items.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// get_file_outline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_file_outline_returns_file_and_symbols() {
+    let resp = call(
+        "get_file_outline",
+        json!({ "repo_id": "repo-1", "file_path": "src/lib.rs" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["file_path"], "src/lib.rs");
+    assert!(!payload["symbols"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn get_file_outline_not_found() {
+    let resp = call(
+        "get_file_outline",
+        json!({ "repo_id": "repo-1", "file_path": "nonexistent.rs" }),
+    );
+    assert_eq!(resp.status, Status::Error);
+    assert_eq!(resp.error.unwrap().code, ErrorCode::NotFound);
+}
+
+// ---------------------------------------------------------------------------
+// get_file_content
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_file_content_returns_content() {
+    let resp = call(
+        "get_file_content",
+        json!({ "repo_id": "repo-1", "file_path": "src/lib.rs" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["file_path"], "src/lib.rs");
+    assert!(payload["content"].is_string());
+}
+
+// ---------------------------------------------------------------------------
+// get_file_tree
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_file_tree_returns_entries() {
+    let resp = call("get_file_tree", json!({ "repo_id": "repo-1" }));
+    assert_eq!(resp.status, Status::Success);
+    let entries = resp.payload.unwrap()["entries"].as_array().unwrap().clone();
+    assert_eq!(entries.len(), 2);
+}
+
+#[test]
+fn get_file_tree_with_prefix() {
+    let resp = call(
+        "get_file_tree",
+        json!({ "repo_id": "repo-1", "path_prefix": "src/main" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let entries = resp.payload.unwrap()["entries"].as_array().unwrap().clone();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["path"], "src/main.rs");
+}
+
+// ---------------------------------------------------------------------------
+// get_repo_outline
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_repo_outline_returns_repo_and_files() {
+    let resp = call("get_repo_outline", json!({ "repo_id": "repo-1" }));
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["repo"]["repo_id"], "repo-1");
+    assert!(!payload["files"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn get_repo_outline_not_found() {
+    let resp = call("get_repo_outline", json!({ "repo_id": "unknown" }));
+    assert_eq!(resp.status, Status::Error);
+    assert_eq!(resp.error.unwrap().code, ErrorCode::NotFound);
+}
+
+// ---------------------------------------------------------------------------
+// search_text
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_text_empty_pattern_returns_error() {
+    let resp = call(
+        "search_text",
+        json!({ "repo_id": "repo-1", "pattern": "  " }),
+    );
+    assert_eq!(resp.status, Status::Error);
+    assert_eq!(resp.error.unwrap().code, ErrorCode::InvalidParams);
+}
+
+#[test]
+fn search_text_returns_structured_result() {
+    let resp = call(
+        "search_text",
+        json!({ "repo_id": "repo-1", "pattern": "hello" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert!(payload["items"].is_array());
+    assert!(payload["total_candidates"].is_number());
+    assert!(payload["truncated"].is_boolean());
+}
+
+// ---------------------------------------------------------------------------
+// Response envelope structure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn success_response_has_no_error_field() {
+    let resp = call("get_file_tree", json!({ "repo_id": "repo-1" }));
+    assert_eq!(resp.status, Status::Success);
+    assert!(resp.payload.is_some());
+    assert!(resp.error.is_none());
+}
+
+#[test]
+fn error_response_has_no_payload_field() {
+    let resp = call("get_symbol", json!({ "id": "missing" }));
+    assert_eq!(resp.status, Status::Error);
+    assert!(resp.payload.is_none());
+    assert!(resp.error.is_some());
+}
+
+#[test]
+fn response_round_trips_through_json() {
+    let resp = call("get_file_tree", json!({ "repo_id": "repo-1" }));
+    let json_str = serde_json::to_string(&resp).expect("serialize");
+    let deserialized: McpResponse = serde_json::from_str(&json_str).expect("deserialize");
+    assert_eq!(resp, deserialized);
+}
+
+#[test]
+fn error_response_round_trips_through_json() {
+    let resp = call("get_symbol", json!({ "id": "missing" }));
+    let json_str = serde_json::to_string(&resp).expect("serialize");
+    let deserialized: McpResponse = serde_json::from_str(&json_str).expect("deserialize");
+    assert_eq!(resp, deserialized);
+}
+
+// ---------------------------------------------------------------------------
+// Provenance: source_adapter in symbol payloads
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_symbol_carries_source_adapter() {
+    let svc = StubQueryService::new();
+    let id = svc.symbols[0].id.clone();
+    let reg = ToolRegistry::new(&svc);
+    let resp = reg.call("get_symbol", json!({ "id": id }));
+    let payload = resp.payload.unwrap();
+    let adapter = payload["source_adapter"].as_str().unwrap();
+    assert!(
+        !adapter.is_empty(),
+        "source_adapter should be non-empty, got: {adapter}"
+    );
+}
+
+#[test]
+fn search_symbols_results_carry_source_adapter() {
+    let resp = call(
+        "search_symbols",
+        json!({ "repo_id": "repo-1", "query": "alpha" }),
+    );
+    let items = resp.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert!(!items.is_empty());
+    for item in &items {
+        assert!(
+            item["source_adapter"].is_string(),
+            "each search result should have source_adapter"
+        );
+    }
+}
+
+#[test]
+fn get_file_outline_symbols_carry_source_adapter() {
+    let resp = call(
+        "get_file_outline",
+        json!({ "repo_id": "repo-1", "file_path": "src/lib.rs" }),
+    );
+    let symbols = resp.payload.unwrap()["symbols"].as_array().unwrap().clone();
+    for sym in &symbols {
+        assert!(
+            sym["source_adapter"].is_string(),
+            "outline symbols should carry source_adapter"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

  Implements issue #36 by adding a new server-mcp crate with a tool registry that routes MCP tool calls to query-engine, returning structured success/error envelopes with _meta per spec §10.1.

  Closes #36

  ## What Changed

  - Added new workspace crate: crates/server-mcp
  - Added MCP tool registry with 8 registered tools:
      - search_symbols
      - get_symbol
      - get_symbols
      - get_file_outline
      - get_file_content
      - get_file_tree
      - get_repo_outline
      - search_text
  - Wired each tool to typed query-engine requests/responses
  - Added structured response envelope:
      - status (success/error)
      - payload (success)
      - error (code/message/retryable)
      - _meta (timing_ms, truncated, quality_stats, index_version)
  - Added query-error to MCP-error mapping (InvalidParams, NotFound, StoreError, etc.)
  - Added symbol payload provenance (source_adapter) and quality fields
  - Replaced panic-prone serialization paths with internal error returns
  - Added comprehensive integration tests for:
      - registry tool coverage/callability
      - success/error envelope behavior
      - _meta contract fields and truncation propagation
      - quality stats computation for symbol-returning tools
      - provenance fields in payloads

  ## Workspace / Dependency Changes

  - Added crates/server-mcp to workspace members in root Cargo.toml
  - Lockfile updated for new package entry (server-mcp)

  ## Validation

  Executed successfully:

  - cargo fmt --check
  - cargo clippy --workspace --all-targets --all-features -- -D warnings
  - cargo test --workspace --all-features

  ## Acceptance Criteria Mapping

  - [x] server-mcp crate exists and builds
  - [x] Core tools are registered and callable
  - [x] Requests route to query-engine with typed responses
