### PR TITLE
Implement file hash map and changed-file detection

### DIFF
--- a/crates/indexer/src/change_detection.rs
+++ b/crates/indexer/src/change_detection.rs
@@ -1,0 +1,170 @@
+//! File-level change detection for incremental indexing.
+//!
+//! Compares discovered files against a persisted hash map (from the metadata
+//! store) to classify each file as changed, new, or unchanged. Files present
+//! in the hash map but absent from discovery are implicitly deleted — handled
+//! by the existing `delete_except` logic in the persist stage.
+//!
+//! See spec §8.5 (Incremental Indexing).
+
+use std::collections::HashMap;
+
+use crate::stage::PreparedFile;
+
+/// Classification of discovered files relative to the previous index.
+#[derive(Debug)]
+pub struct ChangeSet {
+    /// Indices into the discovery file list for files that are new or changed.
+    pub changed_indices: Vec<usize>,
+    /// Number of files that were unchanged (hash match).
+    pub unchanged_count: usize,
+    /// Number of files that are new (not in previous index).
+    pub new_count: usize,
+    /// Number of files whose content hash changed.
+    pub modified_count: usize,
+}
+
+/// Computes which discovered files need re-indexing by comparing their content
+/// hashes against the previously persisted hash map.
+///
+/// - Files whose path is absent from `previous_hashes` are **new**.
+/// - Files whose hash differs from `previous_hashes` are **modified**.
+/// - Files whose hash matches are **unchanged** and can be skipped.
+///
+/// Returns a [`ChangeSet`] with indices into `files` for changed/new entries.
+pub fn detect_changes(
+    files: &[PreparedFile],
+    previous_hashes: &HashMap<String, String>,
+) -> ChangeSet {
+    let mut changed_indices = Vec::new();
+    let mut unchanged_count = 0usize;
+    let mut new_count = 0usize;
+    let mut modified_count = 0usize;
+
+    for (i, file) in files.iter().enumerate() {
+        let path = file.relative_path.to_string_lossy();
+        let current_hash = store::content_hash(&file.content);
+
+        match previous_hashes.get(path.as_ref()) {
+            None => {
+                // New file — not in previous index.
+                new_count += 1;
+                changed_indices.push(i);
+            }
+            Some(prev_hash) if *prev_hash != current_hash => {
+                // Modified file — hash changed.
+                modified_count += 1;
+                changed_indices.push(i);
+            }
+            Some(_) => {
+                // Unchanged — skip re-indexing.
+                unchanged_count += 1;
+            }
+        }
+    }
+
+    ChangeSet {
+        changed_indices,
+        unchanged_count,
+        new_count,
+        modified_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn make_file(path: &str, content: &[u8]) -> PreparedFile {
+        PreparedFile {
+            relative_path: PathBuf::from(path),
+            absolute_path: PathBuf::from("/tmp").join(path),
+            language: "rust".to_string(),
+            content: content.to_vec(),
+        }
+    }
+
+    #[test]
+    fn all_new_files_when_no_previous_hashes() {
+        let files = vec![
+            make_file("src/main.rs", b"fn main() {}"),
+            make_file("src/lib.rs", b"pub fn foo() {}"),
+        ];
+        let previous = HashMap::new();
+
+        let cs = detect_changes(&files, &previous);
+        assert_eq!(cs.changed_indices, vec![0, 1]);
+        assert_eq!(cs.new_count, 2);
+        assert_eq!(cs.modified_count, 0);
+        assert_eq!(cs.unchanged_count, 0);
+    }
+
+    #[test]
+    fn unchanged_files_skipped() {
+        let content = b"fn main() {}";
+        let hash = store::content_hash(content);
+        let files = vec![make_file("src/main.rs", content)];
+        let mut previous = HashMap::new();
+        previous.insert("src/main.rs".to_string(), hash);
+
+        let cs = detect_changes(&files, &previous);
+        assert!(cs.changed_indices.is_empty());
+        assert_eq!(cs.unchanged_count, 1);
+        assert_eq!(cs.new_count, 0);
+        assert_eq!(cs.modified_count, 0);
+    }
+
+    #[test]
+    fn modified_file_detected() {
+        let files = vec![make_file("src/main.rs", b"fn main() { updated }")];
+        let mut previous = HashMap::new();
+        previous.insert(
+            "src/main.rs".to_string(),
+            store::content_hash(b"fn main() {}"),
+        );
+
+        let cs = detect_changes(&files, &previous);
+        assert_eq!(cs.changed_indices, vec![0]);
+        assert_eq!(cs.modified_count, 1);
+        assert_eq!(cs.new_count, 0);
+        assert_eq!(cs.unchanged_count, 0);
+    }
+
+    #[test]
+    fn mixed_new_modified_unchanged() {
+        let unchanged_content = b"unchanged";
+        let unchanged_hash = store::content_hash(unchanged_content);
+
+        let files = vec![
+            make_file("a.rs", unchanged_content),   // unchanged
+            make_file("b.rs", b"modified content"), // modified
+            make_file("c.rs", b"brand new"),        // new
+        ];
+
+        let mut previous = HashMap::new();
+        previous.insert("a.rs".to_string(), unchanged_hash);
+        previous.insert("b.rs".to_string(), store::content_hash(b"old content"));
+        // c.rs not in previous — it's new
+        // d.rs was in previous but not in discovery — implicitly deleted
+
+        let cs = detect_changes(&files, &previous);
+        assert_eq!(cs.changed_indices, vec![1, 2]);
+        assert_eq!(cs.unchanged_count, 1);
+        assert_eq!(cs.modified_count, 1);
+        assert_eq!(cs.new_count, 1);
+    }
+
+    #[test]
+    fn empty_discovery_produces_empty_changeset() {
+        let files: Vec<PreparedFile> = vec![];
+        let mut previous = HashMap::new();
+        previous.insert("old.rs".to_string(), "somehash".to_string());
+
+        let cs = detect_changes(&files, &previous);
+        assert!(cs.changed_indices.is_empty());
+        assert_eq!(cs.unchanged_count, 0);
+        assert_eq!(cs.new_count, 0);
+        assert_eq!(cs.modified_count, 0);
+    }
+}

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -9,11 +9,13 @@
 
 use std::path::PathBuf;
 
+pub mod change_detection;
 pub mod context;
 pub mod enrich;
 pub mod pipeline;
 pub mod stage;
 
+pub use change_detection::{detect_changes, ChangeSet};
 pub use context::PipelineContext;
 pub use pipeline::{run, IndexMetrics, IndexResult};
 pub use stage::{DiscoveryOutput, FileError, ParseOutput, ParsedFile, PreparedFile};

--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 use tracing::info;
 
+use crate::change_detection;
 use crate::context::PipelineContext;
 use crate::stage::{self, DiscoveryOutput, FileError, ParseOutput};
 use crate::PipelineError;
@@ -15,6 +16,8 @@ pub struct IndexMetrics {
     pub files_parsed: usize,
     pub files_errored: usize,
     pub symbols_extracted: usize,
+    /// Files skipped because their content hash matched the previous index.
+    pub files_unchanged: usize,
 }
 
 /// Result of a successful pipeline run.
@@ -42,8 +45,48 @@ pub fn run(
     // Stage 1: Discovery
     let discovery: DiscoveryOutput = stage::discover(ctx)?;
 
-    // Stage 2: Parse
-    let parse_output: ParseOutput = stage::parse(ctx, &discovery);
+    // Stage 1.5: Change detection — load previous file hashes and classify
+    // discovered files as new, modified, or unchanged. Only changed/new
+    // files are sent to the parse stage; unchanged files are skipped.
+    let previous_hashes = store
+        .files()
+        .list_hash_map(&ctx.repo_id)
+        .map_err(PipelineError::Persist)?;
+
+    let change_set = change_detection::detect_changes(&discovery.files, &previous_hashes);
+
+    let files_unchanged = change_set.unchanged_count;
+
+    if files_unchanged > 0 {
+        info!(
+            unchanged = files_unchanged,
+            new = change_set.new_count,
+            modified = change_set.modified_count,
+            "change detection complete"
+        );
+    }
+
+    // Build a filtered discovery output containing only changed/new files.
+    // The full discovery output is still passed to persist for stale cleanup.
+    let changed_discovery = DiscoveryOutput {
+        files: change_set
+            .changed_indices
+            .iter()
+            .map(|&i| {
+                let f = &discovery.files[i];
+                stage::PreparedFile {
+                    relative_path: f.relative_path.clone(),
+                    absolute_path: f.absolute_path.clone(),
+                    language: f.language.clone(),
+                    content: f.content.clone(),
+                }
+            })
+            .collect(),
+        metrics: discovery.metrics.clone(),
+    };
+
+    // Stage 2: Parse (only changed/new files)
+    let parse_output: ParseOutput = stage::parse(ctx, &changed_discovery);
 
     let symbols_extracted: usize = parse_output
         .parsed_files
@@ -52,6 +95,8 @@ pub fn run(
         .sum();
 
     // Stage 3: Persist (blobs first, then metadata in a transaction)
+    // Pass the full discovery for stale file cleanup, but only parsed
+    // changed/new files for upserts.
     stage::persist(ctx, store, blob_store, &discovery, &parse_output)?;
 
     let metrics = IndexMetrics {
@@ -64,12 +109,14 @@ pub fn run(
             .collect::<HashSet<_>>()
             .len(),
         symbols_extracted,
+        files_unchanged,
     };
 
     info!(
         files_discovered = metrics.files_discovered,
         files_parsed = metrics.files_parsed,
         files_errored = metrics.files_errored,
+        files_unchanged = metrics.files_unchanged,
         symbols_extracted = metrics.symbols_extracted,
         "pipeline complete"
     );

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -764,7 +764,9 @@ fn reindex_removes_stale_files_and_recomputes_aggregates() {
     // Remove lib.rs and re-index.
     std::fs::remove_file(src.join("lib.rs")).expect("remove lib.rs");
     let r2 = run(&ctx, &mut db, &blob_store).expect("second run");
-    assert_eq!(r2.metrics.files_parsed, 1);
+    // main.rs is unchanged, so incremental indexing skips it.
+    assert_eq!(r2.metrics.files_parsed, 0);
+    assert_eq!(r2.metrics.files_unchanged, 1);
 
     // Verify stale file was removed.
     assert!(
@@ -1208,9 +1210,10 @@ fn reindex_with_adapter_failure_preserves_previously_indexed_file() {
     };
 
     let r2 = run(&ctx2, &mut db, &blob_store).expect("second run");
-    // Only main.rs should parse; lib.rs fails.
-    assert_eq!(r2.metrics.files_parsed, 1);
-    assert!(r2.metrics.files_errored >= 1);
+    // Both files are unchanged from the first run, so incremental indexing
+    // skips them entirely — the failing adapter is never invoked.
+    assert_eq!(r2.metrics.files_parsed, 0);
+    assert_eq!(r2.metrics.files_unchanged, 2);
 
     // lib.rs file record should still exist (not purged by stale cleanup).
     assert!(
@@ -1273,4 +1276,205 @@ fn pipeline_error_display_covers_all_variants() {
 
     let internal = PipelineError::Internal("oops".to_string());
     assert!(internal.to_string().contains("internal error"));
+}
+
+// ---------------------------------------------------------------------------
+// Incremental indexing: file hash map and changed-file detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn incremental_noop_run_skips_all_files() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "incr-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // First run: full index.
+    let r1 = run(&ctx, &mut db, &blob_store).expect("first run");
+    assert_eq!(r1.metrics.files_parsed, 1);
+    assert_eq!(r1.metrics.files_unchanged, 0);
+
+    // Second run: no changes — should be a no-op.
+    let r2 = run(&ctx, &mut db, &blob_store).expect("second run");
+    assert_eq!(r2.metrics.files_parsed, 0, "no files should be re-parsed");
+    assert_eq!(r2.metrics.files_unchanged, 1);
+    assert_eq!(r2.metrics.symbols_extracted, 0);
+
+    // Metadata should still be intact from the first run.
+    let repo = db
+        .repos()
+        .get("incr-repo")
+        .expect("query repo")
+        .expect("repo record");
+    assert_eq!(repo.file_count, 1);
+    assert!(repo.symbol_count >= 1);
+
+    let file = db
+        .files()
+        .get("incr-repo", "main.rs")
+        .expect("query file")
+        .expect("file record");
+    assert_eq!(file.language, "rust");
+    assert!(file.symbol_count >= 1);
+}
+
+#[test]
+fn incremental_detects_modified_file_and_reindexes() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("lib.rs"), "pub fn alpha() {}\n").expect("write lib.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "incr-mod-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // First run.
+    run(&ctx, &mut db, &blob_store).expect("first run");
+    let syms_before = db
+        .symbols()
+        .list_ids_for_file("incr-mod-repo", "lib.rs")
+        .expect("list symbols");
+    assert_eq!(syms_before.len(), 1);
+
+    // Modify the file: add a second function.
+    std::fs::write(
+        repo_dir.path().join("lib.rs"),
+        "pub fn alpha() {}\npub fn beta() {}\n",
+    )
+    .expect("rewrite lib.rs");
+
+    // Second run: should detect the change and re-index.
+    let r2 = run(&ctx, &mut db, &blob_store).expect("second run");
+    assert_eq!(
+        r2.metrics.files_parsed, 1,
+        "modified file should be re-parsed"
+    );
+    assert_eq!(r2.metrics.files_unchanged, 0);
+
+    // Verify the new symbol was added.
+    let syms_after = db
+        .symbols()
+        .list_ids_for_file("incr-mod-repo", "lib.rs")
+        .expect("list symbols");
+    assert_eq!(syms_after.len(), 2, "should now have alpha + beta");
+}
+
+#[test]
+fn incremental_detects_new_file() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "incr-new-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // First run.
+    run(&ctx, &mut db, &blob_store).expect("first run");
+
+    // Add a new file.
+    std::fs::write(repo_dir.path().join("lib.rs"), "pub fn helper() {}\n").expect("write lib.rs");
+
+    // Second run: main.rs unchanged, lib.rs new.
+    let r2 = run(&ctx, &mut db, &blob_store).expect("second run");
+    assert_eq!(r2.metrics.files_parsed, 1, "only new file should be parsed");
+    assert_eq!(r2.metrics.files_unchanged, 1, "main.rs unchanged");
+
+    // Both files should be in the store.
+    let repo = db
+        .repos()
+        .get("incr-new-repo")
+        .expect("query repo")
+        .expect("repo record");
+    assert_eq!(repo.file_count, 2);
+
+    assert!(
+        db.files().get("incr-new-repo", "lib.rs").unwrap().is_some(),
+        "new file should be indexed"
+    );
+    assert!(
+        db.files()
+            .get("incr-new-repo", "main.rs")
+            .unwrap()
+            .is_some(),
+        "unchanged file should still be present"
+    );
+}
+
+#[test]
+fn incremental_hash_map_persists_across_runs() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
+    std::fs::write(repo_dir.path().join("lib.rs"), "pub fn foo() {}\n").expect("write lib.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "hash-persist-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // First run populates the hash map.
+    run(&ctx, &mut db, &blob_store).expect("first run");
+
+    let hash_map = db
+        .files()
+        .list_hash_map("hash-persist-repo")
+        .expect("list hash map");
+    assert_eq!(
+        hash_map.len(),
+        2,
+        "hash map should have entries for both files"
+    );
+    assert!(hash_map.contains_key("main.rs"));
+    assert!(hash_map.contains_key("lib.rs"));
+
+    // Verify hashes match content_hash of actual file content.
+    let main_content = std::fs::read(repo_dir.path().join("main.rs")).unwrap();
+    let expected_hash = store::content_hash(&main_content);
+    assert_eq!(hash_map["main.rs"], expected_hash);
+
+    // Third run with no changes should still find the same hash map.
+    run(&ctx, &mut db, &blob_store).expect("second run");
+    let hash_map2 = db
+        .files()
+        .list_hash_map("hash-persist-repo")
+        .expect("list hash map");
+    assert_eq!(
+        hash_map, hash_map2,
+        "hash map should be stable across no-op runs"
+    );
 }

--- a/crates/store/src/file_store.rs
+++ b/crates/store/src/file_store.rs
@@ -134,6 +134,29 @@ impl<'a> FileStore<'a> {
         Ok(changed as u64)
     }
 
+    /// Returns a map of `file_path -> file_hash` for all files in a repository.
+    ///
+    /// This is the persistent file hash map used for incremental indexing:
+    /// compare current content hashes against this map to detect changed,
+    /// new, and unchanged files without re-parsing.
+    pub fn list_hash_map(
+        &self,
+        repo_id: &str,
+    ) -> Result<std::collections::HashMap<String, String>, StoreError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT file_path, file_hash FROM files WHERE repo_id = ?1 ORDER BY file_path",
+        )?;
+        let rows = stmt.query_map(params![repo_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut map = std::collections::HashMap::new();
+        for row in rows {
+            let (path, hash) = row?;
+            map.insert(path, hash);
+        }
+        Ok(map)
+    }
+
     /// Returns the total number of file records for a repository.
     pub fn count(&self, repo_id: &str) -> Result<u64, StoreError> {
         let count: i64 = self.conn.query_row(
@@ -384,6 +407,39 @@ mod tests {
         f2.file_path = "src/lib.rs".to_string();
         store.files().upsert(&f2).unwrap();
         assert_eq!(store.files().count("test-repo").unwrap(), 2);
+    }
+
+    #[test]
+    fn list_hash_map_returns_path_to_hash_mapping() {
+        let store = setup_store_with_repo();
+        let mut f1 = test_file();
+        f1.file_path = "src/main.rs".to_string();
+        f1.file_hash = "sha256:aaa".to_string();
+        let mut f2 = test_file();
+        f2.file_path = "src/lib.rs".to_string();
+        f2.file_hash = "sha256:bbb".to_string();
+
+        store.files().upsert(&f1).unwrap();
+        store.files().upsert(&f2).unwrap();
+
+        let map = store.files().list_hash_map("test-repo").unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get("src/main.rs").unwrap(), "sha256:aaa");
+        assert_eq!(map.get("src/lib.rs").unwrap(), "sha256:bbb");
+    }
+
+    #[test]
+    fn list_hash_map_returns_empty_for_no_files() {
+        let store = setup_store_with_repo();
+        let map = store.files().list_hash_map("test-repo").unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn list_hash_map_returns_empty_for_unknown_repo() {
+        let store = setup_store_with_repo();
+        let map = store.files().list_hash_map("unknown-repo").unwrap();
+        assert!(map.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  - Issue: Closes #40
  - Scope: Implement persistent file-hash lookup and incremental changed-file detection so unchanged files are skipped during re-index runs.

  ## Changes

  - Added store::FileStore::list_hash_map() to load persisted file_path -> file_hash entries for a repo.
  - Added indexer::change_detection with detect_changes() and unit tests for new, modified, unchanged, and empty discovery cases.
  - Updated the indexing pipeline to:
      - load previous file hashes before parse
      - classify discovered files as changed/new/unchanged
      - parse only changed/new files
      - continue using full discovery during persist so deleted files are still removed by stale cleanup
  - Extended pipeline metrics with files_unchanged.
  - Updated integration coverage for incremental indexing behavior:
      - no-op runs skip all files
      - modified files are re-indexed
      - new files are indexed while unchanged files are skipped
      - persisted hash map remains stable across runs
      - stale-file cleanup and aggregate recomputation still work with incremental parsing

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Hash map persists across index runs.
  - [x] Criterion 2: Changed/new/deleted detection is correct in tests.
  - [x] Criterion 3: No-op runs perform zero unnecessary re-index work.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional test evidence run locally:

  - [x] cargo test -p indexer incremental_ -- --nocapture
  - [x] cargo test -p indexer --test pipeline_integration -- --nocapture
  - [x] cargo test -p store file_store -- --nocapture

  ## Risk and Mitigation

  - Risk: Incremental skipping could preserve stale metadata if unchanged-file detection were incorrect.
  - Mitigation: Hash comparison is based on persisted file_hash values, changed/new/no-op paths are covered by unit and integration tests, and deleted files still flow through existing stale cleanup based on full discovery.

  ## Security/Observability Impact

  - Security: No new external interfaces or privilege changes; behavior is limited to internal indexing metadata and file-content hash comparison.
  - Logs/Metrics/Tracing: Added files_unchanged reporting and change-detection log fields for unchanged/new/modified counts.