### PR TITLE
Add MCP tool schemas for all existing CodeAtlas tools

### DIFF
--- a/crates/cli/src/mcp_stdio.rs
+++ b/crates/cli/src/mcp_stdio.rs
@@ -717,8 +717,16 @@ mod tests {
             assert!(tool["description"].is_string());
             let schema = &tool["inputSchema"];
             assert_eq!(schema["type"], "object");
-            assert!(schema["properties"].is_object(), "tool {} missing properties", tool["name"]);
-            assert!(schema["required"].is_array(), "tool {} missing required", tool["name"]);
+            assert!(
+                schema["properties"].is_object(),
+                "tool {} missing properties",
+                tool["name"]
+            );
+            assert!(
+                schema["required"].is_array(),
+                "tool {} missing required",
+                tool["name"]
+            );
         }
     }
 
@@ -825,7 +833,10 @@ mod tests {
             .collect();
         assert_eq!(required, vec!["repo_id"]);
         // path_prefix is optional
-        assert!(schema["properties"].as_object().unwrap().contains_key("path_prefix"));
+        assert!(schema["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key("path_prefix"));
         assert_eq!(schema["properties"].as_object().unwrap().len(), 2);
     }
 

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -709,17 +709,17 @@ fn mcp_stdio_tools_list() {
     // properties and required fields (issue #133).
     for tool in tools {
         let name = tool["name"].as_str().unwrap();
-        assert!(tool["description"].is_string(), "{name} missing description");
+        assert!(
+            tool["description"].is_string(),
+            "{name} missing description"
+        );
         let schema = &tool["inputSchema"];
         assert_eq!(schema["type"], "object", "{name} schema type");
         assert!(
             schema["properties"].is_object(),
             "{name} missing properties"
         );
-        assert!(
-            schema["required"].is_array(),
-            "{name} missing required"
-        );
+        assert!(schema["required"].is_array(), "{name} missing required");
     }
 }
 


### PR DESCRIPTION
## Summary

  - Issue: Closes #133
  - Scope: Add real inputSchema definitions for all existing CodeAtlas MCP tools, expose them through tools/list, and add coverage to keep schema output aligned with current tool parameter contracts.

  ## Changes

  - Replaced placeholder inputSchema: { "type": "object" } responses in tools/list with per-tool JSON Schema definitions.
  - Added static schemas for:
      - search_symbols
      - get_symbol
      - get_symbols
      - get_file_outline
      - get_file_content
      - get_file_tree
      - get_repo_outline
      - search_text
  - Matched required fields to the current Rust request param structs.
  - Added enum constraints for kind where applicable.
  - Added defaults and minimum: 0 constraints for limit/offset to reflect usize semantics.
  - Kept schemas aligned with runtime behavior by not setting additionalProperties: false, since the current serde structs do not deny unknown fields.
  - Added unit tests that verify:
      - every registered tool has a schema
      - schema names and descriptions cover the registry
      - required fields/properties match each tool param struct
      - limit/offset expose minimum: 0
      - schemas do not claim stricter unknown-field behavior than runtime
      - runtime behavior matches the schema assumptions for unknown fields and negative integers
  - Extended subprocess integration coverage so tools/list asserts that every tool returns a description plus structured inputSchema fields.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Every existing CodeAtlas MCP tool is included in tools/list.
  - [x] Criterion 2: Each tool has a JSON Schema input definition matching its current parameters.
  - [x] Criterion 3: Required versus optional fields are represented correctly.
  - [x] Criterion 4: Tool names in tools/list match the names accepted by ToolRegistry.
  - [x] Criterion 5: Schema output is stable and suitable for snapshot-style or structure-based testing.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - cargo test -p cli schema_ -- --nocapture
      - integration assertions in mcp_stdio_tools_list

  ## Risk and Mitigation

  - Risk: Handwritten schemas can drift from the actual Rust parameter structs over time.
  - Mitigation: Added focused schema contract tests and runtime-behavior tests to catch drift in required fields, optional fields, unknown-field handling, and numeric constraints.

  ## Security/Observability Impact

  - Security: No new execution surface added; schemas now give clients better input constraints and clearer contract information.
  - Logs/Metrics/Tracing: No new logging, metrics, or tracing changes in this ticket.