### PR TITLE
Add CLI outline commands (file-outline, file-tree, repo-outline)

### DIFF
--- a/crates/cli/src/commands/file_outline.rs
+++ b/crates/cli/src/commands/file_outline.rs
@@ -1,0 +1,86 @@
+//! `codeatlas file-outline` command — lists symbols in a file.
+
+use std::path::PathBuf;
+
+use query_engine::{FileOutlineRequest, QueryService, StoreQueryService};
+
+use crate::error::CliError;
+
+pub fn run(args: &[String]) -> Result<(), CliError> {
+    let opts = parse_args(args)?;
+
+    let db = store::MetadataStore::open(&opts.db_path)?;
+    let svc = StoreQueryService::new(&db);
+
+    let outline = svc.get_file_outline(&FileOutlineRequest {
+        repo_id: opts.repo_id,
+        file_path: opts.file_path,
+    })?;
+
+    println!("file: {}", outline.file.file_path);
+    println!("language: {}", outline.file.language);
+    println!("symbol_count: {}", outline.file.symbol_count);
+    println!("symbols:");
+
+    for s in &outline.symbols {
+        println!(
+            "  - name: {}\n    kind: {}\n    line: {}",
+            s.name,
+            s.kind.as_str(),
+            s.start_line,
+        );
+    }
+
+    Ok(())
+}
+
+struct FileOutlineOpts {
+    db_path: PathBuf,
+    repo_id: String,
+    file_path: String,
+}
+
+fn parse_args(args: &[String]) -> Result<FileOutlineOpts, CliError> {
+    let mut db_path: Option<PathBuf> = None;
+    let mut repo_id: Option<String> = None;
+    let mut file_path: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            "--repo" => {
+                i += 1;
+                repo_id = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--repo requires a value".into()))?
+                        .clone(),
+                );
+            }
+            arg if !arg.starts_with('-') && file_path.is_none() => {
+                file_path = Some(arg.to_string());
+            }
+            other => {
+                return Err(CliError::Usage(format!("unknown option: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let db_path = db_path.ok_or_else(|| CliError::Usage("--db <path> is required".into()))?;
+    let repo_id = repo_id.ok_or_else(|| CliError::Usage("--repo <id> is required".into()))?;
+    let file_path =
+        file_path.ok_or_else(|| CliError::Usage("file path argument is required".into()))?;
+
+    Ok(FileOutlineOpts {
+        db_path,
+        repo_id,
+        file_path,
+    })
+}

--- a/crates/cli/src/commands/file_tree.rs
+++ b/crates/cli/src/commands/file_tree.rs
@@ -1,0 +1,83 @@
+//! `codeatlas file-tree` command — lists files in a repository.
+
+use std::path::PathBuf;
+
+use query_engine::{FileTreeRequest, QueryService, StoreQueryService};
+
+use crate::error::CliError;
+
+pub fn run(args: &[String]) -> Result<(), CliError> {
+    let opts = parse_args(args)?;
+
+    let db = store::MetadataStore::open(&opts.db_path)?;
+    let svc = StoreQueryService::new(&db);
+
+    let entries = svc.get_file_tree(&FileTreeRequest {
+        repo_id: opts.repo_id,
+        path_prefix: opts.path_prefix,
+    })?;
+
+    println!("entries: {}", entries.len());
+    for e in &entries {
+        println!(
+            "  - path: {}\n    language: {}\n    symbols: {}",
+            e.path, e.language, e.symbol_count
+        );
+    }
+
+    Ok(())
+}
+
+struct FileTreeOpts {
+    db_path: PathBuf,
+    repo_id: String,
+    path_prefix: Option<String>,
+}
+
+fn parse_args(args: &[String]) -> Result<FileTreeOpts, CliError> {
+    let mut db_path: Option<PathBuf> = None;
+    let mut repo_id: Option<String> = None;
+    let mut path_prefix: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            "--repo" => {
+                i += 1;
+                repo_id = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--repo requires a value".into()))?
+                        .clone(),
+                );
+            }
+            "--prefix" => {
+                i += 1;
+                path_prefix = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--prefix requires a value".into()))?
+                        .clone(),
+                );
+            }
+            other => {
+                return Err(CliError::Usage(format!("unknown option: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let db_path = db_path.ok_or_else(|| CliError::Usage("--db <path> is required".into()))?;
+    let repo_id = repo_id.ok_or_else(|| CliError::Usage("--repo <id> is required".into()))?;
+
+    Ok(FileTreeOpts {
+        db_path,
+        repo_id,
+        path_prefix,
+    })
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,3 +1,6 @@
+pub mod file_outline;
+pub mod file_tree;
 pub mod get_symbol;
 pub mod index;
+pub mod repo_outline;
 pub mod search_symbols;

--- a/crates/cli/src/commands/repo_outline.rs
+++ b/crates/cli/src/commands/repo_outline.rs
@@ -1,0 +1,73 @@
+//! `codeatlas repo-outline` command — shows repository structure overview.
+
+use std::path::PathBuf;
+
+use query_engine::{QueryService, RepoOutlineRequest, StoreQueryService};
+
+use crate::error::CliError;
+
+pub fn run(args: &[String]) -> Result<(), CliError> {
+    let opts = parse_args(args)?;
+
+    let db = store::MetadataStore::open(&opts.db_path)?;
+    let svc = StoreQueryService::new(&db);
+
+    let outline = svc.get_repo_outline(&RepoOutlineRequest {
+        repo_id: opts.repo_id,
+    })?;
+
+    println!("repo_id: {}", outline.repo.repo_id);
+    println!("display_name: {}", outline.repo.display_name);
+    println!("file_count: {}", outline.repo.file_count);
+    println!("symbol_count: {}", outline.repo.symbol_count);
+    println!("files:");
+
+    for f in &outline.files {
+        println!(
+            "  - path: {}\n    language: {}\n    symbols: {}",
+            f.path, f.language, f.symbol_count,
+        );
+    }
+
+    Ok(())
+}
+
+struct RepoOutlineOpts {
+    db_path: PathBuf,
+    repo_id: String,
+}
+
+fn parse_args(args: &[String]) -> Result<RepoOutlineOpts, CliError> {
+    let mut db_path: Option<PathBuf> = None;
+    let mut repo_id: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            "--repo" => {
+                i += 1;
+                repo_id = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--repo requires a value".into()))?
+                        .clone(),
+                );
+            }
+            other => {
+                return Err(CliError::Usage(format!("unknown option: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let db_path = db_path.ok_or_else(|| CliError::Usage("--db <path> is required".into()))?;
+    let repo_id = repo_id.ok_or_else(|| CliError::Usage("--repo <id> is required".into()))?;
+
+    Ok(RepoOutlineOpts { db_path, repo_id })
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -18,6 +18,9 @@ fn main() {
         "index" => commands::index::run(&args[2..]),
         "search-symbols" => commands::search_symbols::run(&args[2..]),
         "get-symbol" => commands::get_symbol::run(&args[2..]),
+        "file-outline" => commands::file_outline::run(&args[2..]),
+        "file-tree" => commands::file_tree::run(&args[2..]),
+        "repo-outline" => commands::repo_outline::run(&args[2..]),
         "help" | "--help" | "-h" => {
             print_usage();
             Ok(())
@@ -42,5 +45,8 @@ fn print_usage() {
     eprintln!("  index             Index a repository");
     eprintln!("  search-symbols    Search for symbols by name");
     eprintln!("  get-symbol        Get a symbol by ID");
+    eprintln!("  file-outline      List symbols in a file");
+    eprintln!("  file-tree         List files in a repository");
+    eprintln!("  repo-outline      Show repository structure overview");
     eprintln!("  help              Show this help message");
 }

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -272,6 +272,227 @@ fn get_symbol_fails_on_unknown_id() {
 }
 
 // ---------------------------------------------------------------------------
+// Shared helper: index a test repo and return (repo_dir, db_dir, repo_id)
+// ---------------------------------------------------------------------------
+
+fn indexed_test_repo() -> (TempDir, TempDir, String) {
+    let repo_dir = setup_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("index.db");
+
+    let index_output = Command::new(codeatlas_bin())
+        .args(["index", repo_dir.path().to_str().unwrap(), "--db"])
+        .arg(&db_path)
+        .output()
+        .expect("index");
+    assert!(index_output.status.success(), "index should succeed");
+
+    let repo_id = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    (repo_dir, db_dir, repo_id)
+}
+
+// ---------------------------------------------------------------------------
+// file-outline command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn file_outline_shows_symbols() {
+    let (_repo_dir, db_dir, repo_id) = indexed_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "file-outline",
+            "src/lib.rs",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("file-outline");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "file-outline should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("file: src/lib.rs"));
+    assert!(stdout.contains("name: greet"));
+    assert!(stdout.contains("kind: function"));
+}
+
+#[test]
+fn file_outline_not_found() {
+    let (_repo_dir, db_dir, repo_id) = indexed_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "file-outline",
+            "nonexistent.rs",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("file-outline");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not found"));
+}
+
+#[test]
+fn file_outline_fails_without_required_args() {
+    let output = Command::new(codeatlas_bin())
+        .args(["file-outline"])
+        .output()
+        .expect("file-outline");
+
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// file-tree command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn file_tree_lists_files() {
+    let (_repo_dir, db_dir, repo_id) = indexed_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "file-tree",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("file-tree");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "file-tree should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("entries:"));
+    assert!(stdout.contains("src/lib.rs"));
+    assert!(stdout.contains("src/main.rs"));
+}
+
+#[test]
+fn file_tree_with_prefix_filter() {
+    let (_repo_dir, db_dir, repo_id) = indexed_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "file-tree",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+            "--prefix",
+            "src/lib",
+        ])
+        .output()
+        .expect("file-tree");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("src/lib.rs"));
+    assert!(!stdout.contains("src/main.rs"));
+}
+
+#[test]
+fn file_tree_fails_without_required_args() {
+    let output = Command::new(codeatlas_bin())
+        .args(["file-tree"])
+        .output()
+        .expect("file-tree");
+
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
+// repo-outline command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repo_outline_shows_structure() {
+    let (_repo_dir, db_dir, repo_id) = indexed_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo-outline",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("repo-outline");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "repo-outline should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains(&format!("repo_id: {repo_id}")));
+    assert!(stdout.contains("file_count:"));
+    assert!(stdout.contains("symbol_count:"));
+    assert!(stdout.contains("files:"));
+}
+
+#[test]
+fn repo_outline_not_found() {
+    let (_repo_dir, db_dir, _repo_id) = indexed_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo-outline",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            "nonexistent-repo",
+        ])
+        .output()
+        .expect("repo-outline");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not found"));
+}
+
+#[test]
+fn repo_outline_fails_without_required_args() {
+    let output = Command::new(codeatlas_bin())
+        .args(["repo-outline"])
+        .output()
+        .expect("repo-outline");
+
+    assert!(!output.status.success());
+}
+
+// ---------------------------------------------------------------------------
 // Help / unknown command
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

  - Issue: Closes #70
  - Scope: Add CLI structure-navigation commands (file-outline, file-tree, repo-outline) with deterministic output and consistent error handling, plus integration coverage.

  ## Changes

  - Added new CLI commands:
      - crates/cli/src/commands/file_outline.rs
      - crates/cli/src/commands/file_tree.rs
      - crates/cli/src/commands/repo_outline.rs
  - Wired new commands into CLI dispatch and help text:
      - crates/cli/src/main.rs
      - crates/cli/src/commands/mod.rs
  - Added integration tests for all new commands in:
      - crates/cli/tests/cli_integration.rs
  - New test coverage includes:
      - success cases for file-outline, file-tree, repo-outline
      - failure/not-found cases
      - required-args usage failures
      - prefix filtering for file-tree

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: CLI outline commands implemented.
      - Added and wired file-outline, file-tree, repo-outline.
  - [x] Criterion 2: Integration tests cover all outline commands.
      - Added integration tests for each command with success/failure paths.

  ## Test Evidence

  - [x] cargo fmt --all -- --check
  - [x] cargo clippy --all-targets --all-features -- -D warnings
  - [x] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - CLI integration suite expanded to 21 tests, including new outline command coverage.

  ## Risk and Mitigation

  - Risk: CLI output format changes can break tests or downstream parsing expectations.
  - Mitigation: Kept output deterministic and validated via integration tests for each new command path.

  ## Security/Observability Impact

  - Security: No new privileged behavior; commands query existing metadata store via existing query-engine APIs.
  - Logs/Metrics/Tracing: No new logging/metrics/tracing surfaces introduced by this change.
