### PR TITLE
TypeScript semantic adapter: symbol mapping to canonical schema

### DIFF
--- a/crates/adapter-api/src/contract.rs
+++ b/crates/adapter-api/src/contract.rs
@@ -60,6 +60,24 @@ impl ContractFixture {
             ],
         }
     }
+
+    /// A baseline TypeScript fixture covering common symbol kinds.
+    #[must_use]
+    pub fn typescript_baseline() -> Self {
+        Self {
+            language: "typescript".to_string(),
+            source_code: TYPESCRIPT_FIXTURE.as_bytes().to_vec(),
+            relative_path: PathBuf::from("src/config.ts"),
+            expected_min_symbols: 5,
+            expected_symbol_names: vec![
+                "Config".to_string(),
+                "create".to_string(),
+                "process".to_string(),
+                "Mode".to_string(),
+                "MAX_SIZE".to_string(),
+            ],
+        }
+    }
 }
 
 /// Baseline Rust source fixture used by contract tests.
@@ -91,6 +109,34 @@ pub enum Mode {
 }
 
 pub const MAX_SIZE: usize = 1024;
+"#;
+
+/// Baseline TypeScript source fixture used by contract tests.
+const TYPESCRIPT_FIXTURE: &str = r#"/** Configuration for processing. */
+interface Config {
+    name: string;
+    limit: number;
+}
+
+/** Creates a new config with defaults. */
+function create(name: string): Config {
+    return { name, limit: 100 };
+}
+
+class Processor {
+    /** Processes the config. */
+    process(config: Config): boolean {
+        return config.limit > 0;
+    }
+}
+
+/** Operating mode. */
+enum Mode {
+    Fast,
+    Precise,
+}
+
+const MAX_SIZE: number = 1024;
 "#;
 
 // ---------------------------------------------------------------------------

--- a/crates/adapter-semantic-typescript/src/adapter.rs
+++ b/crates/adapter-semantic-typescript/src/adapter.rs
@@ -1,0 +1,585 @@
+use std::cell::RefCell;
+
+use adapter_api::{
+    AdapterCapabilities, AdapterError, AdapterOutput, IndexContext, LanguageAdapter, SourceFile,
+};
+use core_model::QualityLevel;
+use tracing::{debug, warn};
+
+use crate::error::TsServerError;
+use crate::mapping::{map_navtree_to_symbols, NavTreeItem};
+use crate::runtime::SemanticRuntime;
+
+const ADAPTER_ID: &str = "semantic-typescript-v1";
+const LANGUAGE: &str = "typescript";
+
+/// A semantic adapter for TypeScript that uses tsserver's navigation tree
+/// to extract symbols with high-confidence, type-aware metadata.
+///
+/// The adapter communicates with a tsserver process through the
+/// [`SemanticRuntime`] trait, enabling test doubles without real processes.
+pub struct TypeScriptSemanticAdapter<R: SemanticRuntime> {
+    runtime: RefCell<R>,
+    capabilities: AdapterCapabilities,
+}
+
+impl<R: SemanticRuntime> TypeScriptSemanticAdapter<R> {
+    /// Creates a new TypeScript semantic adapter wrapping the given runtime.
+    ///
+    /// The runtime must be started before calling `index_file`. The adapter
+    /// does not manage the runtime lifecycle — callers are responsible for
+    /// starting and stopping the runtime.
+    pub fn new(runtime: R) -> Self {
+        Self {
+            runtime: RefCell::new(runtime),
+            capabilities: AdapterCapabilities::semantic_baseline(),
+        }
+    }
+
+    /// Sends an "open" request to tsserver for the given file, then requests
+    /// the navigation tree and parses the response into `NavTreeItem`s.
+    fn request_navtree(&self, file: &SourceFile) -> Result<Vec<NavTreeItem>, AdapterError> {
+        let file_path = file.absolute_path.to_string_lossy().to_string();
+        let content = String::from_utf8_lossy(&file.content).to_string();
+        let mut rt = self.runtime.borrow_mut();
+
+        // Open the file in tsserver with its content.
+        let open_args = serde_json::json!({
+            "file": file_path,
+            "fileContent": content,
+            "scriptKindName": script_kind_for_path(&file.relative_path),
+        });
+
+        rt.send_request("open", Some(open_args)).map_err(|e| {
+            warn!(file = %file.relative_path.display(), error = %e, "tsserver open failed");
+            ts_error_to_adapter_error(e, &file.relative_path)
+        })?;
+
+        // Request the navigation tree.
+        let navtree_args = serde_json::json!({
+            "file": file_path,
+        });
+
+        let response = rt
+            .send_request("navtree", Some(navtree_args))
+            .map_err(|e| {
+                warn!(file = %file.relative_path.display(), error = %e, "tsserver navtree failed");
+                ts_error_to_adapter_error(e, &file.relative_path)
+            })?;
+
+        // Close the file to free tsserver resources.
+        let close_args = serde_json::json!({ "file": file_path });
+        if let Err(e) = rt.send_request("close", Some(close_args)) {
+            debug!(file = %file.relative_path.display(), error = %e, "tsserver close failed (non-fatal)");
+        }
+
+        // Parse the navtree from the response body.
+        let body = response.body.ok_or_else(|| AdapterError::Parse {
+            path: file.relative_path.clone(),
+            reason: "navtree response has no body".to_string(),
+        })?;
+
+        parse_navtree_body(&body, &file.relative_path)
+    }
+}
+
+impl<R: SemanticRuntime> LanguageAdapter for TypeScriptSemanticAdapter<R> {
+    fn adapter_id(&self) -> &str {
+        ADAPTER_ID
+    }
+
+    fn language(&self) -> &str {
+        LANGUAGE
+    }
+
+    fn capabilities(&self) -> &AdapterCapabilities {
+        &self.capabilities
+    }
+
+    fn index_file(
+        &self,
+        _ctx: &IndexContext,
+        file: &SourceFile,
+    ) -> Result<AdapterOutput, AdapterError> {
+        if file.language != LANGUAGE {
+            return Err(AdapterError::Unsupported {
+                language: file.language.clone(),
+            });
+        }
+
+        // Empty files produce no symbols.
+        if file.content.is_empty() {
+            return Ok(AdapterOutput {
+                symbols: vec![],
+                source_adapter: ADAPTER_ID.to_string(),
+                quality_level: QualityLevel::Semantic,
+            });
+        }
+
+        let navtree_items = self.request_navtree(file)?;
+        let mut symbols = map_navtree_to_symbols(&navtree_items, &file.content);
+
+        // Apply default confidence to symbols that don't have per-symbol overrides.
+        let default_confidence = self.capabilities.default_confidence;
+        for sym in &mut symbols {
+            if sym.confidence_score.is_none() {
+                sym.confidence_score = Some(default_confidence);
+            }
+        }
+
+        Ok(AdapterOutput {
+            symbols,
+            source_adapter: ADAPTER_ID.to_string(),
+            quality_level: QualityLevel::Semantic,
+        })
+    }
+}
+
+/// Parses the navtree response body into a list of `NavTreeItem`s.
+///
+/// The navtree response may be a single root item (with `childItems`)
+/// or directly a list of items.
+fn parse_navtree_body(
+    body: &serde_json::Value,
+    path: &std::path::Path,
+) -> Result<Vec<NavTreeItem>, AdapterError> {
+    // tsserver returns navtree as a single root item. The children of
+    // the root represent the top-level symbols in the file.
+    if let Ok(root) = serde_json::from_value::<NavTreeItem>(body.clone()) {
+        return Ok(root.child_items);
+    }
+
+    // Fallback: try parsing as a direct array.
+    if let Ok(items) = serde_json::from_value::<Vec<NavTreeItem>>(body.clone()) {
+        return Ok(items);
+    }
+
+    Err(AdapterError::Parse {
+        path: path.to_path_buf(),
+        reason: "failed to parse navtree response body".to_string(),
+    })
+}
+
+/// Returns the tsserver script kind based on file extension.
+fn script_kind_for_path(path: &std::path::Path) -> &'static str {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("tsx") => "TSX",
+        Some("jsx") => "JSX",
+        Some("js") | Some("mjs") | Some("cjs") => "JS",
+        _ => "TS",
+    }
+}
+
+/// Converts a `TsServerError` into an `AdapterError`.
+fn ts_error_to_adapter_error(error: TsServerError, path: &std::path::Path) -> AdapterError {
+    match error {
+        TsServerError::Timeout { operation } => AdapterError::Parse {
+            path: path.to_path_buf(),
+            reason: format!("tsserver timed out: {operation}"),
+        },
+        TsServerError::Io { source } => AdapterError::Io {
+            path: Some(path.to_path_buf()),
+            source,
+        },
+        other => AdapterError::Parse {
+            path: path.to_path_buf(),
+            reason: other.to_string(),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::TsServerResponse;
+    use std::path::PathBuf;
+
+    /// A mock runtime that returns canned navtree responses for testing
+    /// the adapter without a real tsserver process.
+    struct MockRuntime {
+        navtree_response: Option<serde_json::Value>,
+        started: bool,
+        request_log: Vec<String>,
+    }
+
+    impl MockRuntime {
+        fn new(navtree_body: serde_json::Value) -> Self {
+            Self {
+                navtree_response: Some(navtree_body),
+                started: true,
+                request_log: Vec::new(),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                navtree_response: None,
+                started: true,
+                request_log: Vec::new(),
+            }
+        }
+    }
+
+    impl SemanticRuntime for MockRuntime {
+        fn start(&mut self) -> Result<(), TsServerError> {
+            self.started = true;
+            Ok(())
+        }
+
+        fn stop(&mut self) {
+            self.started = false;
+        }
+
+        fn restart(&mut self) -> Result<(), TsServerError> {
+            self.started = true;
+            Ok(())
+        }
+
+        fn is_healthy(&mut self) -> bool {
+            self.started
+        }
+
+        fn send_request(
+            &mut self,
+            command: &str,
+            _arguments: Option<serde_json::Value>,
+        ) -> Result<TsServerResponse, TsServerError> {
+            self.request_log.push(command.to_string());
+
+            match command {
+                "open" | "close" => Ok(TsServerResponse {
+                    seq: 0,
+                    msg_type: "response".to_string(),
+                    command: Some(command.to_string()),
+                    request_seq: Some(1),
+                    success: Some(true),
+                    body: None,
+                    message: None,
+                }),
+                "navtree" => {
+                    if let Some(body) = &self.navtree_response {
+                        Ok(TsServerResponse {
+                            seq: 0,
+                            msg_type: "response".to_string(),
+                            command: Some("navtree".to_string()),
+                            request_seq: Some(2),
+                            success: Some(true),
+                            body: Some(body.clone()),
+                            message: None,
+                        })
+                    } else {
+                        Err(TsServerError::Protocol {
+                            reason: "mock: no navtree response configured".to_string(),
+                        })
+                    }
+                }
+                _ => Ok(TsServerResponse {
+                    seq: 0,
+                    msg_type: "response".to_string(),
+                    command: Some(command.to_string()),
+                    request_seq: Some(1),
+                    success: Some(true),
+                    body: None,
+                    message: None,
+                }),
+            }
+        }
+    }
+
+    fn make_context() -> IndexContext {
+        IndexContext {
+            repo_id: "test-repo".to_string(),
+            source_root: PathBuf::from("/tmp/test-repo"),
+        }
+    }
+
+    fn make_ts_file(content: &str) -> SourceFile {
+        SourceFile {
+            relative_path: PathBuf::from("src/main.ts"),
+            absolute_path: PathBuf::from("/tmp/test-repo/src/main.ts"),
+            content: content.as_bytes().to_vec(),
+            language: "typescript".to_string(),
+        }
+    }
+
+    fn navtree_body(child_items: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "text": "<global>",
+            "kind": "script",
+            "kindModifiers": "",
+            "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": 1, "offset": 1}}],
+            "childItems": child_items
+        })
+    }
+
+    // -- Identity and capabilities --
+
+    #[test]
+    fn adapter_id_follows_naming_convention() {
+        let rt = MockRuntime::new(navtree_body(serde_json::json!([])));
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        assert_eq!(adapter.adapter_id(), "semantic-typescript-v1");
+        assert_eq!(adapter.language(), "typescript");
+    }
+
+    #[test]
+    fn capabilities_are_semantic_level() {
+        let rt = MockRuntime::new(navtree_body(serde_json::json!([])));
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let caps = adapter.capabilities();
+        assert_eq!(caps.quality_level, QualityLevel::Semantic);
+        assert!((caps.default_confidence - 0.9).abs() < f32::EPSILON);
+        assert!(caps.supports_type_refs);
+        assert!(caps.supports_call_refs);
+    }
+
+    // -- Language rejection --
+
+    #[test]
+    fn rejects_unsupported_language() {
+        let rt = MockRuntime::new(navtree_body(serde_json::json!([])));
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let ctx = make_context();
+        let file = SourceFile {
+            language: "python".to_string(),
+            ..make_ts_file("x = 1")
+        };
+        let err = adapter.index_file(&ctx, &file).expect_err("should reject");
+        assert!(err.to_string().contains("unsupported language"));
+    }
+
+    // -- Empty file --
+
+    #[test]
+    fn empty_file_produces_no_symbols() {
+        let rt = MockRuntime::new(navtree_body(serde_json::json!([])));
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let ctx = make_context();
+        let file = make_ts_file("");
+        let output = adapter.index_file(&ctx, &file).unwrap();
+        assert!(output.symbols.is_empty());
+        assert_eq!(output.source_adapter, "semantic-typescript-v1");
+        assert_eq!(output.quality_level, QualityLevel::Semantic);
+    }
+
+    // -- Function extraction --
+
+    #[test]
+    fn extracts_function_from_navtree() {
+        let body = navtree_body(serde_json::json!([
+            {
+                "text": "greet",
+                "kind": "function",
+                "kindModifiers": "export",
+                "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": 1, "offset": 38}}],
+                "childItems": []
+            }
+        ]));
+        let source = "export function greet(name: string) {}";
+        let rt = MockRuntime::new(body);
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let ctx = make_context();
+        let file = make_ts_file(source);
+        let output = adapter.index_file(&ctx, &file).unwrap();
+
+        assert_eq!(output.symbols.len(), 1);
+        let sym = &output.symbols[0];
+        assert_eq!(sym.name, "greet");
+        assert_eq!(sym.kind, core_model::SymbolKind::Function);
+        assert_eq!(sym.qualified_name, "greet");
+        assert_eq!(sym.signature, "export function greet");
+        assert!(sym.confidence_score.is_some());
+        assert!((sym.confidence_score.unwrap() - 0.9).abs() < f32::EPSILON);
+    }
+
+    // -- Class with methods --
+
+    #[test]
+    fn extracts_class_with_methods() {
+        let body = navtree_body(serde_json::json!([
+            {
+                "text": "Calculator",
+                "kind": "class",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": 4, "offset": 2}}],
+                "childItems": [
+                    {
+                        "text": "add",
+                        "kind": "method",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 2, "offset": 3}, "end": {"line": 2, "offset": 40}}],
+                        "childItems": []
+                    },
+                    {
+                        "text": "subtract",
+                        "kind": "method",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 3, "offset": 3}, "end": {"line": 3, "offset": 45}}],
+                        "childItems": []
+                    }
+                ]
+            }
+        ]));
+        let source = "class Calculator {\n  add(a: number, b: number): number {}\n  subtract(a: number, b: number): number {}\n}\n";
+        let rt = MockRuntime::new(body);
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let ctx = make_context();
+        let file = make_ts_file(source);
+        let output = adapter.index_file(&ctx, &file).unwrap();
+
+        assert_eq!(output.symbols.len(), 3);
+        assert_eq!(output.symbols[0].name, "Calculator");
+        assert_eq!(output.symbols[0].kind, core_model::SymbolKind::Class);
+
+        assert_eq!(output.symbols[1].name, "add");
+        assert_eq!(output.symbols[1].kind, core_model::SymbolKind::Method);
+        assert_eq!(output.symbols[1].qualified_name, "Calculator::add");
+        assert_eq!(
+            output.symbols[1].parent_qualified_name.as_deref(),
+            Some("Calculator")
+        );
+    }
+
+    // -- Provenance --
+
+    #[test]
+    fn output_carries_provenance_fields() {
+        let body = navtree_body(serde_json::json!([
+            {
+                "text": "hello",
+                "kind": "function",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": 1, "offset": 20}}],
+                "childItems": []
+            }
+        ]));
+        let rt = MockRuntime::new(body);
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let ctx = make_context();
+        let file = make_ts_file("function hello() {}");
+        let output = adapter.index_file(&ctx, &file).unwrap();
+
+        assert_eq!(output.source_adapter, "semantic-typescript-v1");
+        assert_eq!(output.quality_level, QualityLevel::Semantic);
+    }
+
+    // -- Confidence resolution --
+
+    #[test]
+    fn all_symbols_have_resolved_confidence() {
+        let body = navtree_body(serde_json::json!([
+            {
+                "text": "a",
+                "kind": "function",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": 1, "offset": 17}}],
+                "childItems": []
+            },
+            {
+                "text": "B",
+                "kind": "class",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 2, "offset": 1}, "end": {"line": 2, "offset": 12}}],
+                "childItems": []
+            }
+        ]));
+        let source = "function a() {}\nclass B {}\n";
+        let rt = MockRuntime::new(body);
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let ctx = make_context();
+        let file = make_ts_file(source);
+        let output = adapter.index_file(&ctx, &file).unwrap();
+
+        for sym in &output.symbols {
+            let score = sym
+                .confidence_score
+                .unwrap_or_else(|| panic!("symbol '{}' missing confidence", sym.name));
+            assert!(
+                (0.0..=1.0).contains(&score),
+                "symbol '{}' confidence {score} out of range",
+                sym.name
+            );
+        }
+    }
+
+    // -- Error handling --
+
+    #[test]
+    fn navtree_failure_returns_parse_error() {
+        let rt = MockRuntime::failing();
+        let adapter = TypeScriptSemanticAdapter::new(rt);
+        let ctx = make_context();
+        let file = make_ts_file("function broken() {}");
+        let err = adapter
+            .index_file(&ctx, &file)
+            .expect_err("should fail on navtree");
+        assert!(err.to_string().contains("protocol error") || err.to_string().contains("parse"));
+    }
+
+    // -- Script kind detection --
+
+    #[test]
+    fn script_kind_for_ts_files() {
+        assert_eq!(script_kind_for_path(&PathBuf::from("foo.ts")), "TS");
+        assert_eq!(script_kind_for_path(&PathBuf::from("foo.tsx")), "TSX");
+        assert_eq!(script_kind_for_path(&PathBuf::from("foo.js")), "JS");
+        assert_eq!(script_kind_for_path(&PathBuf::from("foo.jsx")), "JSX");
+        assert_eq!(script_kind_for_path(&PathBuf::from("foo.mjs")), "JS");
+    }
+
+    // -- Determinism --
+
+    #[test]
+    fn extraction_is_deterministic() {
+        let body = navtree_body(serde_json::json!([
+            {
+                "text": "Config",
+                "kind": "interface",
+                "kindModifiers": "export",
+                "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": 3, "offset": 2}}],
+                "childItems": [
+                    {
+                        "text": "name",
+                        "kind": "property",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 2, "offset": 3}, "end": {"line": 2, "offset": 16}}],
+                        "childItems": []
+                    }
+                ]
+            },
+            {
+                "text": "create",
+                "kind": "function",
+                "kindModifiers": "export",
+                "spans": [{"start": {"line": 4, "offset": 1}, "end": {"line": 4, "offset": 40}}],
+                "childItems": []
+            }
+        ]));
+        let source =
+            "interface Config {\n  name: string;\n}\nexport function create(): Config {}\n";
+
+        let run = |body: &serde_json::Value| {
+            let rt = MockRuntime::new(body.clone());
+            let adapter = TypeScriptSemanticAdapter::new(rt);
+            let ctx = make_context();
+            let file = make_ts_file(source);
+            adapter.index_file(&ctx, &file).unwrap()
+        };
+
+        let out1 = run(&body);
+        let out2 = run(&body);
+
+        assert_eq!(out1.symbols.len(), out2.symbols.len());
+        for (a, b) in out1.symbols.iter().zip(out2.symbols.iter()) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.qualified_name, b.qualified_name);
+            assert_eq!(a.span, b.span);
+            assert_eq!(a.confidence_score, b.confidence_score);
+        }
+    }
+}

--- a/crates/adapter-semantic-typescript/src/lib.rs
+++ b/crates/adapter-semantic-typescript/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod adapter;
 pub mod config;
 pub mod error;
+pub mod mapping;
 pub mod process;
 pub mod protocol;
 pub mod runtime;

--- a/crates/adapter-semantic-typescript/src/mapping.rs
+++ b/crates/adapter-semantic-typescript/src/mapping.rs
@@ -1,0 +1,665 @@
+use adapter_api::{ExtractedSymbol, SourceSpan};
+use core_model::SymbolKind;
+use serde::Deserialize;
+
+/// A node in tsserver's navigation tree response.
+///
+/// Represents a single symbol in the file's hierarchical structure,
+/// as returned by the `navtree` command. Each node may contain child
+/// items forming the scope tree.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NavTreeItem {
+    pub text: String,
+    pub kind: String,
+    #[serde(default)]
+    pub kind_modifiers: String,
+    #[serde(default)]
+    pub spans: Vec<TextSpan>,
+    #[serde(default)]
+    pub child_items: Vec<NavTreeItem>,
+}
+
+/// A text span as returned by tsserver.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TextSpan {
+    pub start: SpanLocation,
+    pub end: SpanLocation,
+}
+
+/// A location within a source file (tsserver format).
+#[derive(Debug, Clone, Deserialize)]
+pub struct SpanLocation {
+    pub line: u32,
+    pub offset: u32,
+}
+
+/// Maps a tsserver `ScriptElementKind` string to a canonical `SymbolKind`.
+///
+/// tsserver uses strings like "function", "class", "method", "interface",
+/// "enum", "const", "let", "var", "type", "module", etc.
+fn map_ts_kind(ts_kind: &str, parent_kind: Option<&str>) -> Option<SymbolKind> {
+    match ts_kind {
+        "function" => {
+            if is_class_like(parent_kind) {
+                Some(SymbolKind::Method)
+            } else {
+                Some(SymbolKind::Function)
+            }
+        }
+        "method" | "constructor" | "getter" | "setter" => Some(SymbolKind::Method),
+        "class" => Some(SymbolKind::Class),
+        "interface" | "enum" | "type" => Some(SymbolKind::Type),
+        "const" | "let" | "var" => Some(SymbolKind::Constant),
+        // Skip structural nodes that don't map to symbols.
+        "module" | "script" | "directory" | "property" | "index" | "call" | "parameter"
+        | "local function" | "local class" | "string" => None,
+        _ => None,
+    }
+}
+
+/// Returns whether a parent kind represents a class-like container.
+fn is_class_like(parent_kind: Option<&str>) -> bool {
+    matches!(parent_kind, Some("class" | "interface"))
+}
+
+/// Converts a tsserver `TextSpan` to a `SourceSpan` using source bytes
+/// for accurate byte offset computation.
+///
+/// tsserver reports 1-based lines and 1-based character offsets. We convert
+/// to the canonical schema: 1-based lines, 0-based byte offsets, with
+/// byte_length computed from the source content.
+fn text_span_to_source_span(span: &TextSpan, source: &[u8]) -> Option<SourceSpan> {
+    let start_line = span.start.line;
+    let end_line = span.end.line;
+
+    if start_line == 0 || end_line == 0 || end_line < start_line {
+        return None;
+    }
+
+    let start_byte = line_offset_to_byte(source, span.start.line, span.start.offset)?;
+    let end_byte = line_offset_to_byte(source, span.end.line, span.end.offset)?;
+
+    if end_byte <= start_byte {
+        return None;
+    }
+
+    Some(SourceSpan {
+        start_line,
+        end_line,
+        start_byte: start_byte as u64,
+        byte_length: (end_byte - start_byte) as u64,
+    })
+}
+
+/// Converts a 1-based line and 1-based UTF-16 offset to a 0-based byte offset.
+///
+/// tsserver offsets are 1-based positions measured in UTF-16 code units.
+/// A BMP character (U+0000..U+FFFF) counts as 1 code unit; a supplementary
+/// character (U+10000+) counts as 2 (a surrogate pair). This function walks
+/// the source bytes as UTF-8, counting UTF-16 code units consumed, so that
+/// the returned byte offset is correct for any valid UTF-8 source.
+fn line_offset_to_byte(source: &[u8], line: u32, offset: u32) -> Option<usize> {
+    if line == 0 || offset == 0 {
+        return None;
+    }
+
+    let mut current_line: u32 = 1;
+    let mut byte_pos: usize = 0;
+
+    // Advance to the start of the target line.
+    while current_line < line && byte_pos < source.len() {
+        if source[byte_pos] == b'\n' {
+            current_line += 1;
+        }
+        byte_pos += 1;
+    }
+
+    if current_line != line {
+        return None;
+    }
+
+    // Advance by (offset - 1) UTF-16 code units within the line.
+    // tsserver offsets are measured in UTF-16 code units: BMP characters
+    // (U+0000..U+FFFF) count as 1, supplementary characters (U+10000+)
+    // count as 2 (a surrogate pair).
+    let target_utf16_units = (offset - 1) as usize;
+    let mut utf16_units_consumed: usize = 0;
+    let source_str = std::str::from_utf8(&source[byte_pos..]).ok()?;
+
+    for ch in source_str.chars() {
+        if utf16_units_consumed >= target_utf16_units {
+            break;
+        }
+        utf16_units_consumed += ch.len_utf16();
+        byte_pos += ch.len_utf8();
+    }
+
+    if byte_pos > source.len() {
+        return None;
+    }
+
+    Some(byte_pos)
+}
+
+/// Builds a signature string from the node text and kind.
+///
+/// Since tsserver's navtree doesn't include full signature text,
+/// we reconstruct a representative signature from available information.
+fn build_signature(item: &NavTreeItem) -> String {
+    let modifiers = if item.kind_modifiers.is_empty() {
+        String::new()
+    } else {
+        format!("{} ", item.kind_modifiers)
+    };
+
+    match item.kind.as_str() {
+        "function" => format!("{modifiers}function {}", item.text),
+        "method" | "constructor" | "getter" | "setter" => {
+            format!("{modifiers}{}", item.text)
+        }
+        "class" => format!("{modifiers}class {}", item.text),
+        "interface" => format!("{modifiers}interface {}", item.text),
+        "enum" => format!("{modifiers}enum {}", item.text),
+        "type" => format!("{modifiers}type {}", item.text),
+        "const" => format!("const {}", item.text),
+        "let" => format!("let {}", item.text),
+        "var" => format!("var {}", item.text),
+        _ => item.text.clone(),
+    }
+}
+
+/// Recursively maps a tsserver navigation tree into `ExtractedSymbol` values.
+///
+/// Walks the navtree depth-first, tracking scope for qualified name construction.
+/// Only items that map to a canonical `SymbolKind` are emitted.
+pub fn map_navtree_to_symbols(items: &[NavTreeItem], source: &[u8]) -> Vec<ExtractedSymbol> {
+    let mut symbols = Vec::new();
+    let mut scope_stack: Vec<String> = Vec::new();
+    walk_navtree_items(items, source, &mut symbols, &mut scope_stack, None);
+    symbols
+}
+
+fn walk_navtree_items(
+    items: &[NavTreeItem],
+    source: &[u8],
+    symbols: &mut Vec<ExtractedSymbol>,
+    scope_stack: &mut Vec<String>,
+    parent_kind: Option<&str>,
+) {
+    for item in items {
+        let mapped_kind = map_ts_kind(&item.kind, parent_kind);
+
+        if let Some(kind) = mapped_kind {
+            // Skip items with empty or structural names.
+            if item.text.trim().is_empty() || item.text == "<global>" {
+                // Still recurse into children for scope tracking.
+                walk_navtree_items(
+                    &item.child_items,
+                    source,
+                    symbols,
+                    scope_stack,
+                    Some(&item.kind),
+                );
+                continue;
+            }
+
+            let span = item
+                .spans
+                .first()
+                .and_then(|s| text_span_to_source_span(s, source));
+
+            if let Some(span) = span {
+                let qualified_name = build_qualified_name(scope_stack, &item.text);
+                let parent = if scope_stack.is_empty() {
+                    None
+                } else {
+                    Some(scope_stack.join("::"))
+                };
+
+                symbols.push(ExtractedSymbol {
+                    name: item.text.clone(),
+                    qualified_name,
+                    kind,
+                    span,
+                    signature: build_signature(item),
+                    confidence_score: None,
+                    docstring: None,
+                    parent_qualified_name: parent,
+                });
+            }
+        }
+
+        // Push scope for class-like containers before recursing.
+        let is_scope = matches!(
+            item.kind.as_str(),
+            "class" | "interface" | "enum" | "module"
+        ) && !item.text.trim().is_empty()
+            && item.text != "<global>";
+
+        if is_scope {
+            scope_stack.push(item.text.clone());
+        }
+
+        walk_navtree_items(
+            &item.child_items,
+            source,
+            symbols,
+            scope_stack,
+            Some(&item.kind),
+        );
+
+        if is_scope {
+            scope_stack.pop();
+        }
+    }
+}
+
+fn build_qualified_name(scope_stack: &[String], name: &str) -> String {
+    if scope_stack.is_empty() {
+        name.to_string()
+    } else {
+        format!("{}::{name}", scope_stack.join("::"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_span(start_line: u32, start_offset: u32, end_line: u32, end_offset: u32) -> TextSpan {
+        TextSpan {
+            start: SpanLocation {
+                line: start_line,
+                offset: start_offset,
+            },
+            end: SpanLocation {
+                line: end_line,
+                offset: end_offset,
+            },
+        }
+    }
+
+    #[test]
+    fn maps_function_kind() {
+        assert_eq!(map_ts_kind("function", None), Some(SymbolKind::Function));
+    }
+
+    #[test]
+    fn maps_function_in_class_to_method() {
+        assert_eq!(
+            map_ts_kind("function", Some("class")),
+            Some(SymbolKind::Method)
+        );
+    }
+
+    #[test]
+    fn maps_method_kind() {
+        assert_eq!(map_ts_kind("method", None), Some(SymbolKind::Method));
+    }
+
+    #[test]
+    fn maps_class_kind() {
+        assert_eq!(map_ts_kind("class", None), Some(SymbolKind::Class));
+    }
+
+    #[test]
+    fn maps_interface_to_type() {
+        assert_eq!(map_ts_kind("interface", None), Some(SymbolKind::Type));
+    }
+
+    #[test]
+    fn maps_enum_to_type() {
+        assert_eq!(map_ts_kind("enum", None), Some(SymbolKind::Type));
+    }
+
+    #[test]
+    fn maps_const_to_constant() {
+        assert_eq!(map_ts_kind("const", None), Some(SymbolKind::Constant));
+    }
+
+    #[test]
+    fn skips_module_kind() {
+        assert_eq!(map_ts_kind("module", None), None);
+    }
+
+    #[test]
+    fn skips_unknown_kind() {
+        assert_eq!(map_ts_kind("something_else", None), None);
+    }
+
+    #[test]
+    fn text_span_converts_to_source_span() {
+        let source = b"const x = 1;\nfunction foo() {}\n";
+        let span = make_span(2, 1, 2, 19);
+        let result = text_span_to_source_span(&span, source).unwrap();
+        assert_eq!(result.start_line, 2);
+        assert_eq!(result.end_line, 2);
+        assert_eq!(result.start_byte, 13); // byte offset of 'f' on line 2
+        assert_eq!(result.byte_length, 18);
+    }
+
+    #[test]
+    fn text_span_rejects_zero_line() {
+        let source = b"hello\n";
+        let span = make_span(0, 1, 1, 6);
+        assert!(text_span_to_source_span(&span, source).is_none());
+    }
+
+    #[test]
+    fn text_span_rejects_end_before_start() {
+        let source = b"hello\nworld\n";
+        let span = make_span(2, 1, 1, 1);
+        assert!(text_span_to_source_span(&span, source).is_none());
+    }
+
+    #[test]
+    fn line_offset_to_byte_first_line() {
+        let source = b"const x = 1;\n";
+        assert_eq!(line_offset_to_byte(source, 1, 1), Some(0));
+        assert_eq!(line_offset_to_byte(source, 1, 7), Some(6));
+    }
+
+    #[test]
+    fn line_offset_to_byte_second_line() {
+        let source = b"line1\nline2\n";
+        assert_eq!(line_offset_to_byte(source, 2, 1), Some(6));
+        assert_eq!(line_offset_to_byte(source, 2, 3), Some(8));
+    }
+
+    #[test]
+    fn line_offset_to_byte_rejects_zero() {
+        let source = b"hello\n";
+        assert_eq!(line_offset_to_byte(source, 0, 1), None);
+        assert_eq!(line_offset_to_byte(source, 1, 0), None);
+    }
+
+    #[test]
+    fn line_offset_to_byte_handles_bmp_multibyte() {
+        // "café" — 'é' is U+00E9, 2 bytes in UTF-8, 1 UTF-16 code unit.
+        // Bytes: c(1) a(1) f(1) é(2) = 5 bytes total.
+        // tsserver sees: c=1, a=2, f=3, é=4 (4 UTF-16 code units).
+        let source = "café\n".as_bytes();
+        assert_eq!(source.len(), 6); // 5 bytes + newline
+                                     // Offset 1 → byte 0 ('c')
+        assert_eq!(line_offset_to_byte(source, 1, 1), Some(0));
+        // Offset 4 → byte 3 ('é', which is 2 bytes at positions 3..5)
+        assert_eq!(line_offset_to_byte(source, 1, 4), Some(3));
+        // Offset 5 → byte 5 (past 'é', at newline)
+        assert_eq!(line_offset_to_byte(source, 1, 5), Some(5));
+    }
+
+    #[test]
+    fn line_offset_to_byte_handles_cjk() {
+        // "const 名前 = 1;" — '名' and '前' are U+540D and U+524D,
+        // each 3 bytes in UTF-8, 1 UTF-16 code unit.
+        let source = "const 名前 = 1;\n".as_bytes();
+        // "const " = 6 bytes, "名" = 3 bytes, "前" = 3 bytes, " = 1;\n" = 6 bytes
+        assert_eq!(source.len(), 18);
+        // tsserver offset 7 → '名' (UTF-16 units: c=1,o=2,n=3,s=4,t=5,' '=6,'名'=7)
+        assert_eq!(line_offset_to_byte(source, 1, 7), Some(6));
+        // tsserver offset 8 → '前'
+        assert_eq!(line_offset_to_byte(source, 1, 8), Some(9));
+        // tsserver offset 9 → ' ' after '前'
+        assert_eq!(line_offset_to_byte(source, 1, 9), Some(12));
+    }
+
+    #[test]
+    fn line_offset_to_byte_handles_supplementary_characters() {
+        // "𝑓" is U+1D453 — 4 bytes in UTF-8, 2 UTF-16 code units (surrogate pair).
+        // Source: "𝑓x\n" — 𝑓(4 bytes) + x(1 byte) + \n(1 byte) = 6 bytes.
+        let source = "𝑓x\n".as_bytes();
+        assert_eq!(source.len(), 6);
+        // Offset 1 → byte 0 ('𝑓')
+        assert_eq!(line_offset_to_byte(source, 1, 1), Some(0));
+        // Offset 3 → byte 4 ('x'), because '𝑓' consumes 2 UTF-16 code units
+        assert_eq!(line_offset_to_byte(source, 1, 3), Some(4));
+    }
+
+    #[test]
+    fn text_span_correct_for_unicode_source() {
+        // "const 名前 = 1;\nfunction foo() {}\n"
+        // Line 2 starts at byte 18.
+        // tsserver would report line 2, offset 1..19 for "function foo() {}".
+        let source = "const 名前 = 1;\nfunction foo() {}\n".as_bytes();
+        let span = make_span(2, 1, 2, 19);
+        let result = text_span_to_source_span(&span, source).unwrap();
+        assert_eq!(result.start_line, 2);
+        assert_eq!(result.end_line, 2);
+        assert_eq!(result.start_byte, 18);
+        assert_eq!(result.byte_length, 18);
+    }
+
+    #[test]
+    fn build_signature_function() {
+        let item = NavTreeItem {
+            text: "greet".to_string(),
+            kind: "function".to_string(),
+            kind_modifiers: "export".to_string(),
+            spans: vec![],
+            child_items: vec![],
+        };
+        assert_eq!(build_signature(&item), "export function greet");
+    }
+
+    #[test]
+    fn build_signature_class() {
+        let item = NavTreeItem {
+            text: "MyClass".to_string(),
+            kind: "class".to_string(),
+            kind_modifiers: "".to_string(),
+            spans: vec![],
+            child_items: vec![],
+        };
+        assert_eq!(build_signature(&item), "class MyClass");
+    }
+
+    #[test]
+    fn maps_flat_navtree() {
+        let source = b"function greet() {}\nconst PI = 3.14;\n";
+        let items = vec![
+            NavTreeItem {
+                text: "greet".to_string(),
+                kind: "function".to_string(),
+                kind_modifiers: String::new(),
+                spans: vec![make_span(1, 1, 1, 20)],
+                child_items: vec![],
+            },
+            NavTreeItem {
+                text: "PI".to_string(),
+                kind: "const".to_string(),
+                kind_modifiers: String::new(),
+                spans: vec![make_span(2, 1, 2, 17)],
+                child_items: vec![],
+            },
+        ];
+
+        let symbols = map_navtree_to_symbols(&items, source);
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name, "greet");
+        assert_eq!(symbols[0].kind, SymbolKind::Function);
+        assert_eq!(symbols[0].qualified_name, "greet");
+        assert!(symbols[0].parent_qualified_name.is_none());
+
+        assert_eq!(symbols[1].name, "PI");
+        assert_eq!(symbols[1].kind, SymbolKind::Constant);
+    }
+
+    #[test]
+    fn maps_nested_class_methods() {
+        let source = b"class Foo {\n  bar() {}\n  baz() {}\n}\n";
+        let items = vec![NavTreeItem {
+            text: "Foo".to_string(),
+            kind: "class".to_string(),
+            kind_modifiers: String::new(),
+            spans: vec![make_span(1, 1, 4, 2)],
+            child_items: vec![
+                NavTreeItem {
+                    text: "bar".to_string(),
+                    kind: "method".to_string(),
+                    kind_modifiers: String::new(),
+                    spans: vec![make_span(2, 3, 2, 12)],
+                    child_items: vec![],
+                },
+                NavTreeItem {
+                    text: "baz".to_string(),
+                    kind: "method".to_string(),
+                    kind_modifiers: String::new(),
+                    spans: vec![make_span(3, 3, 3, 12)],
+                    child_items: vec![],
+                },
+            ],
+        }];
+
+        let symbols = map_navtree_to_symbols(&items, source);
+        assert_eq!(symbols.len(), 3);
+
+        assert_eq!(symbols[0].name, "Foo");
+        assert_eq!(symbols[0].kind, SymbolKind::Class);
+
+        assert_eq!(symbols[1].name, "bar");
+        assert_eq!(symbols[1].kind, SymbolKind::Method);
+        assert_eq!(symbols[1].qualified_name, "Foo::bar");
+        assert_eq!(symbols[1].parent_qualified_name.as_deref(), Some("Foo"));
+
+        assert_eq!(symbols[2].name, "baz");
+        assert_eq!(symbols[2].qualified_name, "Foo::baz");
+    }
+
+    #[test]
+    fn skips_global_and_structural_nodes() {
+        let source = b"function hello() {}\n";
+        let items = vec![NavTreeItem {
+            text: "<global>".to_string(),
+            kind: "module".to_string(),
+            kind_modifiers: String::new(),
+            spans: vec![make_span(1, 1, 1, 20)],
+            child_items: vec![NavTreeItem {
+                text: "hello".to_string(),
+                kind: "function".to_string(),
+                kind_modifiers: String::new(),
+                spans: vec![make_span(1, 1, 1, 20)],
+                child_items: vec![],
+            }],
+        }];
+
+        let symbols = map_navtree_to_symbols(&items, source);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "hello");
+        assert_eq!(symbols[0].kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn mapping_is_deterministic() {
+        let source = b"class A {\n  method1() {}\n}\nfunction b() {}\n";
+        let items = vec![
+            NavTreeItem {
+                text: "A".to_string(),
+                kind: "class".to_string(),
+                kind_modifiers: String::new(),
+                spans: vec![make_span(1, 1, 3, 2)],
+                child_items: vec![NavTreeItem {
+                    text: "method1".to_string(),
+                    kind: "method".to_string(),
+                    kind_modifiers: String::new(),
+                    spans: vec![make_span(2, 3, 2, 16)],
+                    child_items: vec![],
+                }],
+            },
+            NavTreeItem {
+                text: "b".to_string(),
+                kind: "function".to_string(),
+                kind_modifiers: String::new(),
+                spans: vec![make_span(4, 1, 4, 16)],
+                child_items: vec![],
+            },
+        ];
+
+        let run1 = map_navtree_to_symbols(&items, source);
+        let run2 = map_navtree_to_symbols(&items, source);
+
+        assert_eq!(run1.len(), run2.len());
+        for (a, b) in run1.iter().zip(run2.iter()) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.qualified_name, b.qualified_name);
+            assert_eq!(a.span, b.span);
+            assert_eq!(a.signature, b.signature);
+            assert_eq!(a.parent_qualified_name, b.parent_qualified_name);
+        }
+    }
+
+    #[test]
+    fn maps_interface_with_methods() {
+        let source = b"interface Shape {\n  area(): number;\n}\n";
+        let items = vec![NavTreeItem {
+            text: "Shape".to_string(),
+            kind: "interface".to_string(),
+            kind_modifiers: String::new(),
+            spans: vec![make_span(1, 1, 3, 2)],
+            child_items: vec![NavTreeItem {
+                text: "area".to_string(),
+                kind: "method".to_string(),
+                kind_modifiers: String::new(),
+                spans: vec![make_span(2, 3, 2, 19)],
+                child_items: vec![],
+            }],
+        }];
+
+        let symbols = map_navtree_to_symbols(&items, source);
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name, "Shape");
+        assert_eq!(symbols[0].kind, SymbolKind::Type);
+        assert_eq!(symbols[1].name, "area");
+        assert_eq!(symbols[1].kind, SymbolKind::Method);
+        assert_eq!(symbols[1].qualified_name, "Shape::area");
+    }
+
+    #[test]
+    fn maps_enum_members_are_skipped() {
+        // Enum members have kind "property" in tsserver, which we skip.
+        let source = b"enum Color {\n  Red,\n  Green,\n}\n";
+        let items = vec![NavTreeItem {
+            text: "Color".to_string(),
+            kind: "enum".to_string(),
+            kind_modifiers: String::new(),
+            spans: vec![make_span(1, 1, 4, 2)],
+            child_items: vec![
+                NavTreeItem {
+                    text: "Red".to_string(),
+                    kind: "property".to_string(),
+                    kind_modifiers: String::new(),
+                    spans: vec![make_span(2, 3, 2, 6)],
+                    child_items: vec![],
+                },
+                NavTreeItem {
+                    text: "Green".to_string(),
+                    kind: "property".to_string(),
+                    kind_modifiers: String::new(),
+                    spans: vec![make_span(3, 3, 3, 8)],
+                    child_items: vec![],
+                },
+            ],
+        }];
+
+        let symbols = map_navtree_to_symbols(&items, source);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "Color");
+        assert_eq!(symbols[0].kind, SymbolKind::Type);
+    }
+
+    #[test]
+    fn constructor_maps_to_method() {
+        assert_eq!(map_ts_kind("constructor", None), Some(SymbolKind::Method));
+    }
+
+    #[test]
+    fn getter_setter_map_to_method() {
+        assert_eq!(map_ts_kind("getter", None), Some(SymbolKind::Method));
+        assert_eq!(map_ts_kind("setter", None), Some(SymbolKind::Method));
+    }
+}

--- a/crates/adapter-semantic-typescript/tests/adapter_contract.rs
+++ b/crates/adapter-semantic-typescript/tests/adapter_contract.rs
@@ -1,0 +1,400 @@
+//! Contract test suite for the TypeScript semantic adapter.
+//!
+//! Uses the shared contract harness from `adapter-api` to verify that
+//! the TypeScript semantic adapter satisfies all behavioral contracts.
+//!
+//! These tests use a mock runtime to avoid requiring a real tsserver
+//! process. The mock returns navtree responses that match the fixture
+//! source code, verifying the mapping logic end-to-end.
+
+use adapter_api::contract::{self, ContractFixture};
+use adapter_api::LanguageAdapter;
+use adapter_semantic_typescript::adapter::TypeScriptSemanticAdapter;
+use adapter_semantic_typescript::error::TsServerError;
+use adapter_semantic_typescript::protocol::TsServerResponse;
+use adapter_semantic_typescript::runtime::SemanticRuntime;
+
+/// A mock runtime that returns a canned navtree response matching the
+/// TypeScript baseline fixture from the contract test harness.
+struct FixtureRuntime;
+
+impl SemanticRuntime for FixtureRuntime {
+    fn start(&mut self) -> Result<(), TsServerError> {
+        Ok(())
+    }
+
+    fn stop(&mut self) {}
+
+    fn restart(&mut self) -> Result<(), TsServerError> {
+        Ok(())
+    }
+
+    fn is_healthy(&mut self) -> bool {
+        true
+    }
+
+    fn send_request(
+        &mut self,
+        command: &str,
+        _arguments: Option<serde_json::Value>,
+    ) -> Result<TsServerResponse, TsServerError> {
+        match command {
+            "navtree" => Ok(TsServerResponse {
+                seq: 0,
+                msg_type: "response".to_string(),
+                command: Some("navtree".to_string()),
+                request_seq: Some(1),
+                success: Some(true),
+                body: Some(fixture_navtree_body()),
+                message: None,
+            }),
+            _ => Ok(TsServerResponse {
+                seq: 0,
+                msg_type: "response".to_string(),
+                command: Some(command.to_string()),
+                request_seq: Some(1),
+                success: Some(true),
+                body: None,
+                message: None,
+            }),
+        }
+    }
+}
+
+/// Returns a navtree response body that matches the TypeScript baseline fixture.
+///
+/// The fixture source is:
+/// ```typescript
+/// /** Configuration for processing. */
+/// interface Config {
+///     name: string;
+///     limit: number;
+/// }
+///
+/// /** Creates a new config with defaults. */
+/// function create(name: string): Config {
+///     return { name, limit: 100 };
+/// }
+///
+/// class Processor {
+///     /** Processes the config. */
+///     process(config: Config): boolean {
+///         return config.limit > 0;
+///     }
+/// }
+///
+/// /** Operating mode. */
+/// enum Mode {
+///     Fast,
+///     Precise,
+/// }
+///
+/// const MAX_SIZE: number = 1024;
+/// ```
+fn fixture_navtree_body() -> serde_json::Value {
+    serde_json::json!({
+        "text": "<global>",
+        "kind": "script",
+        "kindModifiers": "",
+        "spans": [{"start": {"line": 1, "offset": 1}, "end": {"line": 27, "offset": 1}}],
+        "childItems": [
+            {
+                "text": "Config",
+                "kind": "interface",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 2, "offset": 1}, "end": {"line": 5, "offset": 2}}],
+                "childItems": [
+                    {
+                        "text": "name",
+                        "kind": "property",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 3, "offset": 5}, "end": {"line": 3, "offset": 18}}],
+                        "childItems": []
+                    },
+                    {
+                        "text": "limit",
+                        "kind": "property",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 4, "offset": 5}, "end": {"line": 4, "offset": 19}}],
+                        "childItems": []
+                    }
+                ]
+            },
+            {
+                "text": "create",
+                "kind": "function",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 8, "offset": 1}, "end": {"line": 10, "offset": 2}}],
+                "childItems": []
+            },
+            {
+                "text": "Processor",
+                "kind": "class",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 12, "offset": 1}, "end": {"line": 17, "offset": 2}}],
+                "childItems": [
+                    {
+                        "text": "process",
+                        "kind": "method",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 14, "offset": 5}, "end": {"line": 16, "offset": 6}}],
+                        "childItems": []
+                    }
+                ]
+            },
+            {
+                "text": "Mode",
+                "kind": "enum",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 20, "offset": 1}, "end": {"line": 23, "offset": 2}}],
+                "childItems": [
+                    {
+                        "text": "Fast",
+                        "kind": "property",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 21, "offset": 5}, "end": {"line": 21, "offset": 9}}],
+                        "childItems": []
+                    },
+                    {
+                        "text": "Precise",
+                        "kind": "property",
+                        "kindModifiers": "",
+                        "spans": [{"start": {"line": 22, "offset": 5}, "end": {"line": 22, "offset": 12}}],
+                        "childItems": []
+                    }
+                ]
+            },
+            {
+                "text": "MAX_SIZE",
+                "kind": "const",
+                "kindModifiers": "",
+                "spans": [{"start": {"line": 25, "offset": 1}, "end": {"line": 25, "offset": 28}}],
+                "childItems": []
+            }
+        ]
+    })
+}
+
+fn make_adapter() -> TypeScriptSemanticAdapter<FixtureRuntime> {
+    TypeScriptSemanticAdapter::new(FixtureRuntime)
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate contract suite
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typescript_semantic_passes_all_contracts() {
+    let adapter = make_adapter();
+    let fixture = ContractFixture::typescript_baseline();
+    contract::run_all_contracts(&adapter, &fixture);
+}
+
+// ---------------------------------------------------------------------------
+// Individual contract tests (for granular failure diagnostics)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_adapter_identity_is_stable() {
+    let adapter = make_adapter();
+    contract::assert_adapter_identity_is_stable(&adapter);
+}
+
+#[test]
+fn contract_capabilities_are_valid() {
+    let adapter = make_adapter();
+    contract::assert_capabilities_are_valid(&adapter);
+}
+
+#[test]
+fn contract_provenance_fields() {
+    let adapter = make_adapter();
+    let fixture = ContractFixture::typescript_baseline();
+    contract::assert_provenance_fields(&adapter, &fixture);
+}
+
+#[test]
+fn contract_expected_symbols() {
+    let adapter = make_adapter();
+    let fixture = ContractFixture::typescript_baseline();
+    contract::assert_expected_symbols(&adapter, &fixture);
+}
+
+#[test]
+fn contract_symbols_are_valid() {
+    let adapter = make_adapter();
+    let fixture = ContractFixture::typescript_baseline();
+    contract::assert_symbols_are_valid(&adapter, &fixture);
+}
+
+#[test]
+fn contract_extraction_is_deterministic() {
+    let adapter = make_adapter();
+    let fixture = ContractFixture::typescript_baseline();
+    contract::assert_extraction_is_deterministic(&adapter, &fixture);
+}
+
+#[test]
+fn contract_unsupported_language_rejected() {
+    let adapter = make_adapter();
+    contract::assert_unsupported_language_rejected(&adapter);
+}
+
+#[test]
+fn contract_empty_file_produces_no_symbols() {
+    let adapter = make_adapter();
+    contract::assert_empty_file_produces_no_symbols(&adapter);
+}
+
+// ---------------------------------------------------------------------------
+// Exact qualified name and symbol ID assertions
+// ---------------------------------------------------------------------------
+
+/// Helper: extracts symbols from the TypeScript baseline fixture.
+fn extract_fixture_symbols() -> Vec<adapter_api::ExtractedSymbol> {
+    let adapter = make_adapter();
+    let fixture = ContractFixture::typescript_baseline();
+    let ctx = adapter_api::IndexContext {
+        repo_id: "test-repo".to_string(),
+        source_root: std::path::PathBuf::from("/tmp/test-repo"),
+    };
+    let file = adapter_api::SourceFile {
+        relative_path: fixture.relative_path.clone(),
+        absolute_path: std::path::PathBuf::from("/tmp/test-repo").join(&fixture.relative_path),
+        content: fixture.source_code.clone(),
+        language: fixture.language.clone(),
+    };
+    adapter.index_file(&ctx, &file).unwrap().symbols
+}
+
+fn find_symbol<'a>(
+    symbols: &'a [adapter_api::ExtractedSymbol],
+    name: &str,
+) -> &'a adapter_api::ExtractedSymbol {
+    symbols.iter().find(|s| s.name == name).unwrap_or_else(|| {
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        panic!("symbol '{name}' not found in: {names:?}")
+    })
+}
+
+#[test]
+fn fixture_qualified_names_match_canonical_rules() {
+    let symbols = extract_fixture_symbols();
+
+    // Top-level symbols have unqualified names.
+    let config = find_symbol(&symbols, "Config");
+    assert_eq!(config.qualified_name, "Config");
+    assert!(
+        config.parent_qualified_name.is_none(),
+        "Config is top-level, should have no parent"
+    );
+
+    let create = find_symbol(&symbols, "create");
+    assert_eq!(create.qualified_name, "create");
+    assert!(
+        create.parent_qualified_name.is_none(),
+        "create is top-level, should have no parent"
+    );
+
+    // Class methods use "::" scope separator.
+    let process = find_symbol(&symbols, "process");
+    assert_eq!(
+        process.qualified_name, "Processor::process",
+        "method must be scoped under its class"
+    );
+    assert_eq!(
+        process.parent_qualified_name.as_deref(),
+        Some("Processor"),
+        "method parent must be the enclosing class"
+    );
+
+    let mode = find_symbol(&symbols, "Mode");
+    assert_eq!(mode.qualified_name, "Mode");
+
+    let max_size = find_symbol(&symbols, "MAX_SIZE");
+    assert_eq!(max_size.qualified_name, "MAX_SIZE");
+}
+
+#[test]
+fn fixture_symbol_kinds_are_correct() {
+    let symbols = extract_fixture_symbols();
+
+    assert_eq!(
+        find_symbol(&symbols, "Config").kind,
+        core_model::SymbolKind::Type,
+        "interface should map to Type"
+    );
+    assert_eq!(
+        find_symbol(&symbols, "create").kind,
+        core_model::SymbolKind::Function,
+    );
+    assert_eq!(
+        find_symbol(&symbols, "Processor").kind,
+        core_model::SymbolKind::Class,
+    );
+    assert_eq!(
+        find_symbol(&symbols, "process").kind,
+        core_model::SymbolKind::Method,
+    );
+    assert_eq!(
+        find_symbol(&symbols, "Mode").kind,
+        core_model::SymbolKind::Type,
+        "enum should map to Type"
+    );
+    assert_eq!(
+        find_symbol(&symbols, "MAX_SIZE").kind,
+        core_model::SymbolKind::Constant,
+    );
+}
+
+#[test]
+fn fixture_symbol_ids_match_expected_canonical_form() {
+    let symbols = extract_fixture_symbols();
+    let file_path = "src/config.ts";
+
+    // Assert exact expected IDs for every fixture symbol.
+    let expected: &[(&str, &str)] = &[
+        ("Config", "src/config.ts::Config#type"),
+        ("create", "src/config.ts::create#function"),
+        ("Processor", "src/config.ts::Processor#class"),
+        ("process", "src/config.ts::Processor::process#method"),
+        ("Mode", "src/config.ts::Mode#type"),
+        ("MAX_SIZE", "src/config.ts::MAX_SIZE#constant"),
+    ];
+
+    for (name, expected_id) in expected {
+        let sym = find_symbol(&symbols, name);
+        let actual_id =
+            core_model::symbol_id::build_symbol_id(file_path, &sym.qualified_name, sym.kind)
+                .unwrap_or_else(|e| panic!("symbol '{name}' failed ID construction: {e}"));
+        assert_eq!(
+            &actual_id, expected_id,
+            "symbol '{name}' produced wrong canonical ID"
+        );
+
+        // Verify the ID also passes parse/validation round-trip.
+        core_model::symbol_id::validate_symbol_id(&actual_id)
+            .unwrap_or_else(|e| panic!("symbol '{name}' ID '{actual_id}' failed validation: {e}"));
+    }
+}
+
+#[test]
+fn fixture_symbol_ids_are_stable_across_runs() {
+    let symbols1 = extract_fixture_symbols();
+    let symbols2 = extract_fixture_symbols();
+    let file_path = "src/config.ts";
+
+    assert_eq!(symbols1.len(), symbols2.len());
+
+    for (a, b) in symbols1.iter().zip(symbols2.iter()) {
+        let id_a =
+            core_model::symbol_id::build_symbol_id(file_path, &a.qualified_name, a.kind).unwrap();
+        let id_b =
+            core_model::symbol_id::build_symbol_id(file_path, &b.qualified_name, b.kind).unwrap();
+        assert_eq!(
+            id_a, id_b,
+            "symbol ID not stable for '{}': '{}' vs '{}'",
+            a.name, id_a, id_b
+        );
+    }
+}


### PR DESCRIPTION
## Summary

  - Issue: Closes #65
  - Scope: Map TypeScript semantic adapter outputs into the canonical extracted-symbol schema with correct symbol kinds, qualified names, spans, confidence/provenance metadata, and stable ID compatibility validated by fixture-driven tests.

  ## Changes

  - Add `TypeScriptSemanticAdapter` that:
    - opens files in tsserver
    - requests `navtree`
    - parses semantic responses into adapter output
    - applies semantic provenance and default confidence metadata
  - Add TypeScript navtree-to-symbol mapping logic for:
    - canonical `SymbolKind` conversion
    - qualified name and parent scope construction
    - representative signature generation
    - `SourceSpan` conversion from tsserver line/offset data
  - Add Unicode-correct byte offset handling for tsserver UTF-16-based offsets.
  - Add fixture-based contract tests for the TypeScript semantic adapter.
  - Add exact fixture assertions for:
    - canonical qualified names
    - symbol kinds
    - exact canonical symbol IDs
    - stable IDs across repeated runs
  - Extend shared adapter contract fixtures with a TypeScript baseline fixture.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Mapping correctness verified with fixture tests.
  - [x] Criterion 2: Stable ID behavior matches core-model rules.

  ## Test Evidence

  - [ ] `cargo fmt --all -- --check`
  - [ ] `cargo clippy --all-targets --all-features -- -D warnings`
  - [ ] `cargo test --all --all-features`
  - [x] Additional tests/benchmarks (if required by issue)
  - [x] `cargo test -p adapter-semantic-typescript`

  ## Risk and Mitigation

  - Risk: Mapping behavior is validated against mocked `navtree` payloads rather than a live `tsserver` session.
  - Mitigation: Fixture tests assert exact canonical names, kinds, spans, provenance, determinism, and symbol ID compatibility, which keeps the mapping contract explicit and reviewable.

  ## Security/Observability Impact

  - Security: No new trust boundary beyond the existing tsserver runtime work; this change focuses on deterministic in-process mapping of semantic outputs.
  - Logs/Metrics/Tracing: No material observability surface added beyond existing adapter/runtime logging.