### PR TITLE
Implement incremental reindex and deleted-file cleanup

### DIFF
--- a/crates/indexer/src/change_detection.rs
+++ b/crates/indexer/src/change_detection.rs
@@ -1,13 +1,11 @@
 //! File-level change detection for incremental indexing.
 //!
 //! Compares discovered files against a persisted hash map (from the metadata
-//! store) to classify each file as changed, new, or unchanged. Files present
-//! in the hash map but absent from discovery are implicitly deleted — handled
-//! by the existing `delete_except` logic in the persist stage.
+//! store) to classify each file as changed, new, unchanged, or deleted.
 //!
 //! See spec §8.5 (Incremental Indexing).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::stage::PreparedFile;
 
@@ -22,6 +20,11 @@ pub struct ChangeSet {
     pub new_count: usize,
     /// Number of files whose content hash changed.
     pub modified_count: usize,
+    /// Paths of files present in the previous index but absent from the
+    /// current discovery (i.e. deleted from disk). The persist stage removes
+    /// these via `delete_except`; this field surfaces them for metrics and
+    /// telemetry.
+    pub deleted_paths: Vec<String>,
 }
 
 /// Computes which discovered files need re-indexing by comparing their content
@@ -30,8 +33,10 @@ pub struct ChangeSet {
 /// - Files whose path is absent from `previous_hashes` are **new**.
 /// - Files whose hash differs from `previous_hashes` are **modified**.
 /// - Files whose hash matches are **unchanged** and can be skipped.
+/// - Files in `previous_hashes` but not in `files` are **deleted**.
 ///
-/// Returns a [`ChangeSet`] with indices into `files` for changed/new entries.
+/// Returns a [`ChangeSet`] with indices into `files` for changed/new entries,
+/// plus the list of deleted paths.
 pub fn detect_changes(
     files: &[PreparedFile],
     previous_hashes: &HashMap<String, String>,
@@ -47,27 +52,38 @@ pub fn detect_changes(
 
         match previous_hashes.get(path.as_ref()) {
             None => {
-                // New file — not in previous index.
                 new_count += 1;
                 changed_indices.push(i);
             }
             Some(prev_hash) if *prev_hash != current_hash => {
-                // Modified file — hash changed.
                 modified_count += 1;
                 changed_indices.push(i);
             }
             Some(_) => {
-                // Unchanged — skip re-indexing.
                 unchanged_count += 1;
             }
         }
     }
+
+    // Compute deleted paths: in previous_hashes but not in discovered files.
+    let discovered_set: HashSet<String> = files
+        .iter()
+        .map(|f| f.relative_path.to_string_lossy().into_owned())
+        .collect();
+
+    let mut deleted_paths: Vec<String> = previous_hashes
+        .keys()
+        .filter(|p| !discovered_set.contains(p.as_str()))
+        .cloned()
+        .collect();
+    deleted_paths.sort();
 
     ChangeSet {
         changed_indices,
         unchanged_count,
         new_count,
         modified_count,
+        deleted_paths,
     }
 }
 
@@ -98,6 +114,7 @@ mod tests {
         assert_eq!(cs.new_count, 2);
         assert_eq!(cs.modified_count, 0);
         assert_eq!(cs.unchanged_count, 0);
+        assert!(cs.deleted_paths.is_empty());
     }
 
     #[test]
@@ -113,6 +130,7 @@ mod tests {
         assert_eq!(cs.unchanged_count, 1);
         assert_eq!(cs.new_count, 0);
         assert_eq!(cs.modified_count, 0);
+        assert!(cs.deleted_paths.is_empty());
     }
 
     #[test]
@@ -129,10 +147,27 @@ mod tests {
         assert_eq!(cs.modified_count, 1);
         assert_eq!(cs.new_count, 0);
         assert_eq!(cs.unchanged_count, 0);
+        assert!(cs.deleted_paths.is_empty());
     }
 
     #[test]
-    fn mixed_new_modified_unchanged() {
+    fn deleted_files_detected() {
+        let content = b"fn main() {}";
+        let hash = store::content_hash(content);
+        let files = vec![make_file("src/main.rs", content)];
+        let mut previous = HashMap::new();
+        previous.insert("src/main.rs".to_string(), hash);
+        previous.insert("src/old.rs".to_string(), "oldhash".to_string());
+        previous.insert("src/gone.rs".to_string(), "gonehash".to_string());
+
+        let cs = detect_changes(&files, &previous);
+        assert!(cs.changed_indices.is_empty());
+        assert_eq!(cs.unchanged_count, 1);
+        assert_eq!(cs.deleted_paths, vec!["src/gone.rs", "src/old.rs"]);
+    }
+
+    #[test]
+    fn mixed_new_modified_unchanged_deleted() {
         let unchanged_content = b"unchanged";
         let unchanged_hash = store::content_hash(unchanged_content);
 
@@ -145,18 +180,20 @@ mod tests {
         let mut previous = HashMap::new();
         previous.insert("a.rs".to_string(), unchanged_hash);
         previous.insert("b.rs".to_string(), store::content_hash(b"old content"));
+        previous.insert("d.rs".to_string(), "deleted_hash".to_string());
         // c.rs not in previous — it's new
-        // d.rs was in previous but not in discovery — implicitly deleted
+        // d.rs in previous but not in discovery — deleted
 
         let cs = detect_changes(&files, &previous);
         assert_eq!(cs.changed_indices, vec![1, 2]);
         assert_eq!(cs.unchanged_count, 1);
         assert_eq!(cs.modified_count, 1);
         assert_eq!(cs.new_count, 1);
+        assert_eq!(cs.deleted_paths, vec!["d.rs"]);
     }
 
     #[test]
-    fn empty_discovery_produces_empty_changeset() {
+    fn empty_discovery_detects_all_as_deleted() {
         let files: Vec<PreparedFile> = vec![];
         let mut previous = HashMap::new();
         previous.insert("old.rs".to_string(), "somehash".to_string());
@@ -166,5 +203,18 @@ mod tests {
         assert_eq!(cs.unchanged_count, 0);
         assert_eq!(cs.new_count, 0);
         assert_eq!(cs.modified_count, 0);
+        assert_eq!(cs.deleted_paths, vec!["old.rs"]);
+    }
+
+    #[test]
+    fn deleted_paths_are_sorted() {
+        let files: Vec<PreparedFile> = vec![];
+        let mut previous = HashMap::new();
+        previous.insert("z.rs".to_string(), "h1".to_string());
+        previous.insert("a.rs".to_string(), "h2".to_string());
+        previous.insert("m.rs".to_string(), "h3".to_string());
+
+        let cs = detect_changes(&files, &previous);
+        assert_eq!(cs.deleted_paths, vec!["a.rs", "m.rs", "z.rs"]);
     }
 }

--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -18,6 +18,8 @@ pub struct IndexMetrics {
     pub symbols_extracted: usize,
     /// Files skipped because their content hash matched the previous index.
     pub files_unchanged: usize,
+    /// Files removed from the index because they were deleted from disk.
+    pub files_deleted: usize,
 }
 
 /// Result of a successful pipeline run.
@@ -56,12 +58,14 @@ pub fn run(
     let change_set = change_detection::detect_changes(&discovery.files, &previous_hashes);
 
     let files_unchanged = change_set.unchanged_count;
+    let files_deleted = change_set.deleted_paths.len();
 
-    if files_unchanged > 0 {
+    if files_unchanged > 0 || files_deleted > 0 {
         info!(
             unchanged = files_unchanged,
             new = change_set.new_count,
             modified = change_set.modified_count,
+            deleted = files_deleted,
             "change detection complete"
         );
     }
@@ -110,6 +114,7 @@ pub fn run(
             .len(),
         symbols_extracted,
         files_unchanged,
+        files_deleted,
     };
 
     info!(
@@ -117,6 +122,7 @@ pub fn run(
         files_parsed = metrics.files_parsed,
         files_errored = metrics.files_errored,
         files_unchanged = metrics.files_unchanged,
+        files_deleted = metrics.files_deleted,
         symbols_extracted = metrics.symbols_extracted,
         "pipeline complete"
     );

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -767,6 +767,7 @@ fn reindex_removes_stale_files_and_recomputes_aggregates() {
     // main.rs is unchanged, so incremental indexing skips it.
     assert_eq!(r2.metrics.files_parsed, 0);
     assert_eq!(r2.metrics.files_unchanged, 1);
+    assert_eq!(r2.metrics.files_deleted, 1);
 
     // Verify stale file was removed.
     assert!(
@@ -1304,11 +1305,13 @@ fn incremental_noop_run_skips_all_files() {
     let r1 = run(&ctx, &mut db, &blob_store).expect("first run");
     assert_eq!(r1.metrics.files_parsed, 1);
     assert_eq!(r1.metrics.files_unchanged, 0);
+    assert_eq!(r1.metrics.files_deleted, 0);
 
     // Second run: no changes — should be a no-op.
     let r2 = run(&ctx, &mut db, &blob_store).expect("second run");
     assert_eq!(r2.metrics.files_parsed, 0, "no files should be re-parsed");
     assert_eq!(r2.metrics.files_unchanged, 1);
+    assert_eq!(r2.metrics.files_deleted, 0);
     assert_eq!(r2.metrics.symbols_extracted, 0);
 
     // Metadata should still be intact from the first run.
@@ -1406,6 +1409,7 @@ fn incremental_detects_new_file() {
     let r2 = run(&ctx, &mut db, &blob_store).expect("second run");
     assert_eq!(r2.metrics.files_parsed, 1, "only new file should be parsed");
     assert_eq!(r2.metrics.files_unchanged, 1, "main.rs unchanged");
+    assert_eq!(r2.metrics.files_deleted, 0);
 
     // Both files should be in the store.
     let repo = db
@@ -1477,4 +1481,332 @@ fn incremental_hash_map_persists_across_runs() {
         hash_map, hash_map2,
         "hash map should be stable across no-op runs"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Incremental reindex: deleted-file cleanup and lifecycle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn incremental_deleted_file_removes_symbols_and_updates_aggregates() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
+    std::fs::write(
+        repo_dir.path().join("lib.rs"),
+        "pub fn alpha() {}\npub fn beta() {}\n",
+    )
+    .expect("write lib.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "del-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // Run 1: index both files.
+    let r1 = run(&ctx, &mut db, &blob_store).expect("run 1");
+    assert_eq!(r1.metrics.files_parsed, 2);
+    assert_eq!(r1.metrics.files_deleted, 0);
+
+    let repo = db.repos().get("del-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 2);
+    let initial_symbol_count = repo.symbol_count;
+    assert!(initial_symbol_count >= 3, "main + alpha + beta");
+
+    // Verify lib.rs symbols exist.
+    let lib_syms = db
+        .symbols()
+        .list_ids_for_file("del-repo", "lib.rs")
+        .unwrap();
+    assert!(lib_syms.len() >= 2, "alpha + beta");
+
+    // Delete lib.rs from disk.
+    std::fs::remove_file(repo_dir.path().join("lib.rs")).expect("remove lib.rs");
+
+    // Run 2: lib.rs deleted, main.rs unchanged.
+    let r2 = run(&ctx, &mut db, &blob_store).expect("run 2");
+    assert_eq!(r2.metrics.files_parsed, 0, "main.rs unchanged");
+    assert_eq!(r2.metrics.files_unchanged, 1);
+    assert_eq!(r2.metrics.files_deleted, 1);
+
+    // lib.rs file record should be gone.
+    assert!(
+        db.files().get("del-repo", "lib.rs").unwrap().is_none(),
+        "deleted file record should be removed"
+    );
+
+    // lib.rs symbols should be gone (cascade delete).
+    let lib_syms_after = db
+        .symbols()
+        .list_ids_for_file("del-repo", "lib.rs")
+        .unwrap();
+    assert!(
+        lib_syms_after.is_empty(),
+        "symbols for deleted file should be removed"
+    );
+
+    // Hash map should no longer contain lib.rs.
+    let hash_map = db.files().list_hash_map("del-repo").unwrap();
+    assert!(!hash_map.contains_key("lib.rs"));
+    assert!(hash_map.contains_key("main.rs"));
+
+    // Aggregates should reflect the deletion.
+    let repo = db.repos().get("del-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 1);
+    assert!(
+        repo.symbol_count < initial_symbol_count,
+        "symbol count should decrease"
+    );
+    assert_eq!(repo.language_counts.get("rust"), Some(&1));
+}
+
+#[test]
+fn incremental_full_lifecycle_add_modify_delete() {
+    // This test exercises the complete incremental lifecycle over 5 runs:
+    // Run 1: Initial index (2 files)
+    // Run 2: No-op (nothing changed)
+    // Run 3: Add new file + modify existing file
+    // Run 4: Delete one file
+    // Run 5: No-op after deletion
+
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
+    std::fs::write(repo_dir.path().join("lib.rs"), "pub fn greet() {}\n").expect("write lib.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "lifecycle-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // --- Run 1: Initial index ---
+    let r1 = run(&ctx, &mut db, &blob_store).expect("run 1");
+    assert_eq!(r1.metrics.files_parsed, 2);
+    assert_eq!(r1.metrics.files_unchanged, 0);
+    assert_eq!(r1.metrics.files_deleted, 0);
+
+    let repo = db.repos().get("lifecycle-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 2);
+    let run1_symbol_count = repo.symbol_count;
+
+    // --- Run 2: No-op ---
+    let r2 = run(&ctx, &mut db, &blob_store).expect("run 2");
+    assert_eq!(r2.metrics.files_parsed, 0);
+    assert_eq!(r2.metrics.files_unchanged, 2);
+    assert_eq!(r2.metrics.files_deleted, 0);
+    assert_eq!(r2.metrics.symbols_extracted, 0);
+
+    // Aggregates unchanged.
+    let repo = db.repos().get("lifecycle-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 2);
+    assert_eq!(repo.symbol_count, run1_symbol_count);
+
+    // --- Run 3: Add utils.rs + modify lib.rs ---
+    std::fs::write(repo_dir.path().join("utils.rs"), "pub fn helper() {}\n")
+        .expect("write utils.rs");
+    std::fs::write(
+        repo_dir.path().join("lib.rs"),
+        "pub fn greet() {}\npub fn farewell() {}\n",
+    )
+    .expect("rewrite lib.rs");
+
+    let r3 = run(&ctx, &mut db, &blob_store).expect("run 3");
+    assert_eq!(
+        r3.metrics.files_parsed, 2,
+        "utils.rs (new) + lib.rs (modified)"
+    );
+    assert_eq!(r3.metrics.files_unchanged, 1, "main.rs unchanged");
+    assert_eq!(r3.metrics.files_deleted, 0);
+
+    let repo = db.repos().get("lifecycle-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 3);
+    assert!(
+        repo.symbol_count > run1_symbol_count,
+        "more symbols after adding utils.rs and modifying lib.rs"
+    );
+    let run3_symbol_count = repo.symbol_count;
+
+    // Verify utils.rs was indexed.
+    assert!(
+        db.files()
+            .get("lifecycle-repo", "utils.rs")
+            .unwrap()
+            .is_some(),
+        "new file should be indexed"
+    );
+
+    // Verify lib.rs now has farewell.
+    let lib_syms = db
+        .symbols()
+        .list_ids_for_file("lifecycle-repo", "lib.rs")
+        .unwrap();
+    assert!(
+        lib_syms.len() >= 2,
+        "lib.rs should have greet + farewell, got {}",
+        lib_syms.len()
+    );
+
+    // --- Run 4: Delete utils.rs ---
+    std::fs::remove_file(repo_dir.path().join("utils.rs")).expect("remove utils.rs");
+
+    let r4 = run(&ctx, &mut db, &blob_store).expect("run 4");
+    assert_eq!(r4.metrics.files_parsed, 0, "no changed files");
+    assert_eq!(r4.metrics.files_unchanged, 2, "main.rs + lib.rs");
+    assert_eq!(r4.metrics.files_deleted, 1, "utils.rs deleted");
+
+    let repo = db.repos().get("lifecycle-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 2);
+    assert!(
+        repo.symbol_count < run3_symbol_count,
+        "fewer symbols after deleting utils.rs"
+    );
+
+    // utils.rs gone from store.
+    assert!(
+        db.files()
+            .get("lifecycle-repo", "utils.rs")
+            .unwrap()
+            .is_none(),
+        "deleted file should be removed"
+    );
+    assert!(
+        db.symbols()
+            .list_ids_for_file("lifecycle-repo", "utils.rs")
+            .unwrap()
+            .is_empty(),
+        "symbols for deleted file should be removed"
+    );
+
+    // --- Run 5: No-op after deletion ---
+    let r5 = run(&ctx, &mut db, &blob_store).expect("run 5");
+    assert_eq!(r5.metrics.files_parsed, 0);
+    assert_eq!(r5.metrics.files_unchanged, 2);
+    assert_eq!(r5.metrics.files_deleted, 0);
+
+    // Final state is stable.
+    let repo = db.repos().get("lifecycle-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 2);
+    let hash_map = db.files().list_hash_map("lifecycle-repo").unwrap();
+    assert_eq!(hash_map.len(), 2);
+    assert!(hash_map.contains_key("main.rs"));
+    assert!(hash_map.contains_key("lib.rs"));
+    assert!(!hash_map.contains_key("utils.rs"));
+}
+
+#[test]
+fn incremental_delete_all_files_leaves_empty_repo() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write main.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "empty-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // Run 1: index.
+    run(&ctx, &mut db, &blob_store).expect("run 1");
+    assert_eq!(db.repos().get("empty-repo").unwrap().unwrap().file_count, 1);
+
+    // Remove the only file.
+    std::fs::remove_file(repo_dir.path().join("main.rs")).expect("remove main.rs");
+
+    // Run 2: all files deleted.
+    let r2 = run(&ctx, &mut db, &blob_store).expect("run 2");
+    assert_eq!(r2.metrics.files_deleted, 1);
+    assert_eq!(r2.metrics.files_parsed, 0);
+    assert_eq!(r2.metrics.files_unchanged, 0);
+
+    let repo = db.repos().get("empty-repo").unwrap().unwrap();
+    assert_eq!(repo.file_count, 0);
+    assert_eq!(repo.symbol_count, 0);
+    assert!(repo.language_counts.is_empty());
+
+    let hash_map = db.files().list_hash_map("empty-repo").unwrap();
+    assert!(hash_map.is_empty());
+}
+
+#[test]
+fn incremental_multiple_deletes_across_runs() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("a.rs"), "pub fn a() {}\n").expect("write a.rs");
+    std::fs::write(repo_dir.path().join("b.rs"), "pub fn b() {}\n").expect("write b.rs");
+    std::fs::write(repo_dir.path().join("c.rs"), "pub fn c() {}\n").expect("write c.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "multi-del-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+    };
+
+    // Run 1: index all 3.
+    let r1 = run(&ctx, &mut db, &blob_store).expect("run 1");
+    assert_eq!(r1.metrics.files_parsed, 3);
+
+    // Delete a.rs.
+    std::fs::remove_file(repo_dir.path().join("a.rs")).expect("remove a.rs");
+    let r2 = run(&ctx, &mut db, &blob_store).expect("run 2");
+    assert_eq!(r2.metrics.files_deleted, 1);
+    assert_eq!(
+        db.repos()
+            .get("multi-del-repo")
+            .unwrap()
+            .unwrap()
+            .file_count,
+        2
+    );
+
+    // Delete b.rs.
+    std::fs::remove_file(repo_dir.path().join("b.rs")).expect("remove b.rs");
+    let r3 = run(&ctx, &mut db, &blob_store).expect("run 3");
+    assert_eq!(r3.metrics.files_deleted, 1);
+    assert_eq!(
+        db.repos()
+            .get("multi-del-repo")
+            .unwrap()
+            .unwrap()
+            .file_count,
+        1
+    );
+
+    // c.rs should still be present and correct.
+    let c_file = db
+        .files()
+        .get("multi-del-repo", "c.rs")
+        .unwrap()
+        .expect("c.rs should exist");
+    assert_eq!(c_file.language, "rust");
+    let c_syms = db
+        .symbols()
+        .list_ids_for_file("multi-del-repo", "c.rs")
+        .unwrap();
+    assert!(!c_syms.is_empty(), "c.rs should have symbols");
 }


### PR DESCRIPTION
## Summary

  - Issue: Closes #41
  - Scope: Implement incremental reindex lifecycle handling for changed/new/deleted files, including deleted-file cleanup, aggregate recomputation, and repeated-run integration coverage.

  ## Changes

  - Extended change detection to surface deleted file paths alongside changed/new/unchanged classification.
  - Added files_deleted to pipeline metrics and change-detection logging.
  - Kept persistence behavior unchanged: deleted files are still removed through stale cleanup driven by full discovery, with symbol cascade cleanup and aggregate recomputation.
  - Expanded integration coverage for incremental lifecycle behavior across repeated runs:
      - deleted file removes file metadata and symbols
      - aggregates and hash map update after deletion
      - full add/modify/delete/no-op lifecycle across multiple runs
      - deleting all files leaves an empty but valid repo state
      - repeated deletes across runs remain correct

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Changed/new/deleted lifecycle behavior is correct.
  - [x] Criterion 2: Integration tests cover repeated incremental runs.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional test evidence run locally:

  - [x] cargo test -p indexer deleted_file -- --nocapture
  - [x] cargo test -p indexer incremental_ -- --nocapture

  ## Risk and Mitigation

  - Risk: Deleted-file accounting could drift from actual persistence behavior if change detection and stale cleanup diverge.
  - Mitigation: The pipeline still relies on full-discovery delete_except cleanup as the source of truth, while tests verify file removal, symbol cleanup, aggregate recomputation, and repeated-run stability.

  ## Security/Observability Impact

  - Security: No new external interfaces or trust-boundary changes; behavior is limited to internal indexing metadata and cleanup flow.
  - Logs/Metrics/Tracing: Added deleted-file visibility via files_deleted metrics and deleted change-detection log fields.