### PR TITLE
Add repo catalog and lifecycle operations for a persistent local service

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4,5 +4,6 @@ pub mod get_symbol;
 pub mod index;
 pub mod mcp_serve;
 pub mod quality_report;
+pub mod repo;
 pub mod repo_outline;
 pub mod search_symbols;

--- a/crates/cli/src/commands/repo.rs
+++ b/crates/cli/src/commands/repo.rs
@@ -1,0 +1,510 @@
+//! `codeatlas repo` command family — repo catalog and lifecycle operations.
+
+use std::path::PathBuf;
+
+use indexer::PipelineContext;
+
+use crate::error::CliError;
+use crate::router;
+
+/// Entry point for the `codeatlas repo` command family.
+pub fn run(args: &[String]) -> Result<(), CliError> {
+    let subcommand = args.first().map(|s| s.as_str());
+    match subcommand {
+        Some("add") => run_add(&args[1..]),
+        Some("list") => run_list(&args[1..]),
+        Some("status") => run_status(&args[1..]),
+        Some("refresh") => run_refresh(&args[1..]),
+        Some("remove") => run_remove(&args[1..]),
+        Some("--help" | "-h") => {
+            print_repo_help();
+            Ok(())
+        }
+        Some(other) => Err(CliError::Usage(format!(
+            "unknown repo subcommand: '{other}'\n\n{}",
+            REPO_HELP
+        ))),
+        None => {
+            print_repo_help();
+            Err(CliError::Usage("missing repo subcommand".into()))
+        }
+    }
+}
+
+// ── repo add ──────────────────────────────────────────────────────────
+
+struct AddOpts {
+    source_root: PathBuf,
+    repo_id: Option<String>,
+    db_path: Option<PathBuf>,
+    git_diff: bool,
+}
+
+fn parse_add_args(args: &[String]) -> Result<AddOpts, CliError> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        eprintln!("Usage: codeatlas repo add <path> [--repo-id <id>] [--db <path>] [--git-diff]");
+        eprintln!();
+        eprintln!("Register and index a repository. The repo_id defaults to the");
+        eprintln!("directory name of <path>.");
+        return Err(CliError::Usage(String::new()));
+    }
+
+    let mut source_root: Option<PathBuf> = None;
+    let mut repo_id: Option<String> = None;
+    let mut db_path: Option<PathBuf> = None;
+    let mut git_diff = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--repo-id" => {
+                i += 1;
+                repo_id = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--repo-id requires a value".into()))?
+                        .clone(),
+                );
+            }
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            "--git-diff" => {
+                git_diff = true;
+            }
+            arg if arg.starts_with('-') => {
+                return Err(CliError::Usage(format!("unknown option: {arg}")));
+            }
+            arg if source_root.is_none() => {
+                source_root = Some(PathBuf::from(arg));
+            }
+            other => {
+                return Err(CliError::Usage(format!("unexpected argument: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let source_root = source_root.ok_or_else(|| {
+        CliError::Usage(
+            "usage: codeatlas repo add <path> [--repo-id <id>] [--db <path>] [--git-diff]".into(),
+        )
+    })?;
+
+    Ok(AddOpts {
+        source_root,
+        repo_id,
+        db_path,
+        git_diff,
+    })
+}
+
+fn run_add(args: &[String]) -> Result<(), CliError> {
+    let opts = parse_add_args(args)?;
+    let source_root = opts.source_root.canonicalize()?;
+
+    let repo_id = match opts.repo_id {
+        Some(id) => id,
+        None => source_root
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .ok_or_else(|| {
+                CliError::Usage(
+                    "cannot derive repo_id from path; use --repo-id to specify one".into(),
+                )
+            })?,
+    };
+
+    let (db_path, blob_path) =
+        cli::data_root::resolve_db_and_blob_paths(opts.db_path).map_err(CliError::Usage)?;
+
+    // Check for repo_id collision with a different source root.
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut db = store::MetadataStore::open(&db_path)?;
+
+    if let Some(existing) = db.repos().get(&repo_id)? {
+        // Canonicalize both sides so that symlinks or relative paths stored
+        // from earlier registrations don't cause false collisions.
+        let existing_canonical = std::path::PathBuf::from(&existing.source_root)
+            .canonicalize()
+            .unwrap_or_else(|_| std::path::PathBuf::from(&existing.source_root));
+        if existing_canonical != source_root {
+            return Err(CliError::Usage(format!(
+                "repo_id '{repo_id}' is already registered with a different source root:\n  \
+                 existing: {}\n  \
+                 new:      {}\n\n\
+                 Use --repo-id <different-id> to register under a different name,\n\
+                 or 'codeatlas repo remove {repo_id}' first.",
+                existing.source_root,
+                source_root.display(),
+            )));
+        }
+    }
+
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let adapter_router = router::build_router(&source_root);
+
+    let ctx = PipelineContext {
+        repo_id: repo_id.clone(),
+        source_root,
+        router: &adapter_router,
+        policy_override: None,
+        correlation_id: None,
+        use_git_diff: opts.git_diff,
+    };
+
+    let result = indexer::run(&ctx, &mut db, &blob_store)?;
+
+    println!("registered: {repo_id}");
+    println!("files_discovered: {}", result.metrics.files_discovered);
+    println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("symbols_extracted: {}", result.metrics.symbols_extracted);
+
+    Ok(())
+}
+
+// ── repo list ─────────────────────────────────────────────────────────
+
+fn parse_db_only_args(args: &[String]) -> Result<Option<PathBuf>, CliError> {
+    let mut db_path: Option<PathBuf> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            "--help" | "-h" => {
+                return Err(CliError::Usage(String::new()));
+            }
+            other => {
+                return Err(CliError::Usage(format!("unexpected argument: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    Ok(db_path)
+}
+
+fn open_db_readonly(db_override: Option<PathBuf>) -> Result<store::MetadataStore, CliError> {
+    let (db_path, _) =
+        cli::data_root::resolve_db_and_blob_paths(db_override).map_err(CliError::Usage)?;
+
+    if !db_path.exists() {
+        return Err(CliError::Usage(format!(
+            "database not found: {}\n\nHint: run 'codeatlas repo add <path>' to register a repository.",
+            db_path.display()
+        )));
+    }
+
+    Ok(store::MetadataStore::open(&db_path)?)
+}
+
+fn run_list(args: &[String]) -> Result<(), CliError> {
+    let db_override = parse_db_only_args(args)?;
+    let db = open_db_readonly(db_override)?;
+    let repos = db.repos().list_all()?;
+
+    if repos.is_empty() {
+        println!("No repositories registered.");
+        println!();
+        println!("Add a repository with: codeatlas repo add <path>");
+        return Ok(());
+    }
+
+    for repo in &repos {
+        println!(
+            "{:<20} {:<8} {:<6} {:>5} files  {:>6} symbols  {}",
+            repo.repo_id,
+            repo.indexing_status.as_str(),
+            repo.freshness_status.as_str(),
+            repo.file_count,
+            repo.symbol_count,
+            repo.source_root,
+        );
+    }
+
+    Ok(())
+}
+
+// ── repo status ───────────────────────────────────────────────────────
+
+fn run_status(args: &[String]) -> Result<(), CliError> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        eprintln!("Usage: codeatlas repo status <repo_id> [--db <path>]");
+        return Err(CliError::Usage(String::new()));
+    }
+
+    let mut repo_id: Option<String> = None;
+    let mut db_path: Option<PathBuf> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            arg if arg.starts_with('-') => {
+                return Err(CliError::Usage(format!("unknown option: {arg}")));
+            }
+            arg if repo_id.is_none() => {
+                repo_id = Some(arg.to_string());
+            }
+            other => {
+                return Err(CliError::Usage(format!("unexpected argument: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let repo_id = repo_id.ok_or_else(|| {
+        CliError::Usage("usage: codeatlas repo status <repo_id> [--db <path>]".into())
+    })?;
+
+    let db = open_db_readonly(db_path)?;
+    let repo = db
+        .repos()
+        .get(&repo_id)?
+        .ok_or_else(|| CliError::Usage(format!("repo '{repo_id}' not found")))?;
+
+    println!("repo_id:          {}", repo.repo_id);
+    println!("display_name:     {}", repo.display_name);
+    println!("source_root:      {}", repo.source_root);
+    println!("indexing_status:  {}", repo.indexing_status.as_str());
+    println!("freshness_status: {}", repo.freshness_status.as_str());
+    println!("indexed_at:       {}", repo.indexed_at);
+    println!("index_version:    {}", repo.index_version);
+    println!("file_count:       {}", repo.file_count);
+    println!("symbol_count:     {}", repo.symbol_count);
+    if let Some(ref registered_at) = repo.registered_at {
+        println!("registered_at:    {}", registered_at);
+    }
+    if let Some(ref git_head) = repo.git_head {
+        println!("git_head:         {}", git_head);
+    }
+    if !repo.language_counts.is_empty() {
+        println!("languages:");
+        for (lang, count) in &repo.language_counts {
+            println!("  {lang}: {count}");
+        }
+    }
+
+    Ok(())
+}
+
+// ── repo refresh ──────────────────────────────────────────────────────
+
+fn run_refresh(args: &[String]) -> Result<(), CliError> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        eprintln!("Usage: codeatlas repo refresh <repo_id> [--db <path>] [--git-diff]");
+        return Err(CliError::Usage(String::new()));
+    }
+
+    let mut repo_id: Option<String> = None;
+    let mut db_path: Option<PathBuf> = None;
+    let mut git_diff = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            "--git-diff" => {
+                git_diff = true;
+            }
+            arg if arg.starts_with('-') => {
+                return Err(CliError::Usage(format!("unknown option: {arg}")));
+            }
+            arg if repo_id.is_none() => {
+                repo_id = Some(arg.to_string());
+            }
+            other => {
+                return Err(CliError::Usage(format!("unexpected argument: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let repo_id = repo_id.ok_or_else(|| {
+        CliError::Usage("usage: codeatlas repo refresh <repo_id> [--db <path>] [--git-diff]".into())
+    })?;
+
+    let (db_path, blob_path) =
+        cli::data_root::resolve_db_and_blob_paths(db_path).map_err(CliError::Usage)?;
+
+    if !db_path.exists() {
+        return Err(CliError::Usage(format!(
+            "database not found: {}",
+            db_path.display()
+        )));
+    }
+
+    let mut db = store::MetadataStore::open(&db_path)?;
+
+    let repo = db
+        .repos()
+        .get(&repo_id)?
+        .ok_or_else(|| CliError::Usage(format!("repo '{repo_id}' not found")))?;
+
+    let source_root = PathBuf::from(&repo.source_root);
+    if !source_root.is_dir() {
+        return Err(CliError::Usage(format!(
+            "source root is not accessible: {}",
+            repo.source_root
+        )));
+    }
+
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let adapter_router = router::build_router(&source_root);
+
+    let ctx = PipelineContext {
+        repo_id: repo_id.clone(),
+        source_root,
+        router: &adapter_router,
+        policy_override: None,
+        correlation_id: None,
+        use_git_diff: git_diff,
+    };
+
+    let result = indexer::run(&ctx, &mut db, &blob_store)?;
+
+    println!("refreshed: {repo_id}");
+    println!("files_discovered: {}", result.metrics.files_discovered);
+    println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_unchanged: {}", result.metrics.files_unchanged);
+    println!("files_deleted: {}", result.metrics.files_deleted);
+    println!("symbols_extracted: {}", result.metrics.symbols_extracted);
+
+    Ok(())
+}
+
+// ── repo remove ───────────────────────────────────────────────────────
+
+fn run_remove(args: &[String]) -> Result<(), CliError> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        eprintln!("Usage: codeatlas repo remove <repo_id> [--db <path>]");
+        return Err(CliError::Usage(String::new()));
+    }
+
+    let mut repo_id: Option<String> = None;
+    let mut db_path: Option<PathBuf> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => {
+                i += 1;
+                db_path =
+                    Some(PathBuf::from(args.get(i).ok_or_else(|| {
+                        CliError::Usage("--db requires a value".into())
+                    })?));
+            }
+            arg if arg.starts_with('-') => {
+                return Err(CliError::Usage(format!("unknown option: {arg}")));
+            }
+            arg if repo_id.is_none() => {
+                repo_id = Some(arg.to_string());
+            }
+            other => {
+                return Err(CliError::Usage(format!("unexpected argument: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    let repo_id = repo_id.ok_or_else(|| {
+        CliError::Usage("usage: codeatlas repo remove <repo_id> [--db <path>]".into())
+    })?;
+
+    let (db_path, blob_path) =
+        cli::data_root::resolve_db_and_blob_paths(db_path).map_err(CliError::Usage)?;
+
+    if !db_path.exists() {
+        return Err(CliError::Usage(format!(
+            "database not found: {}",
+            db_path.display()
+        )));
+    }
+
+    let db = store::MetadataStore::open(&db_path)?;
+
+    // Verify the repo exists before collecting hashes.
+    if db.repos().get(&repo_id)?.is_none() {
+        return Err(CliError::Usage(format!("repo '{repo_id}' not found")));
+    }
+
+    // Collect file hashes before deletion so we can clean up orphaned blobs.
+    let hashes = db.files().list_hashes(&repo_id)?;
+
+    // Delete repo metadata (cascades to files and symbols via ON DELETE CASCADE).
+    db.repos().delete(&repo_id)?;
+
+    // Remove blobs that are no longer referenced by any remaining file.
+    if blob_path.is_dir() {
+        let blob_store = store::BlobStore::open(&blob_path)?;
+        let mut blobs_removed = 0u64;
+        let mut blob_errors = 0u64;
+        for hash in &hashes {
+            if !db.files().is_hash_referenced(hash)? {
+                match blob_store.delete(hash) {
+                    Ok(true) => blobs_removed += 1,
+                    Ok(false) => {} // blob already absent, nothing to do
+                    Err(e) => {
+                        eprintln!("warning: failed to delete blob {hash}: {e}");
+                        blob_errors += 1;
+                    }
+                }
+            }
+        }
+        if blob_errors > 0 {
+            println!(
+                "removed: {repo_id} ({blobs_removed} blobs cleaned up, \
+                 {blob_errors} blob deletions failed)"
+            );
+        } else if blobs_removed > 0 {
+            println!("removed: {repo_id} ({blobs_removed} orphaned blobs cleaned up)");
+        } else {
+            println!("removed: {repo_id}");
+        }
+    } else {
+        println!("removed: {repo_id}");
+    }
+
+    Ok(())
+}
+
+// ── Help ──────────────────────────────────────────────────────────────
+
+const REPO_HELP: &str = "\
+Usage: codeatlas repo <subcommand> [options]
+
+Subcommands:
+  add       Register and index a repository
+  list      List all registered repositories
+  status    Show detailed status for a repository
+  refresh   Re-index a registered repository
+  remove    De-register a repository and delete its data";
+
+fn print_repo_help() {
+    eprintln!("{REPO_HELP}");
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -90,6 +90,7 @@ fn main() {
         "file-outline" => commands::file_outline::run(&args[2..]),
         "file-tree" => commands::file_tree::run(&args[2..]),
         "repo-outline" => commands::repo_outline::run(&args[2..]),
+        "repo" => commands::repo::run(&args[2..]),
         "mcp" => commands::mcp_serve::run(&args[2..]),
         "quality-report" => commands::quality_report::run(&args[2..]),
         "help" | "--help" | "-h" => {
@@ -114,6 +115,7 @@ fn print_usage() {
     eprintln!();
     eprintln!("Commands:");
     eprintln!("  index             Index a repository");
+    eprintln!("  repo              Manage the repository catalog (add/list/status/refresh/remove)");
     eprintln!("  search-symbols    Search for symbols by name");
     eprintln!("  get-symbol        Get a symbol by ID");
     eprintln!("  file-outline      List symbols in a file");

--- a/crates/cli/src/mcp_stdio.rs
+++ b/crates/cli/src/mcp_stdio.rs
@@ -370,6 +370,8 @@ fn tool_description(name: &str) -> &'static str {
         "get_file_tree" => "List files in a repository or subtree",
         "get_repo_outline" => "Show repository structure and file summary",
         "search_text" => "Search for text patterns across indexed files",
+        "list_repos" => "List all indexed repositories with status and metadata",
+        "get_repo_status" => "Get detailed status and metadata for a specific repository",
         _ => "CodeAtlas tool",
     }
 }
@@ -531,6 +533,23 @@ fn tool_input_schema(name: &str) -> Value {
                 }
             },
             "required": ["repo_id", "pattern"]
+        }),
+
+        "list_repos" => serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        }),
+
+        "get_repo_status" => serde_json::json!({
+            "type": "object",
+            "properties": {
+                "repo_id": {
+                    "type": "string",
+                    "description": "Repository identifier"
+                }
+            },
+            "required": ["repo_id"]
         }),
 
         _ => serde_json::json!({
@@ -736,7 +755,7 @@ mod tests {
         let responses = parse_responses(&output);
         assert_eq!(responses.len(), 1);
         let tools = responses[0]["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        assert_eq!(tools.len(), 10);
 
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         assert!(names.contains(&"search_symbols"));
@@ -1139,7 +1158,7 @@ mod tests {
         let responses = parse_responses(&output);
         assert_eq!(responses.len(), 1);
         let tools = responses[0]["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 8);
+        assert_eq!(tools.len(), 10);
     }
 
     #[test]

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -703,7 +703,7 @@ fn mcp_stdio_tools_list() {
     assert_eq!(responses.len(), 1);
     let r: serde_json::Value = serde_json::from_str(&responses[0]).unwrap();
     let tools = r["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 8);
+    assert_eq!(tools.len(), 10);
 
     // Every tool must have a description and a full inputSchema with
     // properties and required fields (issue #133).
@@ -1155,7 +1155,7 @@ fn mcp_stdio_full_smoke_initialize_list_call() {
     let r2: serde_json::Value = serde_json::from_str(&responses[1]).unwrap();
     assert_eq!(r2["id"], 2);
     let tools = r2["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 8);
+    assert_eq!(tools.len(), 10);
 
     // Verify tools/call response.
     let r3: serde_json::Value = serde_json::from_str(&responses[2]).unwrap();
@@ -1343,7 +1343,7 @@ fn mcp_stdio_client_handshake_with_extra_capabilities() {
     assert!(r2["result"].is_object(), "ping should return result");
 
     let r3: serde_json::Value = serde_json::from_str(&responses[2]).unwrap();
-    assert_eq!(r3["result"]["tools"].as_array().unwrap().len(), 8);
+    assert_eq!(r3["result"]["tools"].as_array().unwrap().len(), 10);
 
     let r4: serde_json::Value = serde_json::from_str(&responses[3]).unwrap();
     assert!(r4["result"]["resources"].as_array().unwrap().is_empty());
@@ -1392,4 +1392,302 @@ fn no_args_shows_usage() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Usage:"));
+}
+
+// ---------------------------------------------------------------------------
+// Repo command tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repo_help_shows_subcommands() {
+    let output = Command::new(codeatlas_bin())
+        .args(["repo", "--help"])
+        .output()
+        .expect("repo help");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("add"));
+    assert!(stderr.contains("list"));
+    assert!(stderr.contains("status"));
+    assert!(stderr.contains("refresh"));
+    assert!(stderr.contains("remove"));
+}
+
+#[test]
+fn repo_unknown_subcommand_fails() {
+    let output = Command::new(codeatlas_bin())
+        .args(["repo", "bogus"])
+        .output()
+        .expect("repo bogus");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown repo subcommand"));
+}
+
+#[test]
+fn repo_add_list_status_refresh_remove_lifecycle() {
+    let repo_dir = setup_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("metadata.db");
+
+    // add
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "add",
+            repo_dir.path().to_str().unwrap(),
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("repo add");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "repo add failed: {stdout}");
+    assert!(stdout.contains("registered:"));
+
+    // Derive the repo_id the same way the CLI does (directory name).
+    let repo_id = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // list
+    let output = Command::new(codeatlas_bin())
+        .args(["repo", "list", "--db", db_path.to_str().unwrap()])
+        .output()
+        .expect("repo list");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "repo list failed: {stdout}");
+    assert!(
+        stdout.contains(&repo_id),
+        "list should contain repo_id '{repo_id}': {stdout}"
+    );
+
+    // status
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "status",
+            &repo_id,
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("repo status");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "repo status failed: {stdout}");
+    assert!(stdout.contains("repo_id:"));
+    assert!(stdout.contains("indexing_status:"));
+    assert!(stdout.contains("ready"));
+
+    // refresh
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "refresh",
+            &repo_id,
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("repo refresh");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "repo refresh failed: {stdout}");
+    assert!(stdout.contains("refreshed:"));
+
+    // remove
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "remove",
+            &repo_id,
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("repo remove");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "repo remove failed: {stdout}");
+    assert!(stdout.contains("removed:"));
+
+    // Verify repo is gone after remove.
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "status",
+            &repo_id,
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("repo status after remove");
+    assert!(!output.status.success());
+}
+
+#[test]
+fn repo_list_empty_store() {
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("metadata.db");
+
+    // Create an empty store by opening and closing it.
+    store::MetadataStore::open(&db_path).expect("create empty store");
+
+    let output = Command::new(codeatlas_bin())
+        .args(["repo", "list", "--db", db_path.to_str().unwrap()])
+        .output()
+        .expect("repo list empty");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success());
+    assert!(stdout.contains("No repositories registered"));
+}
+
+#[test]
+fn repo_add_collision_different_source_root() {
+    let repo_dir1 = setup_test_repo();
+    let repo_dir2 = setup_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("metadata.db");
+
+    // Add first repo with explicit repo_id.
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "add",
+            repo_dir1.path().to_str().unwrap(),
+            "--repo-id",
+            "shared-name",
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("first repo add");
+    assert!(output.status.success());
+
+    // Add second repo with same repo_id but different path — should fail.
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "add",
+            repo_dir2.path().to_str().unwrap(),
+            "--repo-id",
+            "shared-name",
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("collision repo add");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("already registered"));
+}
+
+#[test]
+fn repo_remove_nonexistent() {
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("metadata.db");
+    store::MetadataStore::open(&db_path).expect("create empty store");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "remove",
+            "nonexistent",
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("remove nonexistent");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not found"));
+}
+
+#[test]
+fn repo_remove_warns_on_blob_deletion_failure() {
+    let repo_dir = setup_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("metadata.db");
+    let blob_path = db_dir.path().join("blobs");
+
+    // Add a repo so blobs get written.
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "add",
+            repo_dir.path().to_str().unwrap(),
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("repo add");
+    assert!(output.status.success());
+
+    let repo_id = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    // Collect the file hashes stored in the DB so we can sabotage a blob.
+    let db = store::MetadataStore::open(&db_path).expect("open db");
+    let hashes = db.files().list_hashes(&repo_id).expect("list hashes");
+    drop(db);
+
+    // Sabotage one blob by replacing the file with a directory, which makes
+    // fs::remove_file fail with a "is a directory" error.
+    if let Some(hash) = hashes.first() {
+        let shard = &hash[..2];
+        let blob_file = blob_path.join(shard).join(hash);
+        if blob_file.exists() {
+            std::fs::remove_file(&blob_file).expect("remove blob file");
+            std::fs::create_dir(&blob_file).expect("replace blob with dir");
+        }
+    }
+
+    // Remove the repo — should succeed but warn about the blob failure.
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "remove",
+            &repo_id,
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("repo remove with blob error");
+    assert!(output.status.success(), "remove should still succeed");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stderr.contains("warning: failed to delete blob"),
+        "stderr should warn about blob failure: {stderr}"
+    );
+    assert!(
+        stdout.contains("failed"),
+        "stdout summary should mention failure count: {stdout}"
+    );
+}
+
+#[test]
+fn repo_status_nonexistent() {
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("metadata.db");
+    store::MetadataStore::open(&db_path).expect("create empty store");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "repo",
+            "status",
+            "nonexistent",
+            "--db",
+            db_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("status nonexistent");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not found"));
 }

--- a/crates/query-engine/src/lib.rs
+++ b/crates/query-engine/src/lib.rs
@@ -164,6 +164,10 @@ pub trait QueryService {
     fn get_repo_outline(&self, request: &RepoOutlineRequest) -> Result<RepoOutline, QueryError>;
 
     fn search_text(&self, query: &TextQuery) -> Result<QueryResult<TextMatch>, QueryError>;
+
+    fn list_repos(&self) -> Result<Vec<RepoRecord>, QueryError>;
+
+    fn get_repo_status(&self, repo_id: &str) -> Result<RepoRecord, QueryError>;
 }
 
 // ── Validation helpers ─────────────────────────────────────────────────
@@ -479,6 +483,18 @@ pub mod test_support {
                     truncated: false,
                 },
             })
+        }
+
+        fn list_repos(&self) -> Result<Vec<RepoRecord>, QueryError> {
+            Ok(vec![self.repo.clone()])
+        }
+
+        fn get_repo_status(&self, repo_id: &str) -> Result<RepoRecord, QueryError> {
+            if self.repo.repo_id == repo_id {
+                Ok(self.repo.clone())
+            } else {
+                Err(QueryError::NotFound { id: repo_id.into() })
+            }
         }
     }
 }

--- a/crates/query-engine/src/store_service.rs
+++ b/crates/query-engine/src/store_service.rs
@@ -201,6 +201,23 @@ impl QueryService for StoreQueryService<'_> {
         })
     }
 
+    fn list_repos(&self) -> Result<Vec<core_model::RepoRecord>, QueryError> {
+        let span = info_span!("query_list_repos");
+        let _guard = span.enter();
+
+        Ok(self.store.repos().list_all()?)
+    }
+
+    fn get_repo_status(&self, repo_id: &str) -> Result<core_model::RepoRecord, QueryError> {
+        let span = info_span!("query_get_repo_status", repo_id = %repo_id);
+        let _guard = span.enter();
+
+        self.store
+            .repos()
+            .get(repo_id)?
+            .ok_or_else(|| QueryError::NotFound { id: repo_id.into() })
+    }
+
     fn search_text(&self, query: &TextQuery) -> Result<QueryResult<TextMatch>, QueryError> {
         let span = info_span!(
             "query_search_text",

--- a/crates/server-mcp/src/registry.rs
+++ b/crates/server-mcp/src/registry.rs
@@ -19,6 +19,8 @@ pub const TOOL_NAMES: &[&str] = &[
     "get_file_tree",
     "get_repo_outline",
     "search_text",
+    "list_repos",
+    "get_repo_status",
 ];
 
 /// Central dispatcher that routes MCP tool calls to query-engine handlers.
@@ -59,6 +61,8 @@ impl<'a> ToolRegistry<'a> {
             "get_file_tree" => tools::get_file_tree(self.svc, params),
             "get_repo_outline" => tools::get_repo_outline(self.svc, params),
             "search_text" => tools::search_text(self.svc, params),
+            "list_repos" => tools::list_repos(self.svc, params),
+            "get_repo_status" => tools::get_repo_status(self.svc, params),
             _ => {
                 let meta = McpMeta {
                     timing_ms: start.elapsed().as_millis() as u64,

--- a/crates/server-mcp/src/tools.rs
+++ b/crates/server-mcp/src/tools.rs
@@ -65,6 +65,11 @@ pub struct RepoOutlineParams {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct RepoStatusParams {
+    pub repo_id: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct SearchTextParams {
     pub repo_id: String,
     pub pattern: String,
@@ -393,6 +398,60 @@ pub fn search_text(svc: &dyn QueryService, params: serde_json::Value) -> ToolRes
         }),
         truncated: result.meta.truncated,
         quality_stats,
+    })
+}
+
+pub fn list_repos(svc: &dyn QueryService, _params: serde_json::Value) -> ToolResult {
+    let repos = svc.list_repos()?;
+
+    let items: Vec<serde_json::Value> = repos
+        .iter()
+        .map(|r| {
+            json!({
+                "repo_id": r.repo_id,
+                "display_name": r.display_name,
+                "source_root": r.source_root,
+                "indexed_at": r.indexed_at,
+                "indexing_status": r.indexing_status.as_str(),
+                "freshness_status": r.freshness_status.as_str(),
+                "file_count": r.file_count,
+                "symbol_count": r.symbol_count,
+                "language_counts": r.language_counts,
+                "registered_at": r.registered_at,
+            })
+        })
+        .collect();
+
+    Ok(ToolOutput {
+        payload: json!({ "repos": items, "count": items.len() }),
+        truncated: false,
+        quality_stats: QualityStats::default(),
+    })
+}
+
+pub fn get_repo_status(svc: &dyn QueryService, params: serde_json::Value) -> ToolResult {
+    let p: RepoStatusParams =
+        serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
+
+    let repo = svc.get_repo_status(&p.repo_id)?;
+
+    Ok(ToolOutput {
+        payload: json!({
+            "repo_id": repo.repo_id,
+            "display_name": repo.display_name,
+            "source_root": repo.source_root,
+            "indexed_at": repo.indexed_at,
+            "index_version": repo.index_version,
+            "indexing_status": repo.indexing_status.as_str(),
+            "freshness_status": repo.freshness_status.as_str(),
+            "file_count": repo.file_count,
+            "symbol_count": repo.symbol_count,
+            "language_counts": repo.language_counts,
+            "registered_at": repo.registered_at,
+            "git_head": repo.git_head,
+        }),
+        truncated: false,
+        quality_stats: QualityStats::default(),
     })
 }
 

--- a/crates/server-mcp/tests/registry_integration.rs
+++ b/crates/server-mcp/tests/registry_integration.rs
@@ -21,11 +21,11 @@ fn call(tool: &str, params: serde_json::Value) -> McpResponse {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn registry_lists_all_eight_tools() {
+fn registry_lists_all_tools() {
     let svc = StubQueryService::new();
     let reg = ToolRegistry::new(&svc);
     let names = reg.tool_names();
-    assert_eq!(names.len(), 8);
+    assert_eq!(names.len(), 10);
     assert!(names.contains(&"search_symbols"));
     assert!(names.contains(&"get_symbol"));
     assert!(names.contains(&"get_symbols"));
@@ -34,6 +34,8 @@ fn registry_lists_all_eight_tools() {
     assert!(names.contains(&"get_file_tree"));
     assert!(names.contains(&"get_repo_outline"));
     assert!(names.contains(&"search_text"));
+    assert!(names.contains(&"list_repos"));
+    assert!(names.contains(&"get_repo_status"));
 }
 
 #[test]
@@ -445,6 +447,55 @@ fn get_file_outline_symbols_carry_source_adapter() {
 }
 
 // ---------------------------------------------------------------------------
+// Repo catalog tool tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_repos_returns_repos() {
+    let resp = call("list_repos", json!({}));
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    let repos = payload["repos"].as_array().unwrap();
+    assert_eq!(repos.len(), 1);
+    assert_eq!(repos[0]["repo_id"], "repo-1");
+    assert_eq!(repos[0]["indexing_status"], "ready");
+    assert_eq!(repos[0]["freshness_status"], "fresh");
+    assert!(repos[0]["source_root"].is_string());
+    assert_eq!(payload["count"], 1);
+}
+
+#[test]
+fn get_repo_status_returns_full_record() {
+    let resp = call("get_repo_status", json!({ "repo_id": "repo-1" }));
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["repo_id"], "repo-1");
+    assert_eq!(payload["indexing_status"], "ready");
+    assert_eq!(payload["freshness_status"], "fresh");
+    assert!(payload["indexed_at"].is_string());
+    assert!(payload["index_version"].is_string());
+    assert!(payload["file_count"].is_number());
+    assert!(payload["symbol_count"].is_number());
+    assert!(payload["language_counts"].is_object());
+}
+
+#[test]
+fn get_repo_status_not_found() {
+    let resp = call("get_repo_status", json!({ "repo_id": "nonexistent" }));
+    assert_eq!(resp.status, Status::Error);
+    let err = resp.error.unwrap();
+    assert_eq!(err.code, ErrorCode::NotFound);
+}
+
+#[test]
+fn get_repo_status_missing_params() {
+    let resp = call("get_repo_status", json!({}));
+    assert_eq!(resp.status, Status::Error);
+    let err = resp.error.unwrap();
+    assert_eq!(err.code, ErrorCode::InvalidParams);
+}
+
+// ---------------------------------------------------------------------------
 // Retryable error contract
 // ---------------------------------------------------------------------------
 
@@ -514,6 +565,18 @@ impl query_engine::QueryService for FailingQueryService {
         &self,
         _: &query_engine::TextQuery,
     ) -> Result<query_engine::QueryResult<query_engine::TextMatch>, QueryError> {
+        Err(QueryError::Store(store::StoreError::Validation(
+            "simulated store failure".into(),
+        )))
+    }
+
+    fn list_repos(&self) -> Result<Vec<core_model::RepoRecord>, QueryError> {
+        Err(QueryError::Store(store::StoreError::Validation(
+            "simulated store failure".into(),
+        )))
+    }
+
+    fn get_repo_status(&self, _: &str) -> Result<core_model::RepoRecord, QueryError> {
         Err(QueryError::Store(store::StoreError::Validation(
             "simulated store failure".into(),
         )))

--- a/crates/store/src/file_store.rs
+++ b/crates/store/src/file_store.rs
@@ -157,6 +157,27 @@ impl<'a> FileStore<'a> {
         Ok(map)
     }
 
+    /// Returns the distinct `file_hash` values for all files in a repository.
+    pub fn list_hashes(&self, repo_id: &str) -> Result<Vec<String>, StoreError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT file_hash FROM files WHERE repo_id = ?1")?;
+        let hashes = stmt
+            .query_map(params![repo_id], |row| row.get(0))?
+            .collect::<Result<Vec<String>, _>>()?;
+        Ok(hashes)
+    }
+
+    /// Returns whether any file record in the store references the given hash.
+    pub fn is_hash_referenced(&self, file_hash: &str) -> Result<bool, StoreError> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM files WHERE file_hash = ?1 LIMIT 1",
+            params![file_hash],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
     /// Returns the total number of file records for a repository.
     pub fn count(&self, repo_id: &str) -> Result<u64, StoreError> {
         let count: i64 = self.conn.query_row(

--- a/crates/store/src/repo_store.rs
+++ b/crates/store/src/repo_store.rs
@@ -8,6 +8,40 @@ use core_model::{FreshnessStatus, IndexingStatus, RepoRecord, Validate};
 
 use crate::StoreError;
 
+/// Maps a SQLite row (with the canonical repos column order) to a [`RepoRecord`].
+fn row_to_repo(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepoRecord> {
+    let language_counts_json: String = row.get(5)?;
+    let language_counts: BTreeMap<String, u64> = serde_json::from_str(&language_counts_json)
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, Box::new(e))
+        })?;
+
+    let indexing_status_str: String = row.get(10)?;
+    let indexing_status: IndexingStatus = indexing_status_str.parse().unwrap_or_default();
+    let freshness_status_str: String = row.get(11)?;
+    let freshness_status: FreshnessStatus = freshness_status_str.parse().unwrap_or_default();
+
+    Ok(RepoRecord {
+        repo_id: row.get(0)?,
+        display_name: row.get(1)?,
+        source_root: row.get(2)?,
+        indexed_at: row.get(3)?,
+        index_version: row.get(4)?,
+        language_counts,
+        file_count: row.get::<_, i64>(6)? as u64,
+        symbol_count: row.get::<_, i64>(7)? as u64,
+        git_head: row.get(8)?,
+        registered_at: row.get(9)?,
+        indexing_status,
+        freshness_status,
+    })
+}
+
+/// Canonical SELECT column list for the repos table.
+const REPO_COLUMNS: &str = "repo_id, display_name, source_root, indexed_at, index_version, \
+     language_counts, file_count, symbol_count, git_head, \
+     registered_at, indexing_status, freshness_status";
+
 /// Accessor for repository metadata operations.
 pub struct RepoStore<'a> {
     conn: &'a Connection,
@@ -56,53 +90,16 @@ impl<'a> RepoStore<'a> {
 
     /// Retrieves a repository record by ID.
     pub fn get(&self, repo_id: &str) -> Result<Option<RepoRecord>, StoreError> {
-        let mut stmt = self.conn.prepare(
-            "SELECT repo_id, display_name, source_root, indexed_at, index_version,
-                    language_counts, file_count, symbol_count, git_head,
-                    registered_at, indexing_status, freshness_status
-             FROM repos WHERE repo_id = ?1",
-        )?;
-
-        let result = stmt
-            .query_row(params![repo_id], |row| {
-                let language_counts_json: String = row.get(5)?;
-                let language_counts: BTreeMap<String, u64> =
-                    serde_json::from_str(&language_counts_json).map_err(|e| {
-                        rusqlite::Error::FromSqlConversionFailure(
-                            5,
-                            rusqlite::types::Type::Text,
-                            Box::new(e),
-                        )
-                    })?;
-
-                let indexing_status_str: String = row.get(10)?;
-                let indexing_status: IndexingStatus =
-                    indexing_status_str.parse().unwrap_or_default();
-                let freshness_status_str: String = row.get(11)?;
-                let freshness_status: FreshnessStatus =
-                    freshness_status_str.parse().unwrap_or_default();
-
-                Ok(RepoRecord {
-                    repo_id: row.get(0)?,
-                    display_name: row.get(1)?,
-                    source_root: row.get(2)?,
-                    indexed_at: row.get(3)?,
-                    index_version: row.get(4)?,
-                    language_counts,
-                    file_count: row.get::<_, i64>(6)? as u64,
-                    symbol_count: row.get::<_, i64>(7)? as u64,
-                    git_head: row.get(8)?,
-                    registered_at: row.get(9)?,
-                    indexing_status,
-                    freshness_status,
-                })
-            })
-            .optional()?;
-
+        let sql = format!("SELECT {REPO_COLUMNS} FROM repos WHERE repo_id = ?1");
+        let mut stmt = self.conn.prepare(&sql)?;
+        let result = stmt.query_row(params![repo_id], row_to_repo).optional()?;
         Ok(result)
     }
 
-    /// Deletes a repository and all associated files/symbols (cascading).
+    /// Deletes a repository and all associated files/symbols.
+    ///
+    /// Child rows in the `files` and `symbols` tables are removed
+    /// automatically via `ON DELETE CASCADE` foreign keys in the schema.
     pub fn delete(&self, repo_id: &str) -> Result<bool, StoreError> {
         let changed = self
             .conn
@@ -207,6 +204,16 @@ impl<'a> RepoStore<'a> {
             .query_map([], |row| row.get(0))?
             .collect::<Result<Vec<String>, _>>()?;
         Ok(ids)
+    }
+
+    /// Lists all repository records, sorted by `repo_id`.
+    pub fn list_all(&self) -> Result<Vec<RepoRecord>, StoreError> {
+        let sql = format!("SELECT {REPO_COLUMNS} FROM repos ORDER BY repo_id");
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map([], row_to_repo)?
+            .collect::<Result<Vec<RepoRecord>, _>>()?;
+        Ok(rows)
     }
 }
 
@@ -322,6 +329,37 @@ mod tests {
 
         let ids = store.repos().list_ids().unwrap();
         assert_eq!(ids, vec!["alpha-repo", "beta-repo"]);
+    }
+
+    #[test]
+    fn list_all_returns_empty_for_fresh_store() {
+        let store = MetadataStore::open_in_memory().unwrap();
+        let repos = store.repos().list_all().unwrap();
+        assert!(repos.is_empty());
+    }
+
+    #[test]
+    fn list_all_returns_sorted_records() {
+        let store = MetadataStore::open_in_memory().unwrap();
+        let mut r1 = test_repo();
+        r1.repo_id = "beta-repo".to_string();
+        r1.file_count = 20;
+        let mut r2 = test_repo();
+        r2.repo_id = "alpha-repo".to_string();
+        r2.file_count = 10;
+
+        store.repos().upsert(&r1).unwrap();
+        store.repos().upsert(&r2).unwrap();
+
+        let repos = store.repos().list_all().unwrap();
+        assert_eq!(repos.len(), 2);
+        assert_eq!(repos[0].repo_id, "alpha-repo");
+        assert_eq!(repos[0].file_count, 10);
+        assert_eq!(repos[1].repo_id, "beta-repo");
+        assert_eq!(repos[1].file_count, 20);
+        // Verify full record fields are populated (not just IDs).
+        assert_eq!(repos[0].display_name, "Test Repository");
+        assert_eq!(repos[1].indexing_status, IndexingStatus::Ready);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  - Issue: Closes #151
  - Scope: add repo catalog lifecycle commands and repo-status query surfaces for the persistent local service baseline

  ## Changes

  - Added codeatlas repo command family with add, list, status, refresh, and remove subcommands.
  - Added shared repo catalog read APIs through QueryService with list_repos and get_repo_status.
  - Exposed repo catalog tools through MCP, including tool registry wiring, descriptions, and input schemas.
  - Added RepoStore::list_all() and refactored repo row decoding into a shared helper.
  - Added file-hash helpers to support blob cleanup on repo remove.
  - Updated repo remove to clean up orphaned blobs after cascade deletion, warn on per-hash deletion failures, and report cleanup/failure counts.
  - Added MCP integration tests for the new repo catalog tools.
  - Added CLI integration coverage for repo help, invalid subcommands, empty catalog behavior, collision handling, missing-repo errors, and full add/list/status/refresh/remove lifecycle.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: a user can add multiple repos to one CodeAtlas instance
  - [x] Criterion 2: a user can list all indexed or known repos
  - [x] Criterion 3: a user can refresh or remove a repo without affecting others
  - [x] Criterion 4: lifecycle operations surface registration state, index state, and freshness clearly
  - [x] Criterion 5: repo discovery is clear enough that AI tooling or wrappers can choose the correct repo_id

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional tests run:

  - cargo test -p cli repo_add_list_status_refresh_remove_lifecycle -- --nocapture
  - cargo test -p cli repo_remove_nonexistent -- --nocapture
  - cargo test -p cli repo_status_nonexistent -- --nocapture
  - cargo test -p server-mcp list_repos_returns_repos -- --nocapture
  - cargo test -p server-mcp get_repo_status_returns_full_record -- --nocapture
  - cargo test -p store list_all_returns_sorted_records -- --nocapture

  ## Risk and Mitigation

  - Risk: repo remove now performs blob cleanup after metadata deletion, which adds filesystem-side failure modes beyond the DB cascade.
  - Mitigation: orphan cleanup is reference-checked per hash, deletion failures are surfaced as warnings on stderr, and the summary reports cleanup and failure counts.

  ## Security/Observability Impact

  - Security: preserves repo-scoped deletion semantics and only removes blobs after verifying they are no longer referenced anywhere in the store.
  - Logs/Metrics/Tracing: added repo-catalog query spans via query_list_repos and query_get_repo_status; blob cleanup failures are emitted as explicit stderr warnings during repo remove.
