### PR TITLE
docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ is in your `PATH`.
 ### 2. Index a Repository
 
 ```bash
-cargo run -p cli -- index /absolute/path/to/repo
+codeatlas index /absolute/path/to/repo
 ```
 
 Useful options:
 
 ```bash
-cargo run -p cli -- index /absolute/path/to/repo --db /tmp/codeatlas.db
-cargo run -p cli -- index /absolute/path/to/repo --git-diff
+codeatlas index /absolute/path/to/repo --db /tmp/codeatlas.db
+codeatlas index /absolute/path/to/repo --git-diff
 ```
 
 The CLI creates a local index database and content blob store. By default the
@@ -140,43 +140,43 @@ You will need that `repo_id` for query commands.
 Search for symbols:
 
 ```bash
-cargo run -p cli -- search-symbols greet --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
+codeatlas search-symbols greet --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
 ```
 
 Search with filters:
 
 ```bash
-cargo run -p cli -- search-symbols service --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app --kind class --language typescript --limit 10
+codeatlas search-symbols service --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app --kind class --language typescript --limit 10
 ```
 
 Get a symbol by ID:
 
 ```bash
-cargo run -p cli -- get-symbol 'src/lib.rs::greet#function' --db /absolute/path/to/repo/.codeatlas/index.db
+codeatlas get-symbol 'src/lib.rs::greet#function' --db /absolute/path/to/repo/.codeatlas/index.db
 ```
 
 Get a file outline:
 
 ```bash
-cargo run -p cli -- file-outline src/lib.rs --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
+codeatlas file-outline src/lib.rs --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
 ```
 
 Get a file tree:
 
 ```bash
-cargo run -p cli -- file-tree --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
+codeatlas file-tree --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
 ```
 
 Get a repository outline:
 
 ```bash
-cargo run -p cli -- repo-outline --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
+codeatlas repo-outline --db /absolute/path/to/repo/.codeatlas/index.db --repo my-app
 ```
 
 Generate a quality report:
 
 ```bash
-cargo run -p cli -- quality-report /absolute/path/to/repo
+codeatlas quality-report /absolute/path/to/repo
 ```
 
 ## Semantic Adapter Setup
@@ -222,6 +222,9 @@ codeatlas mcp serve --db /path/to/repo/.codeatlas/index.db
 The server communicates over stdio using newline-delimited JSON-RPC 2.0
 (MCP spec 2025-11-25). All diagnostics go to stderr; stdout is reserved for
 protocol messages only.
+
+Compatibility notes for documented clients and additive interoperability shims
+live in [docs/architecture/mcp-client-compatibility.md](docs/architecture/mcp-client-compatibility.md).
 
 ### Client configuration
 

--- a/docs/architecture/mcp-server-planning.md
+++ b/docs/architecture/mcp-server-planning.md
@@ -3,6 +3,10 @@
 This document captures the implementation plan for making CodeAtlas usable as a
 simple local MCP server for mainstream AI clients.
 
+Status note: this plan has now been implemented through Epic 11. The sections
+below remain useful as historical design context, but they should be read as
+"what was planned and delivered" rather than "what is still missing."
+
 The success criterion is not merely "an MCP binary exists." The success
 criterion is: a user can index a repository once, point their AI client at
 CodeAtlas with one obvious command, and use the CodeAtlas query surface through
@@ -26,7 +30,7 @@ The intended user flow is:
 That end-user simplicity is a required part of scope for the first supported
 MCP server release.
 
-## Current State
+## Original Starting State
 
 The `server-mcp` crate is a library-only crate. It contains the business logic
 for tool dispatch but no transport, no MCP protocol handler, and no
@@ -64,8 +68,8 @@ The registry already handles:
 - error wrapping
 - response envelope construction
 
-The missing work is transport/protocol integration, user-facing launch UX,
-client documentation, and diagnostics.
+At planning time, the missing work was transport/protocol integration,
+user-facing launch UX, client documentation, and diagnostics.
 
 ## Product Requirements
 
@@ -129,11 +133,12 @@ Documentation should include:
 - explicit statement of what is and is not supported
 - guidance on `repo_id` usage for tools that require repository scoping
 
-## What Is Missing
+## Original Gaps
 
 ### 1. JSON-RPC 2.0 framing
 
-No request/response framing types or parser exist in the workspace today.
+At planning time, no request/response framing types or parser existed in the
+workspace.
 
 Required types:
 
@@ -152,7 +157,7 @@ misbehaving.
 
 ### 2. MCP protocol state machine
 
-The workspace does not yet handle:
+At planning time, the workspace did not yet handle:
 
 - `initialize`
 - `notifications/initialized`
@@ -163,18 +168,19 @@ The workspace does not yet handle:
 
 ### 3. stdio transport loop
 
-No stdin/stdout read-write loop exists yet.
+At planning time, no stdin/stdout read-write loop existed.
 
 ### 4. User-facing CLI entrypoint
 
-The current CLI in `crates/cli/src/main.rs` does not have an `mcp` command.
+At planning time, the CLI in `crates/cli/src/main.rs` did not have an `mcp`
+command.
 
 This is the preferred place for the primary launch path because it reduces the
 number of things users need to install and understand.
 
 ### 5. Optional alias binary
 
-There is no `main.rs` in `server-mcp` and no `[[bin]]` target in
+There is still no `main.rs` in `server-mcp` and no `[[bin]]` target in
 `crates/server-mcp/Cargo.toml`.
 
 This is optional for product success, but useful as a compatibility alias or a
@@ -186,9 +192,9 @@ thin transport wrapper if the team wants a dedicated executable name.
 
 ### 7. Client-facing documentation
 
-The README currently explains that users need to wrap the MCP library
-themselves. That guidance must be replaced by a supported setup flow once this
-work lands.
+This gap has been resolved in the README and runbook. The original issue was
+that the README explained the MCP library shape without a supported end-user
+setup flow.
 
 ## Recommended Product Shape
 
@@ -371,7 +377,7 @@ remain simple and stable.
 
 ## Acceptance Criteria
 
-The work should be considered complete when all of the following are true:
+The work was considered complete when all of the following became true:
 
 1. A user can run `codeatlas mcp serve --db <path>`.
 2. A generic stdio MCP client can complete `initialize`, `tools/list`, and
@@ -380,7 +386,8 @@ The work should be considered complete when all of the following are true:
 4. Server logs and diagnostics never corrupt stdout protocol frames.
 5. The README documents a copy-pasteable supported MCP setup flow, including a
    small set of real client examples.
-6. Integration tests cover framed stdio communication with a real subprocess.
+6. Integration tests cover newline-delimited stdio communication with a real
+   subprocess.
 7. Documented clients have compatibility validation notes, and any required
    client-specific shims are explicit rather than implicit.
 
@@ -395,7 +402,7 @@ The work should be considered complete when all of the following are true:
 
 ## Recommended First Slice
 
-The smallest useful slice that still matches the product goal is:
+The smallest useful slice that matched the product goal was:
 
 1. add `codeatlas mcp serve --db <path>`
 2. implement JSON-RPC framing
@@ -412,8 +419,8 @@ Fast-follow after the first slice:
 2. add narrowly-scoped interoperability shims only if those validations prove
    they are required
 
-That is enough to make CodeAtlas meaningfully usable with real AI clients
-without introducing a larger SDK or hosted-service surface.
+That slice was enough to make CodeAtlas meaningfully usable with real AI
+clients without introducing a larger SDK or hosted-service surface.
 
 ## References
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -124,6 +124,8 @@ Expected: a JSON response with `"protocolVersion":"2025-11-25"`.
 
 See the [README MCP Server Setup](../../README.md#mcp-server-setup) for
 copy-paste configuration examples for Claude Desktop, Cursor, and OpenAI Codex CLI.
+See [MCP Client Compatibility Notes](../architecture/mcp-client-compatibility.md)
+for the currently documented interoperability shims and rationale.
 
 ### Troubleshoot startup failures
 

--- a/docs/planning/github-issues/mcp-ticket-diagnostics-tests.md
+++ b/docs/planning/github-issues/mcp-ticket-diagnostics-tests.md
@@ -9,7 +9,8 @@ with unit tests alone.
 
 - harden startup/runtime diagnostics for missing DB, unreadable DB, and schema/open failures
 - ensure all diagnostics remain off stdout
-- add subprocess integration tests that cover framed stdio behavior end to end
+- add subprocess integration tests that cover newline-delimited stdio behavior
+  end to end
 - add smoke coverage for `initialize -> tools/list -> tools/call`
 - assert that invalid requests are reported predictably
 

--- a/docs/planning/issue-backlog.md
+++ b/docs/planning/issue-backlog.md
@@ -2,13 +2,15 @@
 
 This backlog is designed for one-PR-per-issue execution.
 
-Progress (updated 2026-03-12): Milestones M0-M9 are complete. The platform now
+Progress (updated 2026-03-12): Milestones M0-M11 are complete. The platform now
 includes indexing pipeline, query engine, MCP serving contracts, local CLI
 commands, incremental indexing with git-diff acceleration and determinism
 regression coverage, plus tracing, redacted structured logging, security
 regression coverage, performance threshold enforcement, TypeScript and Kotlin
-semantic adapters, confidence-aware merge, semantic regression gating, and
-semantic coverage/win-rate metrics. Workspace quality gates are green (`fmt`,
+semantic adapters, confidence-aware merge, semantic regression gating, semantic
+coverage/win-rate metrics, a built-in newline-delimited stdio MCP server,
+documented client setup, packaging guidance, diagnostics coverage, tool
+schemas, and compatibility notes. Workspace quality gates are green (`fmt`,
 `clippy -D warnings`, full workspace tests).
 
 ## Epic 0: Repository Governance and CI Foundation (complete)
@@ -98,15 +100,15 @@ semantic coverage/win-rate metrics. Workspace quality gates are green (`fmt`,
 - Ticket: Add compatibility policy docs (N-1 API, schema migration)
 - Manual: Release readiness checklist and go/no-go review
 
-## Epic 11: First-Class Local MCP Server for AI Clients
+## Epic 11: First-Class Local MCP Server for AI Clients (complete)
 
-- Ticket: Add codeatlas mcp serve canonical CLI entrypoint and server wiring (#135)
-- Ticket: Implement stdio JSON-RPC framing and MCP request routing (#131)
-- Ticket: Add MCP tool schemas for all existing CodeAtlas tools (#133)
-- Ticket: Add MCP diagnostics and subprocess integration coverage (#132)
-- Ticket: Publish supported MCP client setup and troubleshooting docs (#134)
-- Ticket: Add MCP packaging and installation path for end users (#136)
-- Ticket: Validate MCP client compatibility and add minimal interoperability shims (#137)
+- ~~Ticket: Add codeatlas mcp serve canonical CLI entrypoint and server wiring~~ (#135)
+- ~~Ticket: Implement stdio JSON-RPC framing and MCP request routing~~ (#131)
+- ~~Ticket: Add MCP tool schemas for all existing CodeAtlas tools~~ (#133)
+- ~~Ticket: Add MCP diagnostics and subprocess integration coverage~~ (#132)
+- ~~Ticket: Publish supported MCP client setup and troubleshooting docs~~ (#134)
+- ~~Ticket: Add MCP packaging and installation path for end users~~ (#136)
+- ~~Ticket: Validate MCP client compatibility and add minimal interoperability shims~~ (#137)
 
 ## Post-V1 Direction
 

--- a/docs/planning/mcp-github-issues.md
+++ b/docs/planning/mcp-github-issues.md
@@ -4,6 +4,9 @@ This document captures the proposed GitHub epic and ticket bodies for the
 planned CodeAtlas MCP server work. It translates
 `docs/architecture/mcp-server-planning.md` into executable issue tracking.
 
+Status note: these issue bodies are historical planning artifacts for Epic 11,
+which has now been completed.
+
 ## Epic
 
 ### Title
@@ -243,7 +246,8 @@ with unit tests alone.
 
 - harden startup/runtime diagnostics for missing DB, unreadable DB, and schema/open failures
 - ensure all diagnostics remain off stdout
-- add subprocess integration tests that cover framed stdio behavior end to end
+- add subprocess integration tests that cover newline-delimited stdio behavior
+  end to end
 - add smoke coverage for `initialize -> tools/list -> tools/call`
 - assert that invalid requests are reported predictably
 


### PR DESCRIPTION
## Epic Closeout

  Epic 11 is complete.

  Delivered outcomes:

  - codeatlas mcp serve --db <path> is now the canonical local MCP entrypoint
  - stdio MCP transport is implemented using newline-delimited JSON-RPC 2.0
  - core MCP lifecycle/tool methods are supported:
      - initialize
      - notifications/initialized
      - tools/list
      - tools/call
  - all existing MCP tools are exposed with input schemas
  - startup diagnostics and failure paths are covered with subprocess integration tests
  - stdout is kept protocol-only and stderr is used for diagnostics
  - supported client setup is documented for Claude Desktop, Cursor, and OpenAI Codex CLI
  - installation/distribution guidance is documented for v1
  - additive client compatibility shims are implemented and documented

  Completed tickets:

  - #135 codeatlas mcp serve CLI entrypoint
  - #131 stdio JSON-RPC routing
  - #133 MCP tool schemas
  - #132 diagnostics and subprocess integration coverage
  - #134 client setup and troubleshooting docs
  - #136 packaging/install path docs
  - #137 client compatibility validation and minimal shims

  Verification:

  - cargo test -p cli -- --nocapture passed in final review
  - README, runbook, backlog, compatibility notes, and planning artifacts were updated for consistency

  Follow-up note:

  - client config formats and interoperability expectations are external and may change over time, so the documented client examples should be manually revalidated periodically.