### PR TITLE
Add structured logs and redaction policy enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "query-engine",
+ "serde_json",
  "store",
  "tempfile",
  "tracing",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 
+[lib]
+name = "cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "codeatlas"
 path = "src/main.rs"
@@ -15,6 +19,7 @@ adapter-syntax-treesitter.workspace = true
 core-model.workspace = true
 indexer.workspace = true
 query-engine.workspace = true
+serde_json.workspace = true
 store.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,0 +1,3 @@
+//! CodeAtlas CLI library — shared modules for the binary and tests.
+
+pub mod logging;

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -1,0 +1,373 @@
+//! Structured logging with redaction policy enforcement.
+//!
+//! Provides two redaction-aware output modes:
+//!
+//! - [`RedactingJsonLayer`] — structured JSON lines (spec §13.2).
+//! - [`RedactingFieldFormatter`] — compact human-readable output for local
+//!   development, plugged into `tracing_subscriber::fmt` via `.fmt_fields()`.
+//!
+//! Both modes replace sensitive field values with `[REDACTED]` per the
+//! telemetry policy (spec §12.2, §13.2).
+//!
+//! # Redaction policy
+//!
+//! Fields listed in [`SENSITIVE_FIELDS`] have their values fully replaced.
+//! The field *name* is preserved so log consumers can see that the field
+//! was present but its value was suppressed. Relative file paths and
+//! non-secret metadata pass through unredacted.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::io;
+
+use tracing::field::{Field, Visit};
+use tracing::Subscriber;
+use tracing_subscriber::field::RecordFields;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::FormatFields;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+// ---------------------------------------------------------------------------
+// Redaction policy
+// ---------------------------------------------------------------------------
+
+/// Field names whose values are replaced with `[REDACTED]` in log output.
+///
+/// These are fields that could expose host filesystem structure, user
+/// search intent, or source code content in telemetry (spec §12.2).
+pub const SENSITIVE_FIELDS: &[&str] = &[
+    // Absolute paths — reveal host filesystem layout.
+    "source_root",
+    "root",
+    // User-supplied query content — could contain code patterns.
+    "query_text",
+    "pattern",
+];
+
+const REDACTED_VALUE: &str = "[REDACTED]";
+
+/// Returns `true` if the given field name is in the redaction policy.
+pub fn is_sensitive(field_name: &str) -> bool {
+    SENSITIVE_FIELDS.contains(&field_name)
+}
+
+// ---------------------------------------------------------------------------
+// Field collection with redaction
+// ---------------------------------------------------------------------------
+
+/// Collects fields into a `BTreeMap`, redacting sensitive values.
+///
+/// Using `BTreeMap` instead of `HashMap` ensures deterministic field
+/// ordering in JSON output, which simplifies testing and log comparison.
+#[derive(Default)]
+struct RedactingVisitor {
+    fields: BTreeMap<String, serde_json::Value>,
+}
+
+impl Visit for RedactingVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let val = if is_sensitive(field.name()) {
+            serde_json::Value::String(REDACTED_VALUE.into())
+        } else {
+            serde_json::Value::String(format!("{value:?}"))
+        };
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        let val = if is_sensitive(field.name()) {
+            serde_json::Value::String(REDACTED_VALUE.into())
+        } else {
+            serde_json::Value::String(value.to_string())
+        };
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        let val = if is_sensitive(field.name()) {
+            serde_json::Value::String(REDACTED_VALUE.into())
+        } else {
+            serde_json::json!(value)
+        };
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        let val = if is_sensitive(field.name()) {
+            serde_json::Value::String(REDACTED_VALUE.into())
+        } else {
+            serde_json::json!(value)
+        };
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        let val = if is_sensitive(field.name()) {
+            serde_json::Value::String(REDACTED_VALUE.into())
+        } else {
+            serde_json::json!(value)
+        };
+        self.fields.insert(field.name().to_string(), val);
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        let val = if is_sensitive(field.name()) {
+            serde_json::Value::String(REDACTED_VALUE.into())
+        } else {
+            serde_json::json!(value)
+        };
+        self.fields.insert(field.name().to_string(), val);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-span stored fields
+// ---------------------------------------------------------------------------
+
+/// Redacted field snapshot stored in a span's extensions.
+#[derive(Clone, Default)]
+struct SpanFields {
+    fields: BTreeMap<String, serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Redacting field formatter (for compact / fmt layer output)
+// ---------------------------------------------------------------------------
+
+/// A [`FormatFields`] implementation that writes fields as `key=value` pairs
+/// while replacing sensitive values with `[REDACTED]`.
+///
+/// Intended for use with `tracing_subscriber::fmt::layer().fmt_fields(...)`,
+/// ensuring the compact output mode also enforces the redaction policy.
+pub struct RedactingFieldFormatter;
+
+/// Visitor that writes `key=value` pairs directly to a `fmt::Write`,
+/// redacting sensitive fields inline.
+struct CompactRedactingVisitor<'a> {
+    writer: &'a mut dyn fmt::Write,
+    first: bool,
+    result: fmt::Result,
+}
+
+impl<'a> CompactRedactingVisitor<'a> {
+    fn new(writer: &'a mut dyn fmt::Write) -> Self {
+        Self {
+            writer,
+            first: true,
+            result: Ok(()),
+        }
+    }
+
+    fn write_separator(&mut self) {
+        if !self.first {
+            self.result = self.result.and_then(|()| self.writer.write_char(' '));
+        }
+        self.first = false;
+    }
+}
+
+impl Visit for CompactRedactingVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.write_separator();
+        if is_sensitive(field.name()) {
+            self.result = self
+                .result
+                .and_then(|()| write!(self.writer, "{}={}", field.name(), REDACTED_VALUE));
+        } else {
+            self.result = self
+                .result
+                .and_then(|()| write!(self.writer, "{}={:?}", field.name(), value));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.write_separator();
+        if is_sensitive(field.name()) {
+            self.result = self
+                .result
+                .and_then(|()| write!(self.writer, "{}={}", field.name(), REDACTED_VALUE));
+        } else {
+            self.result = self
+                .result
+                .and_then(|()| write!(self.writer, "{}={}", field.name(), value));
+        }
+    }
+}
+
+impl<'writer> FormatFields<'writer> for RedactingFieldFormatter {
+    fn format_fields<R: RecordFields>(
+        &self,
+        mut writer: Writer<'writer>,
+        fields: R,
+    ) -> fmt::Result {
+        let mut visitor = CompactRedactingVisitor::new(&mut writer);
+        fields.record(&mut visitor);
+        visitor.result
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Redacting JSON layer
+// ---------------------------------------------------------------------------
+
+/// A [`tracing_subscriber::Layer`] that emits one JSON line per event,
+/// including parent span context, with sensitive field values redacted.
+///
+/// Output schema (one JSON object per line):
+///
+/// ```json
+/// {
+///   "timestamp": "2026-03-10T12:00:00.000Z",
+///   "level": "INFO",
+///   "target": "indexer::pipeline",
+///   "message": "pipeline started",
+///   "fields": { "files_discovered": 42 },
+///   "spans": [
+///     { "name": "index_pipeline", "repo_id": "test", "correlation_id": "[REDACTED]" }
+///   ]
+/// }
+/// ```
+pub struct RedactingJsonLayer<W> {
+    writer: W,
+}
+
+impl<W> RedactingJsonLayer<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W, S> Layer<S> for RedactingJsonLayer<W>
+where
+    W: for<'a> tracing_subscriber::fmt::MakeWriter<'a> + 'static,
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        let mut visitor = RedactingVisitor::default();
+        attrs.record(&mut visitor);
+
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(SpanFields {
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            let mut visitor = RedactingVisitor::default();
+            values.record(&mut visitor);
+
+            let mut ext = span.extensions_mut();
+            if let Some(stored) = ext.get_mut::<SpanFields>() {
+                stored.fields.extend(visitor.fields);
+            } else {
+                ext.insert(SpanFields {
+                    fields: visitor.fields,
+                });
+            }
+        }
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
+        // Collect event fields (with redaction).
+        let mut visitor = RedactingVisitor::default();
+        event.record(&mut visitor);
+
+        // Extract the message from the special `message` field.
+        let message = visitor
+            .fields
+            .remove("message")
+            .and_then(|v| v.as_str().map(String::from))
+            .unwrap_or_default();
+
+        // Walk the span stack to build the spans array.
+        let mut spans = Vec::new();
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope {
+                let mut span_obj = BTreeMap::new();
+                span_obj.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(span.name().to_string()),
+                );
+                if let Some(stored) = span.extensions().get::<SpanFields>() {
+                    for (k, v) in &stored.fields {
+                        span_obj.insert(k.clone(), v.clone());
+                    }
+                }
+                spans.push(serde_json::Value::Object(span_obj.into_iter().collect()));
+            }
+        }
+        // Reverse so outermost span is first (root → leaf ordering).
+        spans.reverse();
+
+        let meta = event.metadata();
+        let record = serde_json::json!({
+            "timestamp": timestamp_now(),
+            "level": meta.level().as_str(),
+            "target": meta.target(),
+            "message": message,
+            "fields": visitor.fields,
+            "spans": spans,
+        });
+
+        let mut writer = self.writer.make_writer();
+        // Ignore write errors — logging must not crash the application.
+        let _ = io::Write::write_all(&mut writer, record.to_string().as_bytes());
+        let _ = io::Write::write_all(&mut writer, b"\n");
+    }
+}
+
+/// Returns the current UTC time as an RFC 3339 string.
+fn timestamp_now() -> String {
+    // Use a simple seconds-since-epoch representation that doesn't
+    // require pulling in chrono or time formatting in the hot path.
+    let now = std::time::SystemTime::now();
+    let dur = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+    let millis = dur.subsec_millis();
+    format!("{secs}.{millis:03}")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_sensitive_identifies_policy_fields() {
+        assert!(is_sensitive("source_root"));
+        assert!(is_sensitive("root"));
+        assert!(is_sensitive("query_text"));
+        assert!(is_sensitive("pattern"));
+        assert!(!is_sensitive("repo_id"));
+        assert!(!is_sensitive("file_path"));
+        assert!(!is_sensitive("level"));
+        assert!(!is_sensitive("files_discovered"));
+    }
+
+    #[test]
+    fn sensitive_fields_list_is_not_empty() {
+        assert!(
+            !SENSITIVE_FIELDS.is_empty(),
+            "redaction policy must define at least one sensitive field"
+        );
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,45 +9,66 @@ use tracing_subscriber::EnvFilter;
 
 mod commands;
 mod error;
+pub mod logging;
 mod router;
 
 /// Initialises the tracing subscriber stack.
 ///
-/// The base layer is a `tracing-subscriber` `fmt` layer filtered by the
-/// `CODEATLAS_LOG` (or `RUST_LOG`) environment variable, defaulting to
+/// **Log format** is controlled by `CODEATLAS_LOG_FORMAT`:
+/// - `json` (default) — structured JSON lines with redaction (spec §13.2).
+/// - `compact` — human-readable compact output for local development.
+///
+/// **Log level** respects `CODEATLAS_LOG` or `RUST_LOG`, defaulting to
 /// `info`.
 ///
-/// When `OTEL_EXPORTER_OTLP_ENDPOINT` is set **or** `CODEATLAS_OTEL=1`,
-/// an OpenTelemetry span-export layer is added that writes trace spans to
-/// stdout in OTLP-JSON format. Replace the stdout exporter with a
-/// network exporter (e.g. `opentelemetry-otlp`) for production use.
+/// **OpenTelemetry** span export is enabled when `CODEATLAS_OTEL=1` or
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
 fn init_tracing() {
     let env_filter = EnvFilter::try_from_env("CODEATLAS_LOG")
         .or_else(|_| EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| EnvFilter::new("info"));
 
-    let fmt_layer = tracing_subscriber::fmt::layer().compact();
+    let use_json = std::env::var("CODEATLAS_LOG_FORMAT")
+        .map(|v| v != "compact")
+        .unwrap_or(true);
 
     let otel_enabled = std::env::var("CODEATLAS_OTEL").is_ok_and(|v| v == "1")
         || std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok();
 
-    if otel_enabled {
-        let exporter = opentelemetry_stdout::SpanExporter::default();
-        let provider = opentelemetry_sdk::trace::TracerProvider::builder()
-            .with_simple_exporter(exporter)
-            .build();
-        let otel_layer = tracing_opentelemetry::layer().with_tracer(provider.tracer("codeatlas"));
-
-        tracing_subscriber::registry()
+    if use_json {
+        let json_layer = logging::RedactingJsonLayer::new(std::io::stderr);
+        let base = tracing_subscriber::registry()
             .with(env_filter)
-            .with(fmt_layer)
-            .with(otel_layer)
-            .init();
+            .with(json_layer);
+        if otel_enabled {
+            let exporter = opentelemetry_stdout::SpanExporter::default();
+            let provider = opentelemetry_sdk::trace::TracerProvider::builder()
+                .with_simple_exporter(exporter)
+                .build();
+            let otel_layer =
+                tracing_opentelemetry::layer().with_tracer(provider.tracer("codeatlas"));
+            base.with(otel_layer).init();
+        } else {
+            base.init();
+        }
     } else {
-        tracing_subscriber::registry()
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .compact()
+            .fmt_fields(logging::RedactingFieldFormatter);
+        let base = tracing_subscriber::registry()
             .with(env_filter)
-            .with(fmt_layer)
-            .init();
+            .with(fmt_layer);
+        if otel_enabled {
+            let exporter = opentelemetry_stdout::SpanExporter::default();
+            let provider = opentelemetry_sdk::trace::TracerProvider::builder()
+                .with_simple_exporter(exporter)
+                .build();
+            let otel_layer =
+                tracing_opentelemetry::layer().with_tracer(provider.tracer("codeatlas"));
+            base.with(otel_layer).init();
+        } else {
+            base.init();
+        }
     }
 }
 

--- a/crates/cli/tests/structured_logging.rs
+++ b/crates/cli/tests/structured_logging.rs
@@ -1,0 +1,429 @@
+//! Integration tests for structured JSON logging and redaction enforcement.
+//!
+//! Verifies that:
+//! - Log output consists of valid JSON lines (spec §13.2).
+//! - Sensitive fields are redacted per the telemetry policy (spec §12.2).
+//! - Non-sensitive fields pass through unmodified.
+//! - Span context (including correlation ID) is included in log output.
+//! - Compact mode also enforces redaction.
+
+use std::sync::{Arc, Mutex};
+
+use cli::logging::{self, RedactingFieldFormatter, RedactingJsonLayer};
+use tracing_subscriber::layer::SubscriberExt;
+
+// ---------------------------------------------------------------------------
+// Captured writer for test output
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct CapturedWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CapturedWriter {
+    fn new() -> Self {
+        Self {
+            buffer: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn contents(&self) -> String {
+        let buf = self.buffer.lock().expect("lock buffer");
+        String::from_utf8_lossy(&buf).to_string()
+    }
+}
+
+impl std::io::Write for CapturedWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.lock().expect("lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedWriter {
+    type Writer = CapturedWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parses each non-empty line of output as JSON, returning the parsed values.
+fn parse_json_lines(output: &str) -> Vec<serde_json::Value> {
+    output
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("invalid JSON line: {e}\n  line: {line}"))
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn output_is_valid_structured_json() {
+    let writer = CapturedWriter::new();
+    let layer = RedactingJsonLayer::new(writer.clone());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(files_discovered = 10, "pipeline started");
+        tracing::warn!(adapter = "tree-sitter", "adapter failed");
+    });
+
+    let output = writer.contents();
+    let lines = parse_json_lines(&output);
+
+    assert_eq!(lines.len(), 2, "expected 2 JSON log lines");
+
+    // Verify required top-level keys are present.
+    for line in &lines {
+        assert!(line.get("timestamp").is_some(), "missing 'timestamp'");
+        assert!(line.get("level").is_some(), "missing 'level'");
+        assert!(line.get("target").is_some(), "missing 'target'");
+        assert!(line.get("message").is_some(), "missing 'message'");
+        assert!(line.get("fields").is_some(), "missing 'fields'");
+        assert!(line.get("spans").is_some(), "missing 'spans'");
+    }
+
+    // Verify specific values.
+    assert_eq!(lines[0]["level"], "INFO");
+    assert_eq!(lines[0]["message"], "pipeline started");
+    assert_eq!(lines[0]["fields"]["files_discovered"], 10);
+
+    assert_eq!(lines[1]["level"], "WARN");
+    assert_eq!(lines[1]["message"], "adapter failed");
+    assert_eq!(lines[1]["fields"]["adapter"], "tree-sitter");
+}
+
+#[test]
+fn sensitive_fields_are_redacted_in_events() {
+    let writer = CapturedWriter::new();
+    let layer = RedactingJsonLayer::new(writer.clone());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            source_root = "/home/user/secret-project",
+            query_text = "password_hash",
+            pattern = "api_key.*",
+            repo_id = "my-repo",
+            "search started"
+        );
+    });
+
+    let output = writer.contents();
+    let lines = parse_json_lines(&output);
+    assert_eq!(lines.len(), 1);
+
+    let fields = &lines[0]["fields"];
+
+    // Sensitive fields must be redacted.
+    assert_eq!(
+        fields["source_root"], "[REDACTED]",
+        "source_root should be redacted"
+    );
+    assert_eq!(
+        fields["query_text"], "[REDACTED]",
+        "query_text should be redacted"
+    );
+    assert_eq!(
+        fields["pattern"], "[REDACTED]",
+        "pattern should be redacted"
+    );
+
+    // Non-sensitive fields must pass through.
+    assert_eq!(
+        fields["repo_id"], "my-repo",
+        "repo_id should not be redacted"
+    );
+
+    // Redacted values must NOT appear anywhere in the raw output.
+    assert!(
+        !output.contains("/home/user/secret-project"),
+        "absolute path leaked into log output"
+    );
+    assert!(
+        !output.contains("password_hash"),
+        "query text leaked into log output"
+    );
+    assert!(
+        !output.contains("api_key"),
+        "search pattern leaked into log output"
+    );
+}
+
+#[test]
+fn sensitive_fields_are_redacted_in_spans() {
+    let writer = CapturedWriter::new();
+    let layer = RedactingJsonLayer::new(writer.clone());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        let span = tracing::info_span!(
+            "index_pipeline",
+            source_root = "/secret/path",
+            repo_id = "visible-repo",
+        );
+        let _guard = span.enter();
+        tracing::info!("pipeline started");
+    });
+
+    let output = writer.contents();
+    let lines = parse_json_lines(&output);
+    assert_eq!(lines.len(), 1);
+
+    // Span fields should be in the spans array.
+    let spans = lines[0]["spans"].as_array().expect("spans should be array");
+    assert!(!spans.is_empty(), "should have at least one span");
+
+    let pipeline_span = &spans[0];
+    assert_eq!(pipeline_span["name"], "index_pipeline");
+    assert_eq!(
+        pipeline_span["source_root"], "[REDACTED]",
+        "source_root in span should be redacted"
+    );
+    assert_eq!(
+        pipeline_span["repo_id"], "visible-repo",
+        "repo_id in span should not be redacted"
+    );
+
+    // Verify the raw value doesn't leak.
+    assert!(
+        !output.contains("/secret/path"),
+        "absolute path leaked through span fields"
+    );
+}
+
+#[test]
+fn span_context_propagates_to_events() {
+    let writer = CapturedWriter::new();
+    let layer = RedactingJsonLayer::new(writer.clone());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        let outer = tracing::info_span!("request", correlation_id = "job-42");
+        let _outer_guard = outer.enter();
+
+        let inner = tracing::info_span!("stage_discover", repo_id = "test");
+        let _inner_guard = inner.enter();
+
+        tracing::info!(files_discovered = 5, "discovery complete");
+    });
+
+    let output = writer.contents();
+    let lines = parse_json_lines(&output);
+    assert_eq!(lines.len(), 1);
+
+    let spans = lines[0]["spans"].as_array().expect("spans array");
+    assert_eq!(spans.len(), 2, "should have 2 spans (outer + inner)");
+
+    // Root → leaf ordering.
+    assert_eq!(spans[0]["name"], "request");
+    assert_eq!(spans[0]["correlation_id"], "job-42");
+
+    assert_eq!(spans[1]["name"], "stage_discover");
+    assert_eq!(spans[1]["repo_id"], "test");
+}
+
+#[test]
+fn root_field_is_redacted() {
+    let writer = CapturedWriter::new();
+    let layer = RedactingJsonLayer::new(writer.clone());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(root = "/home/user/repos/project", "discovery started");
+    });
+
+    let output = writer.contents();
+    let lines = parse_json_lines(&output);
+    assert_eq!(lines[0]["fields"]["root"], "[REDACTED]");
+    assert!(
+        !output.contains("/home/user/repos/project"),
+        "absolute root path leaked"
+    );
+}
+
+#[test]
+fn non_sensitive_metrics_pass_through() {
+    let writer = CapturedWriter::new();
+    let layer = RedactingJsonLayer::new(writer.clone());
+    let subscriber = tracing_subscriber::registry().with(layer);
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            files_discovered = 42_u64,
+            files_parsed = 40_u64,
+            files_errored = 2_u64,
+            symbols_extracted = 300_u64,
+            "pipeline complete"
+        );
+    });
+
+    let output = writer.contents();
+    let lines = parse_json_lines(&output);
+    let fields = &lines[0]["fields"];
+
+    assert_eq!(fields["files_discovered"], 42);
+    assert_eq!(fields["files_parsed"], 40);
+    assert_eq!(fields["files_errored"], 2);
+    assert_eq!(fields["symbols_extracted"], 300);
+}
+
+#[test]
+fn redaction_policy_is_complete() {
+    // Cross-reference: all fields identified as sensitive in the spec must
+    // be in the SENSITIVE_FIELDS list.
+    let required_sensitive = ["source_root", "root", "query_text", "pattern"];
+
+    for field in &required_sensitive {
+        assert!(
+            logging::is_sensitive(field),
+            "field '{field}' should be in the redaction policy"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Compact mode redaction tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compact_mode_redacts_sensitive_event_fields() {
+    let writer = CapturedWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .compact()
+        .fmt_fields(RedactingFieldFormatter)
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::INFO)
+        .with_ansi(false)
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            source_root = "/home/user/secret-project",
+            query_text = "password_hash",
+            repo_id = "my-repo",
+            "search started"
+        );
+    });
+
+    let output = writer.contents();
+
+    // Sensitive values must not appear in compact output.
+    assert!(
+        !output.contains("/home/user/secret-project"),
+        "absolute path leaked in compact mode: {output}"
+    );
+    assert!(
+        !output.contains("password_hash"),
+        "query text leaked in compact mode: {output}"
+    );
+
+    // Field names should still be present (with redacted values).
+    assert!(
+        output.contains("source_root=[REDACTED]"),
+        "expected source_root=[REDACTED] in compact output: {output}"
+    );
+    assert!(
+        output.contains("query_text=[REDACTED]"),
+        "expected query_text=[REDACTED] in compact output: {output}"
+    );
+
+    // Non-sensitive fields should pass through.
+    assert!(
+        output.contains("repo_id=my-repo"),
+        "expected repo_id=my-repo in compact output: {output}"
+    );
+}
+
+#[test]
+fn compact_mode_redacts_sensitive_span_fields() {
+    let writer = CapturedWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .compact()
+        .fmt_fields(RedactingFieldFormatter)
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::INFO)
+        .with_ansi(false)
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let span = tracing::info_span!(
+            "index_pipeline",
+            source_root = "/secret/path",
+            repo_id = "visible-repo",
+        );
+        let _guard = span.enter();
+        tracing::info!("pipeline started");
+    });
+
+    let output = writer.contents();
+
+    // The absolute path must not appear anywhere.
+    assert!(
+        !output.contains("/secret/path"),
+        "absolute path leaked through compact span fields: {output}"
+    );
+
+    // The redacted placeholder should appear instead.
+    assert!(
+        output.contains("[REDACTED]"),
+        "expected [REDACTED] in compact span output: {output}"
+    );
+
+    // Non-sensitive span fields should pass through.
+    assert!(
+        output.contains("visible-repo"),
+        "expected repo_id to pass through in compact mode: {output}"
+    );
+}
+
+#[test]
+fn compact_mode_passes_through_non_sensitive_fields() {
+    let writer = CapturedWriter::new();
+    let subscriber = tracing_subscriber::fmt()
+        .compact()
+        .fmt_fields(RedactingFieldFormatter)
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::INFO)
+        .with_ansi(false)
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            files_discovered = 42_u64,
+            adapter = "tree-sitter",
+            "stage complete"
+        );
+    });
+
+    let output = writer.contents();
+
+    assert!(
+        output.contains("files_discovered=42"),
+        "expected files_discovered=42 in compact output: {output}"
+    );
+    assert!(
+        output.contains("adapter="),
+        "expected adapter field in compact output: {output}"
+    );
+    assert!(
+        !output.contains("[REDACTED]"),
+        "non-sensitive output should not contain [REDACTED]: {output}"
+    );
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #45
  - Scope: Add structured logging with sensitive-field redaction enforcement for CLI log output, including both JSON and compact formats.

  ## Changes

  - Added a shared CLI logging module with:
      - RedactingJsonLayer for structured JSON log output
      - RedactingFieldFormatter for compact human-readable output with the same redaction policy
      - centralized sensitive-field policy via SENSITIVE_FIELDS and is_sensitive(...)
  - Updated CLI tracing initialization to:
      - default to structured JSON logging
      - support CODEATLAS_LOG_FORMAT=compact for local development
      - enforce redaction in both output modes
      - continue supporting optional OpenTelemetry span export
  - Added a small CLI library target so logging components can be tested directly from integration tests.
  - Added structured logging regression tests covering:
      - valid JSON log schema
      - event-field redaction
      - span-field redaction
      - span context propagation into event output
      - non-sensitive metric passthrough
      - compact-mode redaction for event fields
      - compact-mode redaction for span fields
      - compact-mode passthrough for non-sensitive fields
      - redaction policy completeness checks

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Sensitive fields are redacted by policy.
  - [x] Criterion 2: Log outputs are structured and test-validated.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional test evidence run locally:

  - [x] cargo test -p cli --test structured_logging -- --nocapture

  ## Risk and Mitigation

  - Risk: Sensitive values could leak through alternate log formats or span field rendering even if JSON event logging is redacted.
  - Mitigation: Redaction is centralized in one policy module and applied to both the structured JSON layer and the compact field formatter, with explicit regression coverage for event fields, span fields, and non-sensitive passthrough.

  ## Security/Observability Impact

  - Security: Improves telemetry safety by preventing configured sensitive fields from being emitted in plain form in CLI logs.
  - Logs/Metrics/Tracing: Adds structured JSON logging as the default CLI mode, preserves compact output for local use, and keeps span context visible while enforcing redaction in both formats.