### PR TITLE
milestone docs and CLI usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Primary interface target:
 
 ## Current Status
 
-Milestones M0-M6 are complete:
+Milestones M0-M7 are complete:
 
 - M0-M4: governance, core model, discovery/adapters, storage, and indexing pipeline.
 - M5: query engine and deterministic ranking.
 - M6: MCP server contracts and local CLI interface.
+- M7: incremental indexing, git-diff acceleration, and determinism regression coverage.
 
 ### Workspace crates
 
@@ -60,7 +61,7 @@ Milestones M0-M6 are complete:
 
 ### What does not exist yet
 
-- Incremental indexing and watcher/git-diff accelerated modes.
+- Watcher/local file-system triggered update mode.
 - Semantic adapter implementations beyond syntax baseline.
 - Hosted/server API surface (HTTP/gRPC), auth, quotas, and multi-tenant controls.
 - Production observability dashboards and performance/SLO regression automation.

--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -45,8 +45,9 @@ fn parse_args(args: &[String]) -> Result<IndexOpts, CliError> {
         i += 1;
     }
 
-    let source_root = source_root
-        .ok_or_else(|| CliError::Usage("usage: codeatlas index <path> [--db <path>]".into()))?;
+    let source_root = source_root.ok_or_else(|| {
+        CliError::Usage("usage: codeatlas index <path> [--db <path>] [--git-diff]".into())
+    })?;
 
     Ok(IndexOpts {
         source_root,

--- a/docs/architecture/rust-code-intelligence-plan.md
+++ b/docs/architecture/rust-code-intelligence-plan.md
@@ -47,6 +47,10 @@ Key design decisions:
 - Repo upsert uses INSERT OR IGNORE + UPDATE to avoid ON DELETE CASCADE
 - Aggregates (file_count, symbol_count, language_counts) recomputed from DB state
 - Per-file symbol cleanup before upsert handles renamed/removed symbols
+- Incremental indexing uses persisted file hashes, deleted-file cleanup, and
+  optional git-diff acceleration via persisted `git_head` plus dirty working-tree detection
+- Determinism is guarded by regression coverage for stable IDs, ordering, and
+  incremental vs fresh-index equivalence
 
 ## Milestone/Epic Breakdown
 
@@ -57,7 +61,7 @@ Key design decisions:
 5. ~~Epic 4: Storage and Atomic Index Commit Path~~ (complete)
 6. ~~Epic 5: Query Engine and Deterministic Ranking~~ (complete)
 7. ~~Epic 6: MCP Server Interface and Tool Contracts~~ (complete)
-8. **Epic 7: Incremental Indexing and Reliability Hardening** (next)
+8. ~~Epic 7: Incremental Indexing and Reliability Hardening~~ (complete)
 9. Epic 8: Security, Observability, and Performance Guardrails
 10. Epic 9: Semantic Adapter Integration (at least two languages)
 11. Epic 10: Documentation, Benchmarks, and V1 Readiness Review

--- a/docs/planning/issue-backlog.md
+++ b/docs/planning/issue-backlog.md
@@ -2,10 +2,11 @@
 
 This backlog is designed for one-PR-per-issue execution.
 
-Progress (updated 2026-03-10): Milestones M0-M6 are complete. The platform now
+Progress (updated 2026-03-10): Milestones M0-M7 are complete. The platform now
 includes indexing pipeline, query engine, MCP serving contracts, and local CLI
-commands. Workspace quality gates are green (`fmt`, `clippy -D warnings`, full
-workspace tests).
+commands, plus incremental indexing with git-diff acceleration and determinism
+regression coverage. Workspace quality gates are green (`fmt`, `clippy -D warnings`,
+full workspace tests).
 
 ## Epic 0: Repository Governance and CI Foundation (complete)
 
@@ -62,12 +63,12 @@ workspace tests).
 - ~~Ticket: Create CLI crate for local indexing and query commands~~ (#62, p1)
 - ~~Ticket: Add CLI outline commands (`file-outline`, `file-tree`, `repo-outline`)~~ (#70, p2)
 
-## Epic 7: Incremental Indexing and Reliability (next)
+## Epic 7: Incremental Indexing and Reliability (complete)
 
-- Ticket: File hash map and changed-file detection
-- Ticket: Incremental reindex and deleted-file cleanup
-- Ticket: Optional git-diff accelerated mode
-- Ticket: Determinism and idempotency regression tests
+- ~~Ticket: File hash map and changed-file detection~~ (#40)
+- ~~Ticket: Incremental reindex and deleted-file cleanup~~ (#41)
+- ~~Ticket: Optional git-diff accelerated mode~~ (#42)
+- ~~Ticket: Determinism and idempotency regression tests~~ (#43)
 
 ## Epic 8: Security, Observability, Performance
 


### PR DESCRIPTION
- README.md
    M0-M7 now marked complete, M7 called out explicitly, and the “missing” section now only lists watcher mode rather than incremental/git-diff.
  - issue-backlog.md
    Progress updated to M0-M7 complete, Epic 7 marked complete, and issues #40-#43 struck through with numbers.
  - rust-code-intelligence-plan.md
    Epic 7 marked complete and the indexer design notes now mention persisted hashes, deleted-file cleanup, git-head/dirty-tree git-diff support, and determinism regression coverage.
  - index.rs
    Usage text now includes [--git-diff].