### PR TITLE
Validate MCP client compatibility and add minimal interoperability shims

### DIFF
--- a/crates/cli/src/mcp_stdio.rs
+++ b/crates/cli/src/mcp_stdio.rs
@@ -1,9 +1,16 @@
 //! Stdio MCP transport — newline-delimited JSON-RPC over stdin/stdout.
 //!
 //! Per MCP spec 2025-11-25, stdio messages are delimited by newlines and
-//! MUST NOT contain embedded newlines. This module implements the minimal
-//! MCP protocol subset for tool serving: `initialize`,
-//! `notifications/initialized`, `tools/list`, and `tools/call`.
+//! MUST NOT contain embedded newlines. This module implements the MCP
+//! protocol subset for tool serving: `initialize`,
+//! `notifications/initialized`, `tools/list`, `tools/call`, and `ping`.
+//!
+//! Compatibility shims are included for methods that documented MCP clients
+//! (Claude Desktop, Cursor, OpenAI Codex CLI) may probe during startup:
+//! `resources/list` and `prompts/list` return empty lists rather than
+//! `METHOD_NOT_FOUND`, and `notifications/cancelled` is silently accepted.
+//! These shims keep the server generic and do not add client-specific
+//! branching. See inline comments marked `COMPAT:` for rationale.
 //!
 //! All protocol output goes to stdout. All diagnostics go to stderr.
 
@@ -239,6 +246,29 @@ pub fn serve(registry: &ToolRegistry, input: impl Read, output: impl Write) -> R
                     Ok(result) => write_result(&mut writer, id, result)?,
                     Err(err) => write_error(&mut writer, id, err.code, err.message)?,
                 }
+            }
+            // COMPAT: MCP clients may send `ping` as a health check.
+            // Returning an empty result keeps the connection alive.
+            "ping" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, serde_json::json!({}))?;
+            }
+            // COMPAT: Some MCP clients probe `resources/list` and
+            // `prompts/list` during startup to discover server capabilities.
+            // Returning empty lists is more interoperable than METHOD_NOT_FOUND,
+            // which can cause some clients to treat the server as unhealthy.
+            "resources/list" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, serde_json::json!({ "resources": [] }))?;
+            }
+            "prompts/list" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, serde_json::json!({ "prompts": [] }))?;
+            }
+            // COMPAT: Clients may send `notifications/cancelled` when aborting
+            // a request. This is a notification (no id) and requires no response.
+            "notifications/cancelled" => {
+                // Silently accepted — no response required.
             }
             _ => {
                 if !is_notification {
@@ -994,7 +1024,7 @@ mod tests {
         let (db, make_registry) = test_registry();
         let registry = make_registry(&db);
 
-        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"resources/list"}"#]);
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"completions/complete"}"#]);
 
         let mut output = Vec::new();
         serve(&registry, &input[..], &mut output).unwrap();
@@ -1017,6 +1047,122 @@ mod tests {
         let responses = parse_responses(&output);
         assert!(responses.is_empty());
     }
+
+    // ── Compatibility shim tests ────────────────────────────────────
+
+    #[test]
+    fn serve_ping_returns_empty_result() {
+        let (db, make_registry) = test_registry();
+        let registry = make_registry(&db);
+
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#]);
+
+        let mut output = Vec::new();
+        serve(&registry, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        let r = &responses[0];
+        assert_eq!(r["id"], 1);
+        assert!(r["result"].is_object());
+        assert!(r.get("error").is_none());
+    }
+
+    #[test]
+    fn serve_resources_list_returns_empty() {
+        let (db, make_registry) = test_registry();
+        let registry = make_registry(&db);
+
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"resources/list"}"#]);
+
+        let mut output = Vec::new();
+        serve(&registry, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        let r = &responses[0];
+        assert_eq!(r["id"], 1);
+        let resources = r["result"]["resources"].as_array().unwrap();
+        assert!(resources.is_empty());
+    }
+
+    #[test]
+    fn serve_prompts_list_returns_empty() {
+        let (db, make_registry) = test_registry();
+        let registry = make_registry(&db);
+
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"prompts/list"}"#]);
+
+        let mut output = Vec::new();
+        serve(&registry, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        let r = &responses[0];
+        assert_eq!(r["id"], 1);
+        let prompts = r["result"]["prompts"].as_array().unwrap();
+        assert!(prompts.is_empty());
+    }
+
+    #[test]
+    fn serve_notifications_cancelled_silent() {
+        let (db, make_registry) = test_registry();
+        let registry = make_registry(&db);
+
+        let input = messages(&[
+            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}"#,
+        ]);
+
+        let mut output = Vec::new();
+        serve(&registry, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert!(
+            responses.is_empty(),
+            "notifications/cancelled should produce no response"
+        );
+    }
+
+    #[test]
+    fn serve_tools_list_with_cursor_param() {
+        let (db, make_registry) = test_registry();
+        let registry = make_registry(&db);
+
+        // Some clients send cursor: null when requesting the first page.
+        let input = messages(&[
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"cursor":null}}"#,
+        ]);
+
+        let mut output = Vec::new();
+        serve(&registry, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        let tools = responses[0]["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 8);
+    }
+
+    #[test]
+    fn serve_initialize_with_extra_capabilities() {
+        let (db, make_registry) = test_registry();
+        let registry = make_registry(&db);
+
+        // Clients may advertise capabilities the server doesn't support.
+        // The server should accept and respond normally.
+        let input = messages(&[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{"listChanged":true},"sampling":{}},"clientInfo":{"name":"cursor","version":"0.50"}}}"#,
+        ]);
+
+        let mut output = Vec::new();
+        serve(&registry, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0]["result"]["protocolVersion"], "2025-11-25");
+        assert_eq!(responses[0]["result"]["serverInfo"]["name"], "codeatlas");
+    }
+
+    // ── Remaining server loop tests ──────────────────────────────────
 
     #[test]
     fn serve_malformed_json() {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -823,8 +823,13 @@ fn mcp_stdio_content_length_rejected() {
 // mcp serve signal handling tests (subprocess)
 // ---------------------------------------------------------------------------
 
-#[test]
-fn mcp_stdio_sigterm_clean_shutdown() {
+/// Helper: send an initialize request, wait for the response on stdout to
+/// confirm the server is running, then send a signal and close stdin.
+/// Returns (exit status, stdout lines, stderr).
+fn signal_test_helper(signal: libc::c_int) -> (std::process::ExitStatus, String, String) {
+    use std::io::BufRead;
+    use std::sync::mpsc;
+
     let (_db_dir, db_path) = mcp_test_db();
 
     let mut child = Command::new(codeatlas_bin())
@@ -837,7 +842,7 @@ fn mcp_stdio_sigterm_clean_shutdown() {
 
     let pid = child.id();
 
-    // Send an initialize request so we know the server is running and responsive.
+    // Send an initialize request.
     {
         let stdin = child.stdin.as_mut().expect("stdin");
         writeln!(
@@ -845,19 +850,69 @@ fn mcp_stdio_sigterm_clean_shutdown() {
             r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2025-11-25","capabilities":{{}},"clientInfo":{{"name":"test","version":"1"}}}}}}"#
         )
         .expect("write initialize");
+        stdin.flush().expect("flush stdin");
     }
 
-    // Give the server a moment to process, then send SIGTERM.
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    // Read stdout in a separate thread. Use a channel to notify when the
+    // first response line arrives — this confirms the server has fully
+    // started (DB opened, signal handlers installed, serve loop entered).
+    let stdout_handle = child.stdout.take().expect("stdout");
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(stdout_handle);
+        let mut all_output = String::new();
+        let mut notified = false;
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    all_output.push_str(&line);
+                    if !notified {
+                        let _ = tx.send(());
+                        notified = true;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        all_output
+    });
+
+    // Block until the server has produced its first response, confirming
+    // signal handlers are installed and the serve loop is running.
+    rx.recv_timeout(std::time::Duration::from_secs(5))
+        .expect("server should respond to initialize within 5s");
+
+    // Now send the signal — the server is confirmed to be running.
     unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        libc::kill(pid as libc::pid_t, signal);
     }
 
-    let output = child.wait_with_output().expect("wait");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Close stdin so the blocking read_line returns EOF, allowing the serve
+    // loop to reach the shutdown flag check.
+    drop(child.stdin.take());
+
+    let status = child.wait().expect("wait");
+    let stdout = reader_thread.join().expect("reader thread");
+    let stderr_handle = child.stderr.take();
+    let stderr = stderr_handle
+        .map(|mut h| {
+            let mut s = String::new();
+            std::io::Read::read_to_string(&mut h, &mut s).ok();
+            s
+        })
+        .unwrap_or_default();
+
+    (status, stdout, stderr)
+}
+
+#[test]
+fn mcp_stdio_sigterm_clean_shutdown() {
+    let (status, stdout, stderr) = signal_test_helper(libc::SIGTERM);
 
     assert!(
-        output.status.success(),
+        status.success(),
         "should exit 0 on SIGTERM.\nstderr: {stderr}"
     );
     assert!(
@@ -866,7 +921,6 @@ fn mcp_stdio_sigterm_clean_shutdown() {
     );
 
     // Stdout must contain only valid JSON lines (no partial writes).
-    let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
         if line.trim().is_empty() {
             continue;
@@ -881,43 +935,14 @@ fn mcp_stdio_sigterm_clean_shutdown() {
 
 #[test]
 fn mcp_stdio_sigint_clean_shutdown() {
-    let (_db_dir, db_path) = mcp_test_db();
-
-    let mut child = Command::new(codeatlas_bin())
-        .args(["mcp", "serve", "--db", db_path.to_str().unwrap()])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn mcp serve");
-
-    let pid = child.id();
-
-    // Send an initialize request so we know the server is running.
-    {
-        let stdin = child.stdin.as_mut().expect("stdin");
-        writeln!(
-            stdin,
-            r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"2025-11-25","capabilities":{{}},"clientInfo":{{"name":"test","version":"1"}}}}}}"#
-        )
-        .expect("write initialize");
-    }
-
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGINT);
-    }
-
-    let output = child.wait_with_output().expect("wait");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let (status, stdout, stderr) = signal_test_helper(libc::SIGINT);
 
     assert!(
-        output.status.success(),
+        status.success(),
         "should exit 0 on SIGINT.\nstderr: {stderr}"
     );
 
     // Stdout must contain only valid JSON lines.
-    let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
         if line.trim().is_empty() {
             continue;
@@ -1239,6 +1264,98 @@ fn mcp_stdio_diagnostics_on_stderr_only() {
             parsed.get("jsonrpc").is_some(),
             "stdout line missing jsonrpc field: {line}"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// mcp serve client compatibility shims (subprocess)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mcp_stdio_ping_returns_result() {
+    let (_db_dir, db_path) = mcp_test_db();
+
+    let (responses, _stderr) =
+        mcp_stdio_exchange(&db_path, &[r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#]);
+
+    assert_eq!(responses.len(), 1);
+    let r: serde_json::Value = serde_json::from_str(&responses[0]).unwrap();
+    assert_eq!(r["id"], 1);
+    assert!(r["result"].is_object());
+    assert!(r.get("error").is_none(), "ping should not return an error");
+}
+
+#[test]
+fn mcp_stdio_resources_list_returns_empty() {
+    let (_db_dir, db_path) = mcp_test_db();
+
+    let (responses, _stderr) = mcp_stdio_exchange(
+        &db_path,
+        &[r#"{"jsonrpc":"2.0","id":1,"method":"resources/list"}"#],
+    );
+
+    assert_eq!(responses.len(), 1);
+    let r: serde_json::Value = serde_json::from_str(&responses[0]).unwrap();
+    let resources = r["result"]["resources"].as_array().unwrap();
+    assert!(resources.is_empty());
+}
+
+#[test]
+fn mcp_stdio_prompts_list_returns_empty() {
+    let (_db_dir, db_path) = mcp_test_db();
+
+    let (responses, _stderr) = mcp_stdio_exchange(
+        &db_path,
+        &[r#"{"jsonrpc":"2.0","id":1,"method":"prompts/list"}"#],
+    );
+
+    assert_eq!(responses.len(), 1);
+    let r: serde_json::Value = serde_json::from_str(&responses[0]).unwrap();
+    let prompts = r["result"]["prompts"].as_array().unwrap();
+    assert!(prompts.is_empty());
+}
+
+#[test]
+fn mcp_stdio_client_handshake_with_extra_capabilities() {
+    let (_db_dir, db_path) = mcp_test_db();
+
+    // Simulate a client that advertises capabilities the server doesn't use.
+    let (responses, _stderr) = mcp_stdio_exchange(
+        &db_path,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{"listChanged":true},"sampling":{}},"clientInfo":{"name":"cursor","version":"0.50"}}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#,
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/list"}"#,
+            r#"{"jsonrpc":"2.0","id":4,"method":"resources/list"}"#,
+            r#"{"jsonrpc":"2.0","id":5,"method":"prompts/list"}"#,
+        ],
+    );
+
+    // 5 responses: initialize, ping, tools/list, resources/list, prompts/list.
+    // notifications/initialized produces no response.
+    assert_eq!(responses.len(), 5, "expected 5 responses");
+
+    let r1: serde_json::Value = serde_json::from_str(&responses[0]).unwrap();
+    assert_eq!(r1["result"]["protocolVersion"], "2025-11-25");
+
+    let r2: serde_json::Value = serde_json::from_str(&responses[1]).unwrap();
+    assert!(r2["result"].is_object(), "ping should return result");
+
+    let r3: serde_json::Value = serde_json::from_str(&responses[2]).unwrap();
+    assert_eq!(r3["result"]["tools"].as_array().unwrap().len(), 8);
+
+    let r4: serde_json::Value = serde_json::from_str(&responses[3]).unwrap();
+    assert!(r4["result"]["resources"].as_array().unwrap().is_empty());
+
+    let r5: serde_json::Value = serde_json::from_str(&responses[4]).unwrap();
+    assert!(r5["result"]["prompts"].as_array().unwrap().is_empty());
+
+    // All stdout lines must be valid JSON-RPC.
+    for line in &responses {
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).unwrap_or_else(|_| panic!("not valid JSON: {line}"));
+        assert!(parsed.get("jsonrpc").is_some());
     }
 }
 

--- a/docs/architecture/mcp-client-compatibility.md
+++ b/docs/architecture/mcp-client-compatibility.md
@@ -1,0 +1,125 @@
+# MCP Client Compatibility Notes
+
+This document records intentional compatibility accommodations in the CodeAtlas
+MCP server and their rationale.
+
+## Design Principle
+
+The server targets the generic stdio MCP specification (2025-11-25) and avoids
+client-specific branching. Compatibility shims are additive responses to
+methods that documented clients probe during startup, not behavioral changes
+conditioned on client identity.
+
+## Documented Target Clients
+
+- Claude Desktop
+- Cursor
+- OpenAI Codex CLI
+
+Any stdio MCP client that speaks newline-delimited JSON-RPC 2.0 and the
+supported method subset should work.
+
+## Compatibility Shims
+
+### `ping` method
+
+**Behavior:** Returns an empty JSON-RPC result (`{}`).
+
+**Rationale:** MCP clients may send `ping` as a health check or keepalive. The
+MCP specification defines `ping` as a standard method. Returning
+`METHOD_NOT_FOUND` can cause clients to treat the server as unhealthy.
+
+**Test coverage:** Unit test `serve_ping_returns_empty_result`, subprocess test
+`mcp_stdio_ping_returns_result`.
+
+### `resources/list` method
+
+**Behavior:** Returns `{"resources": []}`.
+
+**Rationale:** Some MCP clients probe `resources/list` during capability
+discovery. Returning an empty list communicates "no resources available" without
+triggering error-handling paths in clients that expect a structured response.
+
+**Test coverage:** Unit test `serve_resources_list_returns_empty`, subprocess
+test `mcp_stdio_resources_list_returns_empty`.
+
+### `prompts/list` method
+
+**Behavior:** Returns `{"prompts": []}`.
+
+**Rationale:** Same as `resources/list`. Clients may probe for prompts during
+startup.
+
+**Test coverage:** Unit test `serve_prompts_list_returns_empty`, subprocess
+test `mcp_stdio_prompts_list_returns_empty`.
+
+### `notifications/cancelled` notification
+
+**Behavior:** Silently accepted (no response).
+
+**Rationale:** Clients may send this notification when aborting a pending
+request. Since it is a notification (no `id`), no response is required per
+JSON-RPC. Explicitly accepting it avoids logging noise from the unknown-method
+fallback.
+
+**Test coverage:** Unit test `serve_notifications_cancelled_silent`.
+
+### Extra client capabilities in `initialize`
+
+**Behavior:** Ignored. The server returns its own capabilities regardless of
+what the client advertises.
+
+**Rationale:** Clients like Cursor advertise capabilities such as `roots` and
+`sampling` that the server does not use. The server must not reject these.
+
+**Test coverage:** Unit test `serve_initialize_with_extra_capabilities`,
+subprocess test `mcp_stdio_client_handshake_with_extra_capabilities`.
+
+### `tools/list` with cursor parameter
+
+**Behavior:** The `params` field is accepted and ignored. All tools are
+returned in a single response.
+
+**Rationale:** Some clients send `{"cursor": null}` when requesting the first
+page. Since CodeAtlas has a small fixed tool set, pagination is unnecessary and
+cursor values are ignored.
+
+**Test coverage:** Unit test `serve_tools_list_with_cursor_param`.
+
+## Content-Length Framing Rejection
+
+**Behavior:** The server detects lines starting with `Content-Length:` and
+returns a `PARSE_ERROR` with a message explaining that the server uses
+newline-delimited JSON per MCP spec 2025-11-25.
+
+**Rationale:** The older MCP transport (2024-11-05) used Content-Length framing.
+If a client sends this format, the server should fail clearly rather than
+silently misbehaving.
+
+**Test coverage:** Unit test `read_message_rejects_content_length`,
+`serve_content_length_rejected`, subprocess test
+`mcp_stdio_content_length_rejected`.
+
+## What Is Not Shimmed
+
+Methods and features not listed above return `METHOD_NOT_FOUND` per JSON-RPC
+2.0. This includes:
+
+- `completions/complete`
+- `resources/read`
+- `prompts/get`
+- `logging/setLevel`
+- Any other method not in the supported set
+
+Unknown notifications (method names not matching a known notification) are
+silently ignored per JSON-RPC 2.0 convention.
+
+## Adding New Shims
+
+New compatibility shims should only be added when a documented client
+demonstrably requires them for basic interoperability. Each shim should:
+
+1. Be minimal and additive (no client-specific branching).
+2. Have a `COMPAT:` comment in the source explaining the rationale.
+3. Be covered by both a unit test and a subprocess integration test.
+4. Be documented in this file.


### PR DESCRIPTION
## Summary

  - Issue: Closes #137
  - Scope: Validate documented MCP client interoperability and add minimal, additive compatibility shims for startup/lifecycle probes without introducing client-specific branching.

  ## Changes

  - Added compatibility shims to the stdio MCP server for startup/lifecycle methods commonly probed by documented clients:
      - ping returns an empty JSON-RPC result
      - resources/list returns { "resources": [] }
      - prompts/list returns { "prompts": [] }
      - notifications/cancelled is silently accepted as a notification
  - Kept the server generic:
      - no branching on client identity
      - no changes to the core tool-serving contract
      - unsupported methods still return METHOD_NOT_FOUND
  - Added compatibility-focused unit tests for:
      - ping
      - resources/list
      - prompts/list
      - notifications/cancelled
      - tools/list with cursor: null
      - initialize with extra advertised client capabilities
  - Added subprocess integration coverage for:
      - ping
      - resources/list
      - prompts/list
      - multi-step client handshake with extra capabilities
  - Tightened signal-shutdown subprocess coverage so SIGTERM/SIGINT tests wait until the server has actually responded before sending the signal, avoiding startup races.
  - Added mcp-client-compatibility.md documenting:
      - the target clients
      - each intentional compatibility shim
      - rationale
      - test coverage
      - what is explicitly not shimmed
      - rules for adding future shims

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Documented target clients have their startup and handshake behavior validated against the implemented server.
  - [x] Criterion 2: Required compatibility shims are small, explicit, and covered by tests.
  - [x] Criterion 3: Client-specific accommodations do not leak non-protocol output to stdout.
  - [x] Criterion 4: Compatibility notes are documented for maintainability.
  - [x] Criterion 5: The server remains generic stdio MCP infrastructure rather than becoming tightly coupled to a single client.
  - [x] Criterion 6: Client-specific shims are additive and only used for documented interoperability needs.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)
      - cargo test -p cli mcp_stdio -- --nocapture

  ## Risk and Mitigation

  - Risk: Compatibility shims can accumulate into undocumented behavior or drift with changing client implementations.
  - Mitigation: Each shim is minimal, documented, covered by both unit and subprocess tests, and recorded in the compatibility notes with an explicit rationale and maintenance rule.

  ## Security/Observability Impact

  - Security: No new privileged behavior or broader protocol surface was added beyond additive empty-result/list responses for compatibility probes.
  - Logs/Metrics/Tracing: Diagnostics remain on stderr, stdout remains protocol-only, and compatibility behavior is documented rather than hidden.