### PR TITLE
Add optional git-diff accelerated mode

### DIFF
--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -11,11 +11,13 @@ use crate::router::TreeSitterRouter;
 struct IndexOpts {
     source_root: PathBuf,
     db_path: Option<PathBuf>,
+    git_diff: bool,
 }
 
 fn parse_args(args: &[String]) -> Result<IndexOpts, CliError> {
     let mut source_root: Option<PathBuf> = None;
     let mut db_path: Option<PathBuf> = None;
+    let mut git_diff = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -26,6 +28,9 @@ fn parse_args(args: &[String]) -> Result<IndexOpts, CliError> {
                     Some(PathBuf::from(args.get(i).ok_or_else(|| {
                         CliError::Usage("--db requires a value".into())
                     })?));
+            }
+            "--git-diff" => {
+                git_diff = true;
             }
             arg if arg.starts_with('-') => {
                 return Err(CliError::Usage(format!("unknown option: {arg}")));
@@ -46,6 +51,7 @@ fn parse_args(args: &[String]) -> Result<IndexOpts, CliError> {
     Ok(IndexOpts {
         source_root,
         db_path,
+        git_diff,
     })
 }
 
@@ -81,12 +87,15 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: opts.git_diff,
     };
 
     let result = indexer::run(&ctx, &mut db, &blob_store)?;
 
     println!("files_discovered: {}", result.metrics.files_discovered);
     println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_unchanged: {}", result.metrics.files_unchanged);
+    println!("files_deleted: {}", result.metrics.files_deleted);
     println!("files_errored: {}", result.metrics.files_errored);
     println!("symbols_extracted: {}", result.metrics.symbols_extracted);
 

--- a/crates/indexer/src/change_detection.rs
+++ b/crates/indexer/src/change_detection.rs
@@ -87,6 +87,82 @@ pub fn detect_changes(
     }
 }
 
+/// Git-diff accelerated change detection.
+///
+/// Uses `git diff --name-only` between the previously stored HEAD and the
+/// current HEAD to identify committed changes, **plus** `git diff` against
+/// HEAD for uncommitted working-tree changes (staged and unstaged). This
+/// ensures that files edited without committing are still detected.
+///
+/// Returns `None` if git-diff is unavailable (not a git repo, missing
+/// commits, etc.), signaling the caller to fall back to hash-based detection.
+pub fn detect_changes_git(
+    files: &[PreparedFile],
+    previous_hashes: &HashMap<String, String>,
+    source_root: &std::path::Path,
+    previous_head: &str,
+    current_head: &str,
+) -> Option<ChangeSet> {
+    // Always collect uncommitted working-tree changes so edits that have
+    // not been committed are never silently skipped.
+    let dirty = crate::git::dirty_files(source_root)?;
+
+    let committed_changes = if previous_head == current_head {
+        // Same commit — no committed changes between the two.
+        HashSet::new()
+    } else {
+        crate::git::diff_files(source_root, previous_head, current_head)?
+    };
+
+    // Union of committed inter-commit changes and uncommitted dirty files.
+    let git_changed: HashSet<&str> = committed_changes
+        .iter()
+        .map(|s| s.as_str())
+        .chain(dirty.iter().map(|s| s.as_str()))
+        .collect();
+
+    let discovered_set: HashSet<String> = files
+        .iter()
+        .map(|f| f.relative_path.to_string_lossy().into_owned())
+        .collect();
+
+    let mut changed_indices = Vec::new();
+    let mut unchanged_count = 0usize;
+    let mut new_count = 0usize;
+    let mut modified_count = 0usize;
+
+    for (i, file) in files.iter().enumerate() {
+        let path = file.relative_path.to_string_lossy();
+
+        if !previous_hashes.contains_key(path.as_ref()) {
+            // New file.
+            new_count += 1;
+            changed_indices.push(i);
+        } else if git_changed.contains(path.as_ref()) {
+            // Git says this file changed (committed or uncommitted).
+            modified_count += 1;
+            changed_indices.push(i);
+        } else {
+            unchanged_count += 1;
+        }
+    }
+
+    let mut deleted_paths: Vec<String> = previous_hashes
+        .keys()
+        .filter(|p| !discovered_set.contains(p.as_str()))
+        .cloned()
+        .collect();
+    deleted_paths.sort();
+
+    Some(ChangeSet {
+        changed_indices,
+        unchanged_count,
+        new_count,
+        modified_count,
+        deleted_paths,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/indexer/src/context.rs
+++ b/crates/indexer/src/context.rs
@@ -20,6 +20,10 @@ pub struct PipelineContext<'a> {
     pub default_policy: AdapterPolicy,
     /// Optional correlation ID for structured log tracing.
     pub correlation_id: Option<String>,
+    /// When `true`, use git-diff to accelerate change detection on
+    /// git-backed repositories. Falls back to hash-based detection
+    /// when the repository is not a git repo or git is unavailable.
+    pub use_git_diff: bool,
 }
 
 impl<'a> PipelineContext<'a> {

--- a/crates/indexer/src/git.rs
+++ b/crates/indexer/src/git.rs
@@ -1,0 +1,321 @@
+//! Git integration utilities for accelerated change detection.
+//!
+//! Uses the `git` CLI via [`std::process::Command`] to avoid adding a
+//! heavy native git dependency. All functions gracefully return `None` or
+//! an empty result when git is unavailable or the path is not a git repo.
+//!
+//! See spec §8.5 (git-diff accelerated mode).
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+use tracing::debug;
+
+/// Returns `true` if the given path is inside a git working tree.
+pub fn is_git_repo(path: &Path) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Returns the current HEAD commit hash (full 40-char SHA), or `None` if
+/// not a git repo or git is unavailable.
+pub fn current_head(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(path)
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if head.is_empty() {
+        None
+    } else {
+        Some(head)
+    }
+}
+
+/// Returns the set of file paths with uncommitted changes (both staged and
+/// unstaged) relative to the repository root.
+///
+/// Combines `git diff --name-only HEAD` (unstaged) and
+/// `git diff --name-only --cached HEAD` (staged) to capture all working-tree
+/// modifications not yet committed. Returns `None` if the git command fails.
+pub fn dirty_files(path: &Path) -> Option<HashSet<String>> {
+    // Unstaged changes (working tree vs index).
+    let unstaged = Command::new("git")
+        .args(["diff", "--name-only", "HEAD"])
+        .current_dir(path)
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    // Staged changes (index vs HEAD).
+    let staged = Command::new("git")
+        .args(["diff", "--name-only", "--cached", "HEAD"])
+        .current_dir(path)
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !unstaged.status.success() || !staged.status.success() {
+        debug!("git diff for dirty files failed, falling back to hash-based detection");
+        return None;
+    }
+
+    let mut files = HashSet::new();
+    for output in [&unstaged.stdout, &staged.stdout] {
+        for line in String::from_utf8_lossy(output).lines() {
+            if !line.is_empty() {
+                files.insert(line.to_string());
+            }
+        }
+    }
+
+    Some(files)
+}
+
+/// Returns the set of file paths that changed between two commits, relative
+/// to the repository root.
+///
+/// Uses `git diff --name-only` which captures added, modified, deleted, and
+/// renamed files. Returns `None` if the git command fails (e.g. invalid
+/// commit, shallow clone missing history).
+pub fn diff_files(path: &Path, from_commit: &str, to_commit: &str) -> Option<HashSet<String>> {
+    let output = Command::new("git")
+        .args(["diff", "--name-only", from_commit, to_commit])
+        .current_dir(path)
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        debug!(
+            from = from_commit,
+            to = to_commit,
+            "git diff failed, falling back to hash-based detection"
+        );
+        return None;
+    }
+
+    let files: HashSet<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect();
+
+    Some(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn init_git_repo(dir: &Path) {
+        Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("git init");
+
+        Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(dir)
+            .stdout(std::process::Stdio::null())
+            .status()
+            .expect("git config email");
+
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir)
+            .stdout(std::process::Stdio::null())
+            .status()
+            .expect("git config name");
+    }
+
+    fn git_add_commit(dir: &Path, message: &str) {
+        Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(dir)
+            .stdout(std::process::Stdio::null())
+            .status()
+            .expect("git add");
+
+        Command::new("git")
+            .args(["commit", "-m", message, "--allow-empty"])
+            .current_dir(dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("git commit");
+    }
+
+    #[test]
+    fn is_git_repo_returns_true_for_git_dir() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+        assert!(is_git_repo(dir.path()));
+    }
+
+    #[test]
+    fn is_git_repo_returns_false_for_non_git_dir() {
+        let dir = TempDir::new().unwrap();
+        assert!(!is_git_repo(dir.path()));
+    }
+
+    #[test]
+    fn current_head_returns_commit_hash() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+        std::fs::write(dir.path().join("file.txt"), "hello").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        let head = current_head(dir.path());
+        assert!(head.is_some());
+        let hash = head.unwrap();
+        assert_eq!(hash.len(), 40, "should be full SHA: {hash}");
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "should be hex: {hash}"
+        );
+    }
+
+    #[test]
+    fn current_head_returns_none_for_non_git_dir() {
+        let dir = TempDir::new().unwrap();
+        assert!(current_head(dir.path()).is_none());
+    }
+
+    #[test]
+    fn diff_files_detects_changes() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+
+        // Commit 1: one file.
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+        git_add_commit(dir.path(), "commit 1");
+        let head1 = current_head(dir.path()).unwrap();
+
+        // Commit 2: modify a.rs, add b.rs.
+        std::fs::write(dir.path().join("a.rs"), "fn a_v2() {}").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "fn b() {}").unwrap();
+        git_add_commit(dir.path(), "commit 2");
+        let head2 = current_head(dir.path()).unwrap();
+
+        let changed = diff_files(dir.path(), &head1, &head2);
+        assert!(changed.is_some());
+        let changed = changed.unwrap();
+        assert!(changed.contains("a.rs"), "a.rs was modified");
+        assert!(changed.contains("b.rs"), "b.rs was added");
+    }
+
+    #[test]
+    fn diff_files_detects_deletion() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "fn b() {}").unwrap();
+        git_add_commit(dir.path(), "commit 1");
+        let head1 = current_head(dir.path()).unwrap();
+
+        std::fs::remove_file(dir.path().join("b.rs")).unwrap();
+        git_add_commit(dir.path(), "commit 2");
+        let head2 = current_head(dir.path()).unwrap();
+
+        let changed = diff_files(dir.path(), &head1, &head2).unwrap();
+        assert!(changed.contains("b.rs"), "b.rs was deleted");
+        assert!(!changed.contains("a.rs"), "a.rs was unchanged");
+    }
+
+    #[test]
+    fn diff_files_returns_none_for_invalid_commit() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+        std::fs::write(dir.path().join("f.txt"), "x").unwrap();
+        git_add_commit(dir.path(), "init");
+
+        assert!(diff_files(
+            dir.path(),
+            "0000000000000000000000000000000000000000",
+            "HEAD"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn diff_files_returns_none_for_non_git_dir() {
+        let dir = TempDir::new().unwrap();
+        assert!(diff_files(dir.path(), "abc", "def").is_none());
+    }
+
+    #[test]
+    fn dirty_files_detects_unstaged_changes() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "fn b() {}").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        // Modify a.rs without committing.
+        std::fs::write(dir.path().join("a.rs"), "fn a_v2() {}").unwrap();
+
+        let dirty = dirty_files(dir.path()).unwrap();
+        assert!(dirty.contains("a.rs"), "a.rs was modified in working tree");
+        assert!(!dirty.contains("b.rs"), "b.rs was not touched");
+    }
+
+    #[test]
+    fn dirty_files_detects_staged_changes() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        // Stage a change without committing.
+        std::fs::write(dir.path().join("a.rs"), "fn a_staged() {}").unwrap();
+        Command::new("git")
+            .args(["add", "a.rs"])
+            .current_dir(dir.path())
+            .stdout(std::process::Stdio::null())
+            .status()
+            .expect("git add");
+
+        let dirty = dirty_files(dir.path()).unwrap();
+        assert!(dirty.contains("a.rs"), "a.rs was staged");
+    }
+
+    #[test]
+    fn dirty_files_returns_empty_when_clean() {
+        let dir = TempDir::new().unwrap();
+        init_git_repo(dir.path());
+
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+        git_add_commit(dir.path(), "initial");
+
+        let dirty = dirty_files(dir.path()).unwrap();
+        assert!(dirty.is_empty(), "no dirty files expected");
+    }
+
+    #[test]
+    fn dirty_files_returns_none_for_non_git_dir() {
+        let dir = TempDir::new().unwrap();
+        assert!(dirty_files(dir.path()).is_none());
+    }
+}

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 pub mod change_detection;
 pub mod context;
 pub mod enrich;
+pub mod git;
 pub mod pipeline;
 pub mod stage;
 

--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -55,7 +55,41 @@ pub fn run(
         .list_hash_map(&ctx.repo_id)
         .map_err(PipelineError::Persist)?;
 
-    let change_set = change_detection::detect_changes(&discovery.files, &previous_hashes);
+    let change_set = if ctx.use_git_diff {
+        // Try git-diff accelerated detection; fall back to hash-based on failure.
+        let previous_head = store
+            .repos()
+            .get(&ctx.repo_id)
+            .map_err(PipelineError::Persist)?
+            .and_then(|r| r.git_head);
+
+        match (previous_head, crate::git::current_head(ctx.source_root())) {
+            (Some(prev), Some(curr)) => {
+                info!(
+                    previous_head = %prev,
+                    current_head = %curr,
+                    "attempting git-diff accelerated change detection"
+                );
+                change_detection::detect_changes_git(
+                    &discovery.files,
+                    &previous_hashes,
+                    ctx.source_root(),
+                    &prev,
+                    &curr,
+                )
+                .unwrap_or_else(|| {
+                    info!("git-diff failed, falling back to hash-based detection");
+                    change_detection::detect_changes(&discovery.files, &previous_hashes)
+                })
+            }
+            _ => {
+                info!("git-diff not available (no previous head or not a git repo), using hash-based detection");
+                change_detection::detect_changes(&discovery.files, &previous_hashes)
+            }
+        }
+    } else {
+        change_detection::detect_changes(&discovery.files, &previous_hashes)
+    };
 
     let files_unchanged = change_set.unchanged_count;
     let files_deleted = change_set.deleted_paths.len();

--- a/crates/indexer/src/stage.rs
+++ b/crates/indexer/src/stage.rs
@@ -315,7 +315,11 @@ pub fn persist(
         language_counts: BTreeMap::new(),
         file_count: 0,
         symbol_count: 0,
-        git_head: None,
+        git_head: if ctx.use_git_diff {
+            crate::git::current_head(ctx.source_root())
+        } else {
+            None
+        },
     };
 
     if let Err(e) = provisional_repo.validate() {

--- a/crates/indexer/tests/determinism_regression.rs
+++ b/crates/indexer/tests/determinism_regression.rs
@@ -208,6 +208,7 @@ fn full_index_produces_identical_state_across_independent_runs() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
     run(&ctx, &mut db1, &blob_store).expect("run 1");
 
@@ -279,6 +280,7 @@ fn reindex_same_content_is_idempotent() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // Run 1: full index.
@@ -326,6 +328,7 @@ fn symbol_ids_stable_when_identity_unchanged() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // Run 1.
@@ -381,6 +384,7 @@ fn file_hashes_stable_for_unchanged_files() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     run(&ctx, &mut db, &blob_store).expect("run 1");
@@ -435,6 +439,7 @@ fn incremental_and_full_reindex_produce_equivalent_state() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
     run(&ctx, &mut db_incremental, &blob_store).expect("incremental: run 1");
 
@@ -507,6 +512,7 @@ fn store_ordering_is_deterministic() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     run(&ctx, &mut db, &blob_store).expect("run");
@@ -559,6 +565,7 @@ pub fn run_delta() {}
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // Run 1.
@@ -624,6 +631,7 @@ fn lifecycle_determinism_across_independent_runs() {
             router: &router,
             default_policy: AdapterPolicy::SyntaxOnly,
             correlation_id: None,
+            use_git_diff: false,
         };
 
         // Step 1: Initial files.

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -187,6 +187,7 @@ fn pipeline_end_to_end_smoke_test() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: Some("test-correlation-001".to_string()),
+        use_git_diff: false,
     };
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
@@ -300,6 +301,7 @@ pub fn greet(config: &Config) -> String {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
@@ -378,6 +380,7 @@ fn pipeline_treesitter_unsupported_language_reports_error_with_provenance() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
@@ -495,6 +498,7 @@ fn adapter_fallback_continues_past_failing_adapter() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
@@ -558,6 +562,7 @@ fn adapter_error_carries_adapter_id_provenance() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
@@ -599,6 +604,7 @@ fn discovery_stage_finds_files() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let output = stage::discover(&ctx).expect("discovery should succeed");
@@ -616,6 +622,7 @@ fn discovery_stage_rejects_invalid_root() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let err = stage::discover(&ctx).expect_err("should fail on invalid root");
@@ -639,6 +646,7 @@ fn discovery_detects_extensionless_script_via_content() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let output = stage::discover(&ctx).expect("discovery should succeed");
@@ -671,6 +679,7 @@ fn parse_stage_handles_no_adapter() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let discovery = stage::discover(&ctx).expect("discovery ok");
@@ -704,6 +713,7 @@ fn parse_stage_uses_context_default_policy() {
         router: &router,
         default_policy: AdapterPolicy::SemanticPreferred,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let discovery = stage::discover(&ctx).expect("discovery ok");
@@ -746,6 +756,7 @@ fn reindex_removes_stale_files_and_recomputes_aggregates() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // First run: both files indexed.
@@ -835,6 +846,7 @@ fn reindex_cleans_up_removed_symbols_within_file() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // First run.
@@ -915,6 +927,7 @@ pub fn greet(config: &Config) -> String {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
@@ -1018,6 +1031,7 @@ fn enrichment_is_deterministic_across_runs() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     run(&ctx, &mut db1, &blob_store).expect("run 1");
@@ -1174,6 +1188,7 @@ fn reindex_with_adapter_failure_preserves_previously_indexed_file() {
         router: &ts_router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let r1 = run(&ctx1, &mut db, &blob_store).expect("first run");
@@ -1208,6 +1223,7 @@ fn reindex_with_adapter_failure_preserves_previously_indexed_file() {
         router: &fail_router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let r2 = run(&ctx2, &mut db, &blob_store).expect("second run");
@@ -1299,6 +1315,7 @@ fn incremental_noop_run_skips_all_files() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // First run: full index.
@@ -1348,6 +1365,7 @@ fn incremental_detects_modified_file_and_reindexes() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // First run.
@@ -1397,6 +1415,7 @@ fn incremental_detects_new_file() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // First run.
@@ -1449,6 +1468,7 @@ fn incremental_hash_map_persists_across_runs() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // First run populates the hash map.
@@ -1508,6 +1528,7 @@ fn incremental_deleted_file_removes_symbols_and_updates_aggregates() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // Run 1: index both files.
@@ -1591,6 +1612,7 @@ fn incremental_full_lifecycle_add_modify_delete() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // --- Run 1: Initial index ---
@@ -1723,6 +1745,7 @@ fn incremental_delete_all_files_leaves_empty_repo() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // Run 1: index.
@@ -1765,6 +1788,7 @@ fn incremental_multiple_deletes_across_runs() {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     // Run 1: index all 3.
@@ -1809,4 +1833,271 @@ fn incremental_multiple_deletes_across_runs() {
         .list_ids_for_file("multi-del-repo", "c.rs")
         .unwrap();
     assert!(!c_syms.is_empty(), "c.rs should have symbols");
+}
+
+// ---------------------------------------------------------------------------
+// Git-diff accelerated mode integration tests
+// ---------------------------------------------------------------------------
+
+fn init_git_repo(dir: &std::path::Path) {
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("git init");
+
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .status()
+        .expect("git config email");
+
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .status()
+        .expect("git config name");
+}
+
+fn git_add_commit(dir: &std::path::Path, message: &str) {
+    std::process::Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .status()
+        .expect("git add");
+
+    std::process::Command::new("git")
+        .args(["commit", "-m", message, "--allow-empty"])
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("git commit");
+}
+
+/// Git-diff mode produces the same final DB state as hash-based mode after
+/// initial index + modify + delete lifecycle.
+#[test]
+fn git_diff_parity_with_hash_based_detection() {
+    let router = TreeSitterRouter::new();
+
+    // --- Run A: hash-based mode ---
+    let repo_a = TempDir::new().expect("repo_a dir");
+    let blob_a = TempDir::new().expect("blob_a dir");
+    let blob_store_a = setup_blob_store(&blob_a);
+    let mut db_a = store::MetadataStore::open_in_memory().expect("db_a");
+
+    // Initial index.
+    std::fs::write(repo_a.path().join("a.rs"), "pub fn a() {}\n").unwrap();
+    std::fs::write(repo_a.path().join("b.rs"), "pub fn b() {}\n").unwrap();
+
+    let ctx_a = PipelineContext {
+        repo_id: "parity-repo".to_string(),
+        source_root: repo_a.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: false,
+    };
+    run(&ctx_a, &mut db_a, &blob_store_a).expect("hash run 1");
+
+    // Modify a.rs, delete b.rs, add c.rs.
+    std::fs::write(repo_a.path().join("a.rs"), "pub fn a_v2() {}\n").unwrap();
+    std::fs::remove_file(repo_a.path().join("b.rs")).unwrap();
+    std::fs::write(repo_a.path().join("c.rs"), "pub fn c() {}\n").unwrap();
+    let r_a = run(&ctx_a, &mut db_a, &blob_store_a).expect("hash run 2");
+
+    // --- Run B: git-diff mode ---
+    let repo_b = TempDir::new().expect("repo_b dir");
+    let blob_b = TempDir::new().expect("blob_b dir");
+    let blob_store_b = setup_blob_store(&blob_b);
+    let mut db_b = store::MetadataStore::open_in_memory().expect("db_b");
+
+    init_git_repo(repo_b.path());
+    std::fs::write(repo_b.path().join("a.rs"), "pub fn a() {}\n").unwrap();
+    std::fs::write(repo_b.path().join("b.rs"), "pub fn b() {}\n").unwrap();
+    git_add_commit(repo_b.path(), "initial");
+
+    let ctx_b = PipelineContext {
+        repo_id: "parity-repo".to_string(),
+        source_root: repo_b.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: true,
+    };
+    run(&ctx_b, &mut db_b, &blob_store_b).expect("git run 1");
+
+    // Modify a.rs, delete b.rs, add c.rs — commit so git-diff can see changes.
+    std::fs::write(repo_b.path().join("a.rs"), "pub fn a_v2() {}\n").unwrap();
+    std::fs::remove_file(repo_b.path().join("b.rs")).unwrap();
+    std::fs::write(repo_b.path().join("c.rs"), "pub fn c() {}\n").unwrap();
+    git_add_commit(repo_b.path(), "modify and delete");
+    let r_b = run(&ctx_b, &mut db_b, &blob_store_b).expect("git run 2");
+
+    // Compare metrics.
+    assert_eq!(
+        r_a.metrics.files_parsed, r_b.metrics.files_parsed,
+        "files_parsed mismatch"
+    );
+    assert_eq!(
+        r_a.metrics.files_deleted, r_b.metrics.files_deleted,
+        "files_deleted mismatch"
+    );
+    assert_eq!(
+        r_a.metrics.symbols_extracted, r_b.metrics.symbols_extracted,
+        "symbols_extracted mismatch"
+    );
+
+    // Compare final DB state: same files and symbols.
+    let files_a = db_a.files().list_hash_map("parity-repo").unwrap();
+    let files_b = db_b.files().list_hash_map("parity-repo").unwrap();
+    assert_eq!(files_a, files_b, "file hash maps should be identical");
+
+    // Compare symbols per file.
+    for path in files_a.keys() {
+        let syms_a = db_a
+            .symbols()
+            .list_ids_for_file("parity-repo", path)
+            .unwrap();
+        let syms_b = db_b
+            .symbols()
+            .list_ids_for_file("parity-repo", path)
+            .unwrap();
+        assert_eq!(syms_a, syms_b, "symbol IDs for {path} should be identical");
+    }
+}
+
+/// Git-diff mode detects uncommitted working-tree changes (same HEAD).
+#[test]
+fn git_diff_detects_uncommitted_changes() {
+    let router = TreeSitterRouter::new();
+    let repo_dir = TempDir::new().expect("repo dir");
+    let blob_dir = TempDir::new().expect("blob dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let mut db = store::MetadataStore::open_in_memory().expect("db");
+
+    init_git_repo(repo_dir.path());
+    std::fs::write(repo_dir.path().join("a.rs"), "pub fn a() {}\n").unwrap();
+    git_add_commit(repo_dir.path(), "initial");
+
+    let ctx = PipelineContext {
+        repo_id: "dirty-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: true,
+    };
+
+    // Initial index — a.rs is new.
+    let r1 = run(&ctx, &mut db, &blob_store).expect("run 1");
+    assert_eq!(r1.metrics.files_parsed, 1);
+
+    // Modify a.rs WITHOUT committing.
+    std::fs::write(repo_dir.path().join("a.rs"), "pub fn a_modified() {}\n").unwrap();
+
+    // Second run — HEAD is the same but file is dirty; must reindex.
+    let r2 = run(&ctx, &mut db, &blob_store).expect("run 2");
+    assert_eq!(r2.metrics.files_parsed, 1, "dirty file must be re-parsed");
+    assert_eq!(
+        r2.metrics.files_unchanged, 0,
+        "dirty file must not be skipped"
+    );
+
+    // Verify the updated symbol is in the DB.
+    let syms = db
+        .symbols()
+        .list_ids_for_file("dirty-repo", "a.rs")
+        .unwrap();
+    assert!(
+        !syms.is_empty(),
+        "a.rs should have symbols after dirty reindex"
+    );
+}
+
+/// Git-diff mode persists git_head and uses it for subsequent runs.
+#[test]
+fn git_diff_persists_and_uses_git_head() {
+    let router = TreeSitterRouter::new();
+    let repo_dir = TempDir::new().expect("repo dir");
+    let blob_dir = TempDir::new().expect("blob dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let mut db = store::MetadataStore::open_in_memory().expect("db");
+
+    init_git_repo(repo_dir.path());
+    std::fs::write(repo_dir.path().join("a.rs"), "pub fn a() {}\n").unwrap();
+    git_add_commit(repo_dir.path(), "initial");
+
+    let ctx = PipelineContext {
+        repo_id: "head-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: true,
+    };
+
+    run(&ctx, &mut db, &blob_store).expect("run 1");
+
+    // Verify git_head was persisted.
+    let repo_record = db.repos().get("head-repo").unwrap().unwrap();
+    assert!(
+        repo_record.git_head.is_some(),
+        "git_head should be persisted"
+    );
+    let head1 = repo_record.git_head.unwrap();
+    assert_eq!(head1.len(), 40, "should be full SHA");
+
+    // Make a new commit and reindex.
+    std::fs::write(repo_dir.path().join("b.rs"), "pub fn b() {}\n").unwrap();
+    git_add_commit(repo_dir.path(), "add b");
+
+    let r2 = run(&ctx, &mut db, &blob_store).expect("run 2");
+    assert_eq!(
+        r2.metrics.files_parsed, 1,
+        "only new file b.rs should be parsed"
+    );
+    assert_eq!(r2.metrics.files_unchanged, 1, "a.rs should be unchanged");
+
+    // Verify git_head was updated.
+    let repo_record2 = db.repos().get("head-repo").unwrap().unwrap();
+    let head2 = repo_record2.git_head.unwrap();
+    assert_ne!(head1, head2, "git_head should have been updated");
+}
+
+/// Git-diff mode with no previous head falls back to hash-based (first run).
+#[test]
+fn git_diff_first_run_indexes_all_files() {
+    let router = TreeSitterRouter::new();
+    let repo_dir = TempDir::new().expect("repo dir");
+    let blob_dir = TempDir::new().expect("blob dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let mut db = store::MetadataStore::open_in_memory().expect("db");
+
+    init_git_repo(repo_dir.path());
+    std::fs::write(repo_dir.path().join("a.rs"), "pub fn a() {}\n").unwrap();
+    std::fs::write(repo_dir.path().join("b.rs"), "pub fn b() {}\n").unwrap();
+    git_add_commit(repo_dir.path(), "initial");
+
+    let ctx = PipelineContext {
+        repo_id: "first-run-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: true,
+    };
+
+    let r = run(&ctx, &mut db, &blob_store).expect("run 1");
+    assert_eq!(
+        r.metrics.files_parsed, 2,
+        "all files should be parsed on first run"
+    );
+    assert_eq!(r.metrics.files_unchanged, 0);
 }

--- a/crates/query-engine/tests/search_text_integration.rs
+++ b/crates/query-engine/tests/search_text_integration.rs
@@ -589,6 +589,7 @@ struct HttpServer {
             router: &router,
             default_policy: AdapterPolicy::SyntaxOnly,
             correlation_id: None,
+            use_git_diff: false,
         };
         let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
         assert!(result.metrics.symbols_extracted >= 2);

--- a/crates/server-mcp/tests/e2e_integration.rs
+++ b/crates/server-mcp/tests/e2e_integration.rs
@@ -77,6 +77,7 @@ fn indexed_store() -> (store::MetadataStore, TempDir) {
         router: &router,
         default_policy: AdapterPolicy::SyntaxOnly,
         correlation_id: None,
+        use_git_diff: false,
     };
 
     let result = indexer::run(&ctx, &mut db, &blob_store).expect("indexing should succeed");


### PR DESCRIPTION
## Summary

  - Issue: Closes #42
  - Scope: Add an optional git-diff accelerated mode for incremental change detection, with safe fallback to hash-based detection and parity coverage against the existing path.

  ## Changes

  - Added a use_git_diff pipeline option and exposed it through the CLI as --git-diff.
  - Added git helper utilities for:
      - detecting the current HEAD
      - diffing files between commits
      - detecting dirty working-tree files, including staged and unstaged changes
  - Updated change detection to support a git-diff accelerated path that:
      - compares the previously persisted git_head to the current HEAD
      - uses commit-to-commit diff results for committed changes
      - unions in dirty working-tree changes so uncommitted edits are not skipped
      - falls back to hash-based detection when git metadata is unavailable or commands fail
  - Persisted git_head in repo metadata when git-diff mode is enabled.
  - Added integration coverage for git-diff mode:
      - parity with hash-based detection for add/modify/delete lifecycle changes
      - detection of uncommitted working-tree changes with unchanged HEAD
      - persistence and update of git_head
      - first-run behavior when no previous head exists

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Feature flag/config for git-diff mode exists.
  - [x] Criterion 2: Tests validate change set parity with hash-based mode.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional test evidence run locally:

  - [x] cargo test -p indexer git_diff_ -- --nocapture
  - [x] cargo test -p indexer dirty_files -- --nocapture

  ## Risk and Mitigation

  - Risk: Git-based acceleration could miss real file changes and leave indexed metadata stale, especially with uncommitted working-tree edits or missing git history.
  - Mitigation: The accelerated path unions committed diff results with dirty-file detection, persists git_head only when the mode is enabled, and falls back to hash-based detection whenever git information is unavailable or a git command fails.

  ## Security/Observability Impact

  - Security: No new external service dependency or privilege change; the feature shells out to the local git CLI within the indexed repo root.
  - Logs/Metrics/Tracing: Added logging around git-diff acceleration attempts and fallback behavior; existing change-detection metrics continue to report parsed, unchanged, and deleted counts.