### PR TITLE
Add performance benchmark job and threshold checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,28 @@ jobs:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --all-features --no-deps
 
+  rust-bench:
+    name: Performance Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run performance threshold tests
+        run: |
+          cargo test -p repo-walker --test perf_thresholds -- --nocapture
+          cargo test -p indexer --test perf_thresholds -- --nocapture
+          cargo test -p query-engine --test perf_thresholds -- --nocapture
+
+      - name: Run criterion benchmarks
+        run: cargo bench --workspace
+
   msrv-check:
     name: Rust MSRV Check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +125,58 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli"
@@ -147,6 +217,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +276,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -199,6 +311,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -363,6 +481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +556,7 @@ dependencies = [
  "adapter-api",
  "adapter-syntax-treesitter",
  "core-model",
+ "criterion",
  "query-engine",
  "repo-walker",
  "store",
@@ -440,6 +576,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -545,6 +701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opentelemetry"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +784,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +852,7 @@ dependencies = [
  "adapter-api",
  "adapter-syntax-treesitter",
  "core-model",
+ "criterion",
  "indexer",
  "query-engine",
  "store",
@@ -716,6 +907,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +959,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "repo-walker"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "globset",
  "ignore",
  "tempfile",
@@ -1001,6 +1213,16 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1272,6 +1494,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ opentelemetry = "0.27"
 opentelemetry_sdk = "0.27"
 opentelemetry-stdout = "0.27"
 tracing-opentelemetry = "0.28"
+criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -15,6 +15,11 @@ tracing.workspace = true
 
 [dev-dependencies]
 adapter-syntax-treesitter = { path = "../adapter-syntax-treesitter" }
+criterion.workspace = true
 query-engine = { path = "../query-engine" }
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+
+[[bench]]
+name = "pipeline"
+harness = false

--- a/crates/indexer/benches/pipeline.rs
+++ b/crates/indexer/benches/pipeline.rs
@@ -1,0 +1,163 @@
+//! Criterion benchmarks for the indexing pipeline.
+//!
+//! Measures end-to-end pipeline throughput (discovery → parse → persist)
+//! across synthetic repos. Used for regression detection in CI (spec §13.1, §15).
+
+use std::fs;
+
+use adapter_api::{AdapterPolicy, AdapterRouter, LanguageAdapter};
+use adapter_syntax_treesitter::{create_adapter, supported_languages, TreeSitterAdapter};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use indexer::{run, PipelineContext};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Router backed by real tree-sitter adapters
+// ---------------------------------------------------------------------------
+
+struct TreeSitterRouter {
+    adapters: Vec<TreeSitterAdapter>,
+}
+
+impl TreeSitterRouter {
+    fn new() -> Self {
+        let adapters = supported_languages()
+            .iter()
+            .filter_map(|lang| create_adapter(lang))
+            .collect();
+        Self { adapters }
+    }
+}
+
+impl AdapterRouter for TreeSitterRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        self.adapters
+            .iter()
+            .filter(|a| a.language() == language)
+            .map(|a| a as &dyn LanguageAdapter)
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture setup
+// ---------------------------------------------------------------------------
+
+fn create_rust_repo(file_count: usize) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).expect("create src dir");
+
+    for i in 0..file_count {
+        let content = format!(
+            "pub struct Type{i} {{}}\n\
+             pub fn func_{i}(x: &Type{i}) -> bool {{ true }}\n\
+             impl Type{i} {{\n    \
+                 pub fn method_{i}(&self) -> u32 {{ {i} }}\n\
+             }}\n"
+        );
+        fs::write(src.join(format!("mod_{i}.rs")), content).expect("write file");
+    }
+
+    // Write a main.rs that references the modules.
+    let main_content = (0..file_count)
+        .map(|i| format!("mod mod_{i};"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\nfn main() {}\n";
+    fs::write(src.join("main.rs"), main_content).expect("write main.rs");
+
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_pipeline_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pipeline_throughput");
+    group.sample_size(10);
+
+    let router = TreeSitterRouter::new();
+
+    for &file_count in &[5, 20, 50] {
+        let repo_dir = create_rust_repo(file_count);
+        let blob_dir = TempDir::new().expect("blob temp dir");
+        let blob_store =
+            store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+
+        group.bench_with_input(
+            BenchmarkId::new("end_to_end", file_count),
+            &file_count,
+            |b, _| {
+                b.iter(|| {
+                    // Fresh DB each iteration to measure full index (not incremental).
+                    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+                    let ctx = PipelineContext {
+                        repo_id: "bench-repo".to_string(),
+                        source_root: repo_dir.path().to_path_buf(),
+                        router: &router,
+                        default_policy: AdapterPolicy::SyntaxOnly,
+                        correlation_id: None,
+                        use_git_diff: false,
+                    };
+
+                    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+                    assert!(result.metrics.files_discovered > 0);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_incremental_reindex(c: &mut Criterion) {
+    let mut group = c.benchmark_group("incremental_reindex");
+    group.sample_size(10);
+
+    let router = TreeSitterRouter::new();
+    let repo_dir = create_rust_repo(20);
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+
+    // Pre-populate the store with an initial index.
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+    let ctx = PipelineContext {
+        repo_id: "bench-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: false,
+    };
+    run(&ctx, &mut db, &blob_store).expect("initial index");
+
+    group.bench_function("reindex_no_changes", |b| {
+        b.iter(|| {
+            let ctx = PipelineContext {
+                repo_id: "bench-repo".to_string(),
+                source_root: repo_dir.path().to_path_buf(),
+                router: &router,
+                default_policy: AdapterPolicy::SyntaxOnly,
+                correlation_id: None,
+                use_git_diff: false,
+            };
+            let result = run(&ctx, &mut db, &blob_store).expect("reindex should succeed");
+            assert_eq!(
+                result.metrics.files_unchanged,
+                result.metrics.files_discovered
+            );
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_pipeline_throughput,
+    bench_incremental_reindex
+);
+criterion_main!(benches);

--- a/crates/indexer/tests/perf_thresholds.rs
+++ b/crates/indexer/tests/perf_thresholds.rs
@@ -1,0 +1,178 @@
+//! Performance threshold tests for the indexing pipeline.
+//!
+//! Enforces that key pipeline operations complete within defined time
+//! budgets, providing hard-fail regression detection in CI (spec §13.1, §15).
+//!
+//! SLO reference (spec §13.4):
+//! - Incremental index update visible < 10s on small repos.
+
+use std::fs;
+use std::time::Instant;
+
+use adapter_api::{AdapterPolicy, AdapterRouter, LanguageAdapter};
+use adapter_syntax_treesitter::{create_adapter, supported_languages, TreeSitterAdapter};
+use indexer::{run, PipelineContext};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+struct TreeSitterRouter {
+    adapters: Vec<TreeSitterAdapter>,
+}
+
+impl TreeSitterRouter {
+    fn new() -> Self {
+        let adapters = supported_languages()
+            .iter()
+            .filter_map(|lang| create_adapter(lang))
+            .collect();
+        Self { adapters }
+    }
+}
+
+impl AdapterRouter for TreeSitterRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        self.adapters
+            .iter()
+            .filter(|a| a.language() == language)
+            .map(|a| a as &dyn LanguageAdapter)
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+fn create_rust_repo(file_count: usize) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).expect("create src dir");
+
+    for i in 0..file_count {
+        let content = format!(
+            "pub struct Model{i} {{}}\n\
+             pub fn create_model_{i}() -> Model{i} {{ Model{i} {{}} }}\n\
+             impl Model{i} {{\n    \
+                 pub fn validate(&self) -> bool {{ true }}\n\
+             }}\n"
+        );
+        fs::write(src.join(format!("model_{i}.rs")), content).expect("write file");
+    }
+    fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+
+    dir
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: full pipeline on small repo < 10s (spec §13.4)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_pipeline_small_repo_under_threshold() {
+    let router = TreeSitterRouter::new();
+    let repo_dir = create_rust_repo(20);
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "perf-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let start = Instant::now();
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+    let elapsed = start.elapsed();
+
+    let threshold = std::time::Duration::from_secs(10);
+    assert!(
+        elapsed < threshold,
+        "full pipeline on 20-file repo took {elapsed:?}, exceeds threshold {threshold:?}"
+    );
+    assert!(result.metrics.files_discovered >= 20);
+    assert!(result.metrics.symbols_extracted > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: incremental reindex (no changes) < 5s
+// ---------------------------------------------------------------------------
+
+#[test]
+fn incremental_reindex_no_changes_under_threshold() {
+    let router = TreeSitterRouter::new();
+    let repo_dir = create_rust_repo(20);
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "perf-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    // Initial index.
+    run(&ctx, &mut db, &blob_store).expect("initial index");
+
+    // Re-index with no changes.
+    let start = Instant::now();
+    let result = run(&ctx, &mut db, &blob_store).expect("reindex should succeed");
+    let elapsed = start.elapsed();
+
+    let threshold = std::time::Duration::from_secs(5);
+    assert!(
+        elapsed < threshold,
+        "incremental reindex took {elapsed:?}, exceeds threshold {threshold:?}"
+    );
+    // All files should be detected as unchanged.
+    assert_eq!(
+        result.metrics.files_unchanged, result.metrics.files_discovered,
+        "all files should be unchanged on reindex"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: pipeline throughput on larger repo
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pipeline_50_files_under_threshold() {
+    let router = TreeSitterRouter::new();
+    let repo_dir = create_rust_repo(50);
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "perf-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let start = Instant::now();
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+    let elapsed = start.elapsed();
+
+    let threshold = std::time::Duration::from_secs(30);
+    assert!(
+        elapsed < threshold,
+        "pipeline on 50-file repo took {elapsed:?}, exceeds threshold {threshold:?}"
+    );
+    assert!(result.metrics.files_discovered >= 50);
+}

--- a/crates/query-engine/Cargo.toml
+++ b/crates/query-engine/Cargo.toml
@@ -16,7 +16,12 @@ tracing.workspace = true
 [dev-dependencies]
 adapter-api.workspace = true
 adapter-syntax-treesitter.workspace = true
+criterion.workspace = true
 indexer.workspace = true
 query-engine = { path = ".", features = ["test-support"] }
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+
+[[bench]]
+name = "queries"
+harness = false

--- a/crates/query-engine/benches/queries.rs
+++ b/crates/query-engine/benches/queries.rs
@@ -1,0 +1,285 @@
+//! Criterion benchmarks for query-engine latency.
+//!
+//! Measures query p50/p95/p99 against a pre-populated in-memory store.
+//! Covers the SLO targets from spec §13.4:
+//! - `search_symbols` p95 < 300ms (warmed index)
+//! - `get_symbol` p95 < 120ms
+//!
+//! Used for regression detection in CI (spec §13.1, §15).
+
+use std::fs;
+
+use adapter_api::{AdapterPolicy, AdapterRouter, LanguageAdapter};
+use adapter_syntax_treesitter::{create_adapter, supported_languages, TreeSitterAdapter};
+use criterion::{criterion_group, criterion_main, Criterion};
+use indexer::{run, PipelineContext};
+use query_engine::StoreQueryService;
+use query_engine::{
+    FileOutlineRequest, FileTreeRequest, QueryFilters, QueryService, RepoOutlineRequest,
+    SymbolQuery, TextQuery,
+};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+struct TreeSitterRouter {
+    adapters: Vec<TreeSitterAdapter>,
+}
+
+impl TreeSitterRouter {
+    fn new() -> Self {
+        let adapters = supported_languages()
+            .iter()
+            .filter_map(|lang| create_adapter(lang))
+            .collect();
+        Self { adapters }
+    }
+}
+
+impl AdapterRouter for TreeSitterRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        self.adapters
+            .iter()
+            .filter(|a| a.language() == language)
+            .map(|a| a as &dyn LanguageAdapter)
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: pre-populated store
+// ---------------------------------------------------------------------------
+
+struct BenchFixture {
+    db: store::MetadataStore,
+    _repo_dir: TempDir,
+    _blob_dir: TempDir,
+}
+
+fn create_populated_store(file_count: usize) -> BenchFixture {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src");
+    fs::create_dir_all(&src).expect("create src dir");
+
+    for i in 0..file_count {
+        let content = format!(
+            "pub struct Widget{i} {{}}\n\
+             pub fn create_widget_{i}() -> Widget{i} {{ Widget{i} {{}} }}\n\
+             impl Widget{i} {{\n    \
+                 pub fn process(&self) -> u32 {{ {i} }}\n    \
+                 pub fn render(&self) -> String {{ format!(\"widget-{i}\") }}\n\
+             }}\n"
+        );
+        fs::write(src.join(format!("widget_{i}.rs")), content).expect("write file");
+    }
+    fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "bench-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    run(&ctx, &mut db, &blob_store).expect("index should succeed");
+
+    BenchFixture {
+        db,
+        _repo_dir: repo_dir,
+        _blob_dir: blob_dir,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_search_symbols(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_search_symbols");
+    group.sample_size(50);
+
+    let fixture = create_populated_store(50);
+    let svc = StoreQueryService::new(&fixture.db);
+
+    group.bench_function("exact_match", |b| {
+        b.iter(|| {
+            let query = SymbolQuery {
+                repo_id: "bench-repo".to_string(),
+                text: "Widget0".to_string(),
+                limit: 10,
+                offset: 0,
+                filters: QueryFilters::default(),
+            };
+            let result = svc.search_symbols(&query).expect("search should succeed");
+            assert!(!result.items.is_empty());
+        });
+    });
+
+    group.bench_function("prefix_match", |b| {
+        b.iter(|| {
+            let query = SymbolQuery {
+                repo_id: "bench-repo".to_string(),
+                text: "create_widget".to_string(),
+                limit: 20,
+                offset: 0,
+                filters: QueryFilters::default(),
+            };
+            svc.search_symbols(&query).expect("search should succeed");
+        });
+    });
+
+    group.bench_function("no_match", |b| {
+        b.iter(|| {
+            let query = SymbolQuery {
+                repo_id: "bench-repo".to_string(),
+                text: "nonexistent_symbol_xyz".to_string(),
+                limit: 10,
+                offset: 0,
+                filters: QueryFilters::default(),
+            };
+            let result = svc.search_symbols(&query).expect("search should succeed");
+            assert!(result.items.is_empty());
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_get_symbol(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_get_symbol");
+    group.sample_size(50);
+
+    let fixture = create_populated_store(50);
+    let svc = StoreQueryService::new(&fixture.db);
+
+    // Find a real symbol ID to query.
+    let query = SymbolQuery {
+        repo_id: "bench-repo".to_string(),
+        text: "Widget0".to_string(),
+        limit: 1,
+        offset: 0,
+        filters: QueryFilters::default(),
+    };
+    let result = svc.search_symbols(&query).expect("find symbol");
+    let symbol_id = result.items[0].record.id.clone();
+
+    group.bench_function("by_id", |b| {
+        b.iter(|| {
+            svc.get_symbol(&symbol_id).expect("get should succeed");
+        });
+    });
+
+    group.bench_function("not_found", |b| {
+        b.iter(|| {
+            let _ = svc.get_symbol("nonexistent-id-12345");
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_file_outline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_file_outline");
+    group.sample_size(50);
+
+    let fixture = create_populated_store(50);
+    let svc = StoreQueryService::new(&fixture.db);
+
+    group.bench_function("single_file", |b| {
+        b.iter(|| {
+            let request = FileOutlineRequest {
+                repo_id: "bench-repo".to_string(),
+                file_path: "src/widget_0.rs".to_string(),
+            };
+            svc.get_file_outline(&request)
+                .expect("outline should succeed");
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_file_tree(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_file_tree");
+    group.sample_size(50);
+
+    let fixture = create_populated_store(50);
+    let svc = StoreQueryService::new(&fixture.db);
+
+    group.bench_function("full_tree", |b| {
+        b.iter(|| {
+            let request = FileTreeRequest {
+                repo_id: "bench-repo".to_string(),
+                path_prefix: None,
+            };
+            svc.get_file_tree(&request).expect("tree should succeed");
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_repo_outline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_repo_outline");
+    group.sample_size(50);
+
+    let fixture = create_populated_store(50);
+    let svc = StoreQueryService::new(&fixture.db);
+
+    group.bench_function("full_outline", |b| {
+        b.iter(|| {
+            let request = RepoOutlineRequest {
+                repo_id: "bench-repo".to_string(),
+            };
+            svc.get_repo_outline(&request)
+                .expect("outline should succeed");
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_search_text(c: &mut Criterion) {
+    let mut group = c.benchmark_group("query_search_text");
+    group.sample_size(50);
+
+    let fixture = create_populated_store(50);
+    let svc = StoreQueryService::new(&fixture.db);
+
+    group.bench_function("fts_query", |b| {
+        b.iter(|| {
+            let query = TextQuery {
+                repo_id: "bench-repo".to_string(),
+                pattern: "widget".to_string(),
+                filters: QueryFilters::default(),
+                limit: 20,
+                offset: 0,
+            };
+            svc.search_text(&query).expect("search should succeed");
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_search_symbols,
+    bench_get_symbol,
+    bench_file_outline,
+    bench_file_tree,
+    bench_repo_outline,
+    bench_search_text,
+);
+criterion_main!(benches);

--- a/crates/query-engine/tests/perf_thresholds.rs
+++ b/crates/query-engine/tests/perf_thresholds.rs
@@ -1,0 +1,307 @@
+//! Performance threshold tests for query-engine operations.
+//!
+//! These tests enforce the SLO targets from spec §13.4 and §15:
+//! - `search_symbols` < 300ms (warmed index, p95)
+//! - `get_symbol` < 120ms
+//!
+//! Thresholds are intentionally generous to accommodate CI runner variance.
+//! Criterion benchmarks provide detailed profiling; these tests provide
+//! hard-fail regression detection.
+
+use std::fs;
+use std::time::Instant;
+
+use adapter_api::{AdapterPolicy, AdapterRouter, LanguageAdapter};
+use adapter_syntax_treesitter::{create_adapter, supported_languages, TreeSitterAdapter};
+use indexer::{run, PipelineContext};
+use query_engine::{
+    FileOutlineRequest, FileTreeRequest, QueryFilters, QueryService, RepoOutlineRequest,
+    StoreQueryService, SymbolQuery, TextQuery,
+};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+struct TreeSitterRouter {
+    adapters: Vec<TreeSitterAdapter>,
+}
+
+impl TreeSitterRouter {
+    fn new() -> Self {
+        let adapters = supported_languages()
+            .iter()
+            .filter_map(|lang| create_adapter(lang))
+            .collect();
+        Self { adapters }
+    }
+}
+
+impl AdapterRouter for TreeSitterRouter {
+    fn select(&self, language: &str, _policy: AdapterPolicy) -> Vec<&dyn LanguageAdapter> {
+        self.adapters
+            .iter()
+            .filter(|a| a.language() == language)
+            .map(|a| a as &dyn LanguageAdapter)
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture setup
+// ---------------------------------------------------------------------------
+
+fn setup_populated_store(file_count: usize) -> (store::MetadataStore, TempDir, TempDir) {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src");
+    fs::create_dir_all(&src).expect("create src dir");
+
+    for i in 0..file_count {
+        let content = format!(
+            "pub struct Component{i} {{}}\n\
+             pub fn build_component_{i}() -> Component{i} {{ Component{i} {{}} }}\n\
+             impl Component{i} {{\n    \
+                 pub fn update(&self) -> u32 {{ {i} }}\n    \
+                 pub fn draw(&self) -> String {{ format!(\"c-{i}\") }}\n\
+             }}\n"
+        );
+        fs::write(src.join(format!("component_{i}.rs")), content).expect("write file");
+    }
+    fs::write(src.join("main.rs"), "fn main() {}\n").expect("write main.rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "perf-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        default_policy: AdapterPolicy::SyntaxOnly,
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    run(&ctx, &mut db, &blob_store).expect("index should succeed");
+
+    (db, repo_dir, blob_dir)
+}
+
+/// Runs `op` `n` times, returning all durations sorted.
+fn measure_latencies<F: FnMut()>(mut op: F, n: usize) -> Vec<std::time::Duration> {
+    let mut durations = Vec::with_capacity(n);
+    for _ in 0..n {
+        let start = Instant::now();
+        op();
+        durations.push(start.elapsed());
+    }
+    durations.sort();
+    durations
+}
+
+/// Returns the p95 value from a sorted duration slice.
+fn p95(sorted: &[std::time::Duration]) -> std::time::Duration {
+    let idx = (sorted.len() as f64 * 0.95) as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: search_symbols p95 < 300ms (spec §13.4)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_symbols_p95_under_threshold() {
+    let (db, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db);
+
+    // Warm-up.
+    for _ in 0..5 {
+        let _ = svc.search_symbols(&SymbolQuery {
+            repo_id: "perf-repo".to_string(),
+            text: "Component".to_string(),
+            limit: 10,
+            offset: 0,
+            filters: QueryFilters::default(),
+        });
+    }
+
+    let latencies = measure_latencies(
+        || {
+            svc.search_symbols(&SymbolQuery {
+                repo_id: "perf-repo".to_string(),
+                text: "Component".to_string(),
+                limit: 10,
+                offset: 0,
+                filters: QueryFilters::default(),
+            })
+            .expect("search should succeed");
+        },
+        100,
+    );
+
+    let threshold = std::time::Duration::from_millis(300);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "search_symbols p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: get_symbol p95 < 120ms (spec §13.4)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_symbol_p95_under_threshold() {
+    let (db, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db);
+
+    // Find a real symbol ID.
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "perf-repo".to_string(),
+            text: "Component0".to_string(),
+            limit: 1,
+            offset: 0,
+            filters: QueryFilters::default(),
+        })
+        .expect("find symbol");
+    let symbol_id = result.items[0].record.id.clone();
+
+    // Warm-up.
+    for _ in 0..5 {
+        let _ = svc.get_symbol(&symbol_id);
+    }
+
+    let latencies = measure_latencies(
+        || {
+            svc.get_symbol(&symbol_id).expect("get should succeed");
+        },
+        100,
+    );
+
+    let threshold = std::time::Duration::from_millis(120);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "get_symbol p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: file_outline completes in reasonable time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn file_outline_p95_under_threshold() {
+    let (db, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db);
+
+    let latencies = measure_latencies(
+        || {
+            svc.get_file_outline(&FileOutlineRequest {
+                repo_id: "perf-repo".to_string(),
+                file_path: "src/component_0.rs".to_string(),
+            })
+            .expect("outline should succeed");
+        },
+        100,
+    );
+
+    let threshold = std::time::Duration::from_millis(200);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "file_outline p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: file_tree completes in reasonable time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn file_tree_p95_under_threshold() {
+    let (db, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db);
+
+    let latencies = measure_latencies(
+        || {
+            svc.get_file_tree(&FileTreeRequest {
+                repo_id: "perf-repo".to_string(),
+                path_prefix: None,
+            })
+            .expect("tree should succeed");
+        },
+        100,
+    );
+
+    let threshold = std::time::Duration::from_millis(200);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "file_tree p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: repo_outline completes in reasonable time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repo_outline_p95_under_threshold() {
+    let (db, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db);
+
+    let latencies = measure_latencies(
+        || {
+            svc.get_repo_outline(&RepoOutlineRequest {
+                repo_id: "perf-repo".to_string(),
+            })
+            .expect("outline should succeed");
+        },
+        100,
+    );
+
+    let threshold = std::time::Duration::from_millis(300);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "repo_outline p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: search_text (FTS) completes in reasonable time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_text_p95_under_threshold() {
+    let (db, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db);
+
+    let latencies = measure_latencies(
+        || {
+            svc.search_text(&TextQuery {
+                repo_id: "perf-repo".to_string(),
+                pattern: "component".to_string(),
+                filters: QueryFilters::default(),
+                limit: 20,
+                offset: 0,
+            })
+            .expect("search should succeed");
+        },
+        100,
+    );
+
+    let threshold = std::time::Duration::from_millis(300);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "search_text p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}

--- a/crates/repo-walker/Cargo.toml
+++ b/crates/repo-walker/Cargo.toml
@@ -11,5 +11,10 @@ ignore.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+
+[[bench]]
+name = "discovery"
+harness = false

--- a/crates/repo-walker/benches/discovery.rs
+++ b/crates/repo-walker/benches/discovery.rs
@@ -1,0 +1,84 @@
+//! Criterion benchmarks for repository discovery throughput.
+//!
+//! Measures wall-clock time for `walk_repository` across synthetic repos
+//! of varying sizes. Used for regression detection in CI (spec §13.1, §15).
+
+use std::fs;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use repo_walker::{walk_repository, WalkerOptions};
+use tempfile::TempDir;
+
+/// Creates a temporary repo with `n` Rust source files spread across directories.
+fn create_fixture_repo(n: usize) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    for i in 0..n {
+        let subdir = format!("src/pkg{}", i / 10);
+        let path = dir.path().join(&subdir);
+        fs::create_dir_all(&path).expect("create dir");
+        fs::write(
+            path.join(format!("file_{i}.rs")),
+            format!("pub fn func_{i}() {{}}\n"),
+        )
+        .expect("write file");
+    }
+    dir
+}
+
+fn bench_discovery_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group("discovery_throughput");
+    group.sample_size(20);
+
+    for &file_count in &[50, 100, 500] {
+        let repo = create_fixture_repo(file_count);
+        let options = WalkerOptions::default();
+
+        group.bench_with_input(BenchmarkId::new("walk", file_count), &file_count, |b, _| {
+            b.iter(|| {
+                let result = walk_repository(repo.path(), &options).expect("walk should succeed");
+                assert_eq!(result.metrics.files_discovered, file_count);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_discovery_with_filters(c: &mut Criterion) {
+    let mut group = c.benchmark_group("discovery_with_filters");
+    group.sample_size(20);
+
+    let repo = create_fixture_repo(200);
+
+    // Baseline: no extra filters.
+    group.bench_function("no_filters", |b| {
+        let options = WalkerOptions::default();
+        b.iter(|| walk_repository(repo.path(), &options).expect("walk"));
+    });
+
+    // With extra ignore rules.
+    group.bench_function("with_ignore_rules", |b| {
+        let options = WalkerOptions {
+            extra_ignore_rules: vec!["src/pkg0/**".to_string(), "src/pkg1/**".to_string()],
+            ..WalkerOptions::default()
+        };
+        b.iter(|| walk_repository(repo.path(), &options).expect("walk"));
+    });
+
+    // With file size cap.
+    group.bench_function("with_size_cap", |b| {
+        let options = WalkerOptions {
+            max_file_size_bytes: Some(1024),
+            ..WalkerOptions::default()
+        };
+        b.iter(|| walk_repository(repo.path(), &options).expect("walk"));
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_discovery_throughput,
+    bench_discovery_with_filters
+);
+criterion_main!(benches);

--- a/crates/repo-walker/tests/perf_thresholds.rs
+++ b/crates/repo-walker/tests/perf_thresholds.rs
@@ -1,0 +1,127 @@
+//! Performance threshold tests for repository discovery.
+//!
+//! Enforces that discovery operations complete within defined time budgets,
+//! providing hard-fail regression detection in CI (spec §13.1, §15).
+
+use std::fs;
+use std::time::Instant;
+
+use repo_walker::{walk_repository, WalkerOptions};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+fn create_fixture_repo(file_count: usize) -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    for i in 0..file_count {
+        let subdir = format!("src/pkg{}", i / 10);
+        let path = dir.path().join(&subdir);
+        fs::create_dir_all(&path).expect("create dir");
+        fs::write(
+            path.join(format!("file_{i}.rs")),
+            format!("pub fn func_{i}() {{}}\n"),
+        )
+        .expect("write file");
+    }
+    dir
+}
+
+/// Runs `op` `n` times, returning all durations sorted.
+fn measure_latencies<F: FnMut()>(mut op: F, n: usize) -> Vec<std::time::Duration> {
+    let mut durations = Vec::with_capacity(n);
+    for _ in 0..n {
+        let start = Instant::now();
+        op();
+        durations.push(start.elapsed());
+    }
+    durations.sort();
+    durations
+}
+
+/// Returns the p95 value from a sorted duration slice.
+fn p95(sorted: &[std::time::Duration]) -> std::time::Duration {
+    let idx = (sorted.len() as f64 * 0.95) as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: discovery of 100 files p95 < 500ms
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discovery_100_files_p95_under_threshold() {
+    let repo = create_fixture_repo(100);
+    let options = WalkerOptions::default();
+
+    // Warm-up.
+    for _ in 0..3 {
+        let _ = walk_repository(repo.path(), &options);
+    }
+
+    let latencies = measure_latencies(
+        || {
+            let result = walk_repository(repo.path(), &options).expect("walk should succeed");
+            assert_eq!(result.metrics.files_discovered, 100);
+        },
+        50,
+    );
+
+    let threshold = std::time::Duration::from_millis(500);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "discovery 100 files p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: discovery of 500 files < 3s
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discovery_500_files_under_threshold() {
+    let repo = create_fixture_repo(500);
+    let options = WalkerOptions::default();
+
+    let start = Instant::now();
+    let result = walk_repository(repo.path(), &options).expect("walk should succeed");
+    let elapsed = start.elapsed();
+
+    assert_eq!(result.metrics.files_discovered, 500);
+
+    let threshold = std::time::Duration::from_secs(3);
+    assert!(
+        elapsed < threshold,
+        "discovery 500 files took {elapsed:?}, exceeds threshold {threshold:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Threshold: discovery with ignore rules p95 < 500ms
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discovery_with_filters_p95_under_threshold() {
+    let repo = create_fixture_repo(200);
+    let options = WalkerOptions {
+        extra_ignore_rules: vec!["src/pkg0/**".to_string(), "src/pkg1/**".to_string()],
+        max_file_size_bytes: Some(1024),
+        ..WalkerOptions::default()
+    };
+
+    let latencies = measure_latencies(
+        || {
+            walk_repository(repo.path(), &options).expect("walk should succeed");
+        },
+        50,
+    );
+
+    let threshold = std::time::Duration::from_millis(500);
+    let measured = p95(&latencies);
+    assert!(
+        measured < threshold,
+        "discovery with filters p95 = {measured:?}, exceeds threshold {threshold:?}"
+    );
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #47
  - Scope: Add CI benchmark execution and hard performance threshold checks for discovery, indexing, and query paths so regressions fail visibly in CI.

  ## Changes

  - Added a dedicated Performance Benchmarks CI job in .github/workflows/ci.yml that:
      - runs performance threshold tests for repo-walker, indexer, and query-engine
      - runs workspace Criterion benchmarks via cargo bench --workspace
  - Added Criterion benchmark harnesses for:
      - repository discovery in repo-walker
      - end-to-end pipeline throughput and incremental reindex in indexer
      - query latency in query-engine
  - Added hard-fail threshold tests for:
      - repo-walker
          - 100-file discovery p95 < 500ms
          - 500-file discovery < 3s
          - filtered discovery p95 < 500ms
      - indexer
          - full small-repo pipeline under threshold
          - no-change incremental reindex under threshold
          - 50-file pipeline under threshold
      - query-engine
          - search_symbols p95 under threshold
          - get_symbol p95 under threshold
          - file_outline, file_tree, repo_outline, and search_text under defined thresholds
  - Defined visible failure behavior through normal test failures, so threshold regressions break the CI job instead of only producing benchmark output.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Benchmark job runs in CI.
  - [x] Criterion 2: Thresholds are defined and failures are visible.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional test evidence run locally:

  - [x] cargo test -p repo-walker --test perf_thresholds -- --nocapture
  - [x] cargo test -p indexer --test perf_thresholds -- --nocapture
  - [x] cargo test -p query-engine --test perf_thresholds -- --nocapture

  ## Risk and Mitigation

  - Risk: Performance regressions can slip through if benchmarks run only for visibility and are not tied to explicit failure thresholds.
  - Mitigation: CI now runs hard-fail threshold tests for discovery, indexing, and query paths, while Criterion benchmarks still provide trend/profiling data for deeper analysis.

  ## Security/Observability Impact

  - Security: No direct security behavior change; impact is CI and test infrastructure only.
  - Logs/Metrics/Tracing: Improves operational visibility by making performance regressions explicit in CI and by establishing baseline benchmark coverage for key latency-sensitive paths.