### PR TITLE
Add MCP packaging and installation path for end users

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ re-reading the whole codebase every time.
 
 - [What CodeAtlas Is](#what-codeatlas-is)
 - [What You Can Do With It](#what-you-can-do-with-it)
+- [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Semantic Adapter Setup](#semantic-adapter-setup)
 - [MCP Server Setup](#mcp-server-setup)
@@ -57,25 +58,51 @@ MCP-capable AI client at `codeatlas mcp serve --db <path>`.
 - `repo-outline`: inspect repository structure and counts
 - `quality-report`: inspect semantic coverage and merge quality metrics
 
+## Installation
+
+### Option 1: Install from source with Cargo (recommended for v1)
+
+Requires the Rust toolchain (1.81+).
+
+```bash
+cargo install --git https://github.com/developepper/CodeAtlas.git --bin codeatlas
+```
+
+This builds and installs the `codeatlas` binary to `~/.cargo/bin/`. Make sure
+that directory is in your `PATH`.
+
+After installation, verify it works:
+
+```bash
+codeatlas help
+```
+
+### Option 2: Build from a local clone
+
+```bash
+git clone https://github.com/developepper/CodeAtlas.git
+cd CodeAtlas
+cargo build --release -p cli
+```
+
+The binary is at `./target/release/codeatlas`. Copy it to a directory in your
+`PATH` or run it directly.
+
+### What is not yet supported
+
+- Prebuilt GitHub Release binaries
+- Homebrew formula
+- Platform-specific installers (`.deb`, `.rpm`, `.msi`)
+- Docker images
+
+These may be added in future releases based on demand.
+
 ## Quick Start
 
-### 1. Build the CLI
+### 1. Install CodeAtlas
 
-```bash
-cargo build -p cli
-```
-
-You can then run the binary directly:
-
-```bash
-./target/debug/codeatlas help
-```
-
-Or with Cargo:
-
-```bash
-cargo run -p cli -- help
-```
+See [Installation](#installation) above. The examples below assume `codeatlas`
+is in your `PATH`.
 
 ### 2. Index a Repository
 
@@ -183,7 +210,7 @@ CodeAtlas includes a built-in MCP server that works with any stdio MCP client.
 
 ### Prerequisites
 
-1. Build or install `codeatlas` (see [Quick Start](#quick-start)).
+1. Install `codeatlas` (see [Installation](#installation)).
 2. Index a repository so an index database exists.
 
 ### Launch the MCP server

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true
+description = "CodeAtlas CLI — local code intelligence indexing, querying, and MCP server"
 
 [lib]
 name = "cli"

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -22,9 +22,15 @@ databases, or production alerting.
 
 ## 1. Local Environment Setup
 
-### Required baseline tools
+### Install CodeAtlas
 
-- Rust toolchain compatible with workspace `rust-version`
+See the [README Installation section](../../README.md#installation) for
+supported install paths (`cargo install`, GitHub Release binaries, or building
+from source).
+
+### Required baseline tools (for building from source)
+
+- Rust toolchain compatible with workspace `rust-version` (1.81+)
 - `cargo`
 - Git
 


### PR DESCRIPTION
## Summary

  - Issue: Closes #136
  - Scope: Define and document the realistic v1 installation/distribution story for CodeAtlas MCP usage, keeping codeatlas as the canonical executable and avoiding unsupported packaging claims.

  ## Changes

  - Added a dedicated Installation section to the README.
  - Documented the supported v1 install paths:
      - cargo install --git https://github.com/developepper/CodeAtlas.git --bin codeatlas
      - build from a local clone with cargo build --release -p cli
  - Clarified that the installed/built artifact is the codeatlas binary and that MCP usage is launched through:
      - codeatlas mcp serve --db <path>
  - Updated Quick Start to assume codeatlas is installed and available in PATH.
  - Updated MCP setup docs to point back to the new installation section instead of “build or install” language.
  - Updated the operations runbook so local environment setup references the supported install paths before source-build prerequisites.
  - Explicitly documented what is not yet supported for packaging/distribution in v1:
      - Homebrew
      - platform-specific installers
      - Docker images
      - prebuilt release binaries

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: The project has a documented supported install path for end users who want to use MCP.
  - [x] Criterion 2: Packaging/release docs make codeatlas mcp serve --db <path> discoverable as the MCP launch path.
  - [x] Criterion 3: The chosen install story does not require users to build custom wrappers.
  - [x] Criterion 4: Release/distribution expectations for MCP support are captured in repo docs.
  - [x] Criterion 5: The packaging guidance remains consistent with the product decision to keep codeatlas as the canonical executable.
  - [x] Criterion 6: The initial supported packaging story is explicit about what is in v1 and what is deferred.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - Manual doc review to confirm the install story only references currently supported paths and remains consistent across README/runbook/MCP setup guidance

  ## Risk and Mitigation

  - Risk: Installation guidance can drift from the repo’s real distribution capabilities and overpromise packaging support that does not exist.
  - Mitigation: The docs now limit the supported v1 story to paths that are actually available today and explicitly list deferred packaging options under “not yet supported.”

  ## Security/Observability Impact

  - Security: No runtime surface changes; docs now avoid steering users toward nonexistent or unofficial distribution channels.
  - Logs/Metrics/Tracing: No logging, metrics, or tracing changes in this ticket.