### PR TITLE
Adapt AI client integration for the persistent service model

### DIFF
--- a/crates/cli/src/commands/mcp_serve.rs
+++ b/crates/cli/src/commands/mcp_serve.rs
@@ -16,12 +16,13 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     let subcommand = args.first().map(|s| s.as_str());
     match subcommand {
         Some("serve") => run_serve(&args[1..]),
+        Some("bridge") => run_bridge(&args[1..]),
         Some("--help" | "-h") => {
             print_mcp_help();
             Ok(())
         }
         Some(other) => Err(CliError::Usage(format!(
-            "unknown mcp subcommand: '{other}'\n\nUsage: codeatlas mcp <subcommand>\n\nSubcommands:\n  serve    Start the MCP tool server (stdio)"
+            "unknown mcp subcommand: '{other}'\n\nUsage: codeatlas mcp <subcommand>\n\nSubcommands:\n  serve     Start the MCP tool server (stdio, direct store)\n  bridge    Start the MCP bridge to the persistent service"
         ))),
         None => {
             print_mcp_help();
@@ -109,6 +110,77 @@ fn run_serve(args: &[String]) -> Result<(), CliError> {
         .map_err(|e| CliError::Usage(format!("mcp server error: {e}")))
 }
 
+/// `codeatlas mcp bridge [--service-url <addr>]`
+///
+/// Validates that the service is reachable, then runs the MCP bridge
+/// stdio loop. All diagnostics go to stderr; stdout is reserved for
+/// MCP protocol messages.
+fn run_bridge(args: &[String]) -> Result<(), CliError> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        print_bridge_help();
+        return Ok(());
+    }
+
+    let opts = parse_bridge_args(args)?;
+
+    eprintln!(
+        "codeatlas mcp bridge: connecting to service at {}",
+        opts.service_addr
+    );
+
+    crate::mcp_bridge::install_signal_handlers();
+
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    crate::mcp_bridge::serve_bridge(&opts.service_addr, stdin.lock(), stdout.lock())
+        .map_err(|e| CliError::Io(std::io::Error::other(format!("mcp bridge: {e}"))))
+}
+
+#[derive(Debug)]
+struct BridgeOpts {
+    service_addr: String,
+}
+
+fn parse_bridge_args(args: &[String]) -> Result<BridgeOpts, CliError> {
+    let mut service_addr: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--service-url" => {
+                i += 1;
+                service_addr = Some(
+                    args.get(i)
+                        .ok_or_else(|| CliError::Usage("--service-url requires a value".into()))?
+                        .clone(),
+                );
+            }
+            other => {
+                return Err(CliError::Usage(format!("unknown option: {other}")));
+            }
+        }
+        i += 1;
+    }
+
+    // Default to the canonical service address.
+    let service_addr = match service_addr {
+        Some(addr) => addr,
+        None => {
+            let port = std::env::var("CODEATLAS_PORT")
+                .ok()
+                .and_then(|v| v.parse::<u16>().ok())
+                .unwrap_or(service::DEFAULT_PORT);
+            let host = std::env::var("CODEATLAS_HOST")
+                .ok()
+                .and_then(|v| v.parse::<std::net::IpAddr>().ok())
+                .unwrap_or(service::DEFAULT_HOST);
+            format!("{host}:{port}")
+        }
+    };
+
+    Ok(BridgeOpts { service_addr })
+}
+
 // ── Argument parsing ───────────────────────────────────────────────────
 
 #[derive(Debug)]
@@ -150,9 +222,37 @@ fn print_mcp_help() {
     eprintln!("Usage: codeatlas mcp <subcommand>");
     eprintln!();
     eprintln!("Subcommands:");
-    eprintln!("  serve    Start the MCP tool server (stdio)");
+    eprintln!("  serve     Start the MCP tool server (stdio, direct store)");
+    eprintln!("  bridge    Start the MCP bridge to the persistent service");
     eprintln!();
-    eprintln!("Run 'codeatlas mcp serve --help' for serve options.");
+    eprintln!("Run 'codeatlas mcp <subcommand> --help' for options.");
+}
+
+fn print_bridge_help() {
+    eprintln!("Usage: codeatlas mcp bridge [--service-url <host:port>]");
+    eprintln!();
+    eprintln!("Start an MCP bridge that proxies tool calls to the persistent");
+    eprintln!("CodeAtlas HTTP service. AI clients launch this as their MCP command");
+    eprintln!("instead of 'codeatlas mcp serve'.");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!("  --service-url <host:port>  Service address to connect to");
+    eprintln!(
+        "                             Default: 127.0.0.1:52337 (or CODEATLAS_HOST/CODEATLAS_PORT)"
+    );
+    eprintln!();
+    eprintln!("Prerequisites:");
+    eprintln!("  The CodeAtlas service must be running ('codeatlas serve').");
+    eprintln!();
+    eprintln!("Example client configuration (Claude Desktop, Cursor):");
+    eprintln!("  {{");
+    eprintln!("    \"mcpServers\": {{");
+    eprintln!("      \"codeatlas\": {{");
+    eprintln!("        \"command\": \"codeatlas\",");
+    eprintln!("        \"args\": [\"mcp\", \"bridge\"]");
+    eprintln!("      }}");
+    eprintln!("    }}");
+    eprintln!("  }}");
 }
 
 fn print_serve_help() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::EnvFilter;
 mod commands;
 mod error;
 pub mod logging;
+pub mod mcp_bridge;
 pub mod mcp_stdio;
 mod router;
 

--- a/crates/cli/src/mcp_bridge.rs
+++ b/crates/cli/src/mcp_bridge.rs
@@ -1,0 +1,672 @@
+//! MCP-to-HTTP bridge — translates stdio MCP tool calls into HTTP
+//! requests to the running CodeAtlas service.
+//!
+//! This module implements the same MCP protocol subset as `mcp_stdio`
+//! but instead of dispatching tools through a local `ToolRegistry`, it
+//! forwards `tools/call` requests to the persistent HTTP service via
+//! `POST /tools/call`.
+//!
+//! All protocol output goes to stdout. All diagnostics go to stderr.
+//!
+//! ## Technical debt
+//!
+//! The JSON-RPC types, message framing, and MCP protocol handling are
+//! duplicated from `mcp_stdio.rs`. A future cleanup should extract the
+//! shared MCP protocol machinery (types, framing, initialize/ping/shim
+//! handlers) into a common module that both the direct server and the
+//! bridge can use.
+
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+use std::net::TcpStream;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use server_mcp::registry::TOOL_NAMES;
+
+use crate::mcp_stdio;
+
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Install signal handlers for the bridge process.
+#[cfg(unix)]
+pub fn install_signal_handlers() {
+    unsafe {
+        libc::signal(
+            libc::SIGTERM,
+            signal_handler as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGINT,
+            signal_handler as *const () as libc::sighandler_t,
+        );
+    }
+}
+
+/// No-op on non-Unix platforms. Signal-based shutdown relies on stdin
+/// EOF from the client process instead.
+#[cfg(not(unix))]
+pub fn install_signal_handlers() {}
+
+#[cfg(unix)]
+extern "C" fn signal_handler(_sig: libc::c_int) {
+    SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
+}
+
+// ── JSON-RPC types ─────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    #[serde(default)]
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: &'static str,
+    id: Value,
+    result: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcErrorObj {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcErrorResponse {
+    jsonrpc: &'static str,
+    id: Value,
+    error: JsonRpcErrorObj,
+}
+
+const PARSE_ERROR: i32 = -32700;
+const INVALID_REQUEST: i32 = -32600;
+const METHOD_NOT_FOUND: i32 = -32601;
+const INVALID_PARAMS: i32 = -32602;
+const INTERNAL_ERROR: i32 = -32603;
+
+// ── Newline-delimited framing ──────────────────────────────────────────
+
+fn read_message(reader: &mut impl BufRead) -> Result<Option<String>, String> {
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader
+            .read_line(&mut line)
+            .map_err(|e| format!("read error: {e}"))?;
+
+        if bytes_read == 0 {
+            return Ok(None);
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if trimmed.starts_with("Content-Length:") {
+            return Err(
+                "received Content-Length header; this server uses newline-delimited \
+                 JSON per MCP spec 2025-11-25, not Content-Length framing"
+                    .into(),
+            );
+        }
+
+        return Ok(Some(trimmed.to_string()));
+    }
+}
+
+fn write_message(writer: &mut impl Write, json: &str) -> std::io::Result<()> {
+    writeln!(writer, "{json}")?;
+    writer.flush()
+}
+
+fn write_result(writer: &mut impl Write, id: Value, result: Value) -> Result<(), String> {
+    let resp = JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result,
+    };
+    let json = serde_json::to_string(&resp).map_err(|e| format!("serialization error: {e}"))?;
+    write_message(writer, &json).map_err(|e| format!("write error: {e}"))
+}
+
+fn write_error(
+    writer: &mut impl Write,
+    id: Value,
+    code: i32,
+    message: String,
+) -> Result<(), String> {
+    let resp = JsonRpcErrorResponse {
+        jsonrpc: "2.0",
+        id,
+        error: JsonRpcErrorObj {
+            code,
+            message,
+            data: None,
+        },
+    };
+    let json = serde_json::to_string(&resp).map_err(|e| format!("serialization error: {e}"))?;
+    write_message(writer, &json).map_err(|e| format!("write error: {e}"))
+}
+
+// ── HTTP client ────────────────────────────────────────────────────────
+
+/// Minimal HTTP client for communicating with the local service.
+struct ServiceClient {
+    addr: String,
+}
+
+impl ServiceClient {
+    fn new(addr: String) -> Self {
+        Self { addr }
+    }
+
+    /// POST JSON to `path` and return `(status_code, body)`.
+    fn post(&self, path: &str, body: &str) -> Result<(u16, String), String> {
+        let mut stream = TcpStream::connect(&self.addr)
+            .map_err(|e| format!("cannot connect to service at {}: {e}", self.addr))?;
+        stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+
+        let request = format!(
+            "POST {path} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            self.addr,
+            body.len()
+        );
+        stream
+            .write_all(request.as_bytes())
+            .map_err(|e| format!("write error: {e}"))?;
+
+        let mut response = String::new();
+        stream
+            .read_to_string(&mut response)
+            .map_err(|e| format!("read error: {e}"))?;
+
+        // Parse status code from "HTTP/1.1 200 OK\r\n..."
+        let status_code = response
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|s| s.parse::<u16>().ok())
+            .unwrap_or(0);
+
+        // Extract body after the blank line.
+        let body = response
+            .split("\r\n\r\n")
+            .nth(1)
+            .map(|s| s.to_string())
+            .ok_or_else(|| "malformed HTTP response".to_string())?;
+
+        Ok((status_code, body))
+    }
+
+    /// Check if the service is reachable.
+    fn health_check(&self) -> Result<(), String> {
+        let mut stream = TcpStream::connect(&self.addr)
+            .map_err(|e| format!("cannot connect to service at {}: {e}", self.addr))?;
+        stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+
+        let request = format!(
+            "GET /health HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+            self.addr
+        );
+        stream
+            .write_all(request.as_bytes())
+            .map_err(|e| format!("write error: {e}"))?;
+
+        let mut response = String::new();
+        stream
+            .read_to_string(&mut response)
+            .map_err(|e| format!("read error: {e}"))?;
+
+        if response.contains("200 OK") {
+            Ok(())
+        } else {
+            Err(format!("service health check failed: {response}"))
+        }
+    }
+}
+
+// ── Bridge server loop ─────────────────────────────────────────────────
+
+/// Run the MCP bridge, reading from `input` and writing to `output`.
+///
+/// Proxies `tools/call` to the HTTP service. Handles `initialize`,
+/// `tools/list`, `ping`, and compatibility shims locally.
+///
+/// `service_addr` is the `host:port` of the running CodeAtlas service.
+///
+/// Validates that the service is reachable before entering the MCP loop.
+/// Returns an error if the service cannot be reached.
+pub fn serve_bridge(
+    service_addr: &str,
+    input: impl Read,
+    output: impl Write,
+) -> Result<(), String> {
+    let client = ServiceClient::new(service_addr.to_string());
+
+    // Validate service connectivity before entering the protocol loop.
+    client.health_check().map_err(|e| {
+        format!(
+            "cannot reach CodeAtlas service at {service_addr}: {e}\n\n\
+             Hint: start the service with 'codeatlas serve' first."
+        )
+    })?;
+
+    eprintln!("codeatlas mcp bridge: connected to service at {service_addr}");
+    serve(&client, input, output)
+}
+
+fn serve(client: &ServiceClient, input: impl Read, output: impl Write) -> Result<(), String> {
+    let mut reader = BufReader::new(input);
+    let mut writer = BufWriter::new(output);
+
+    loop {
+        if SHUTDOWN_REQUESTED.load(Ordering::SeqCst) {
+            eprintln!("codeatlas mcp bridge: received signal, shutting down");
+            return Ok(());
+        }
+
+        let message = match read_message(&mut reader) {
+            Ok(Some(msg)) => msg,
+            Ok(None) => {
+                eprintln!("codeatlas mcp bridge: stdin closed, shutting down");
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!("codeatlas mcp bridge: framing error: {e}");
+                write_error(&mut writer, Value::Null, PARSE_ERROR, e)?;
+                continue;
+            }
+        };
+
+        let request: JsonRpcRequest = match serde_json::from_str(&message) {
+            Ok(req) => req,
+            Err(e) => {
+                write_error(
+                    &mut writer,
+                    Value::Null,
+                    PARSE_ERROR,
+                    format!("invalid JSON: {e}"),
+                )?;
+                continue;
+            }
+        };
+
+        if request.jsonrpc != "2.0" {
+            write_error(
+                &mut writer,
+                request.id.unwrap_or(Value::Null),
+                INVALID_REQUEST,
+                "jsonrpc must be \"2.0\"".into(),
+            )?;
+            continue;
+        }
+
+        let is_notification = request.id.is_none();
+
+        match request.method.as_str() {
+            "initialize" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, handle_initialize())?;
+            }
+            "notifications/initialized" => {
+                eprintln!("codeatlas mcp bridge: client initialized");
+            }
+            "tools/list" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, handle_tools_list())?;
+            }
+            "tools/call" => {
+                let id = request.id.unwrap_or(Value::Null);
+                match handle_tools_call(client, request.params) {
+                    Ok(result) => write_result(&mut writer, id, result)?,
+                    Err(err) => write_error(&mut writer, id, err.code, err.message)?,
+                }
+            }
+            "ping" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, serde_json::json!({}))?;
+            }
+            // COMPAT: Same shims as the direct MCP server.
+            "resources/list" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, serde_json::json!({ "resources": [] }))?;
+            }
+            "prompts/list" => {
+                let id = request.id.unwrap_or(Value::Null);
+                write_result(&mut writer, id, serde_json::json!({ "prompts": [] }))?;
+            }
+            "notifications/cancelled" => {}
+            _ => {
+                if !is_notification {
+                    let id = request.id.unwrap_or(Value::Null);
+                    write_error(
+                        &mut writer,
+                        id,
+                        METHOD_NOT_FOUND,
+                        format!("method not found: {}", request.method),
+                    )?;
+                }
+            }
+        }
+    }
+}
+
+// ── MCP method handlers ───────────────────────────────────────────────
+
+fn handle_initialize() -> Value {
+    serde_json::json!({
+        "protocolVersion": "2025-11-25",
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": "codeatlas",
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    })
+}
+
+fn handle_tools_list() -> Value {
+    let tools: Vec<Value> = TOOL_NAMES
+        .iter()
+        .map(|name| {
+            serde_json::json!({
+                "name": name,
+                "description": mcp_stdio::tool_description(name),
+                "inputSchema": mcp_stdio::tool_input_schema(name)
+            })
+        })
+        .collect();
+
+    serde_json::json!({ "tools": tools })
+}
+
+fn handle_tools_call(
+    client: &ServiceClient,
+    params: Option<Value>,
+) -> Result<Value, JsonRpcErrorObj> {
+    let params = params.ok_or_else(|| JsonRpcErrorObj {
+        code: INVALID_PARAMS,
+        message: "missing params".into(),
+        data: None,
+    })?;
+
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| JsonRpcErrorObj {
+            code: INVALID_PARAMS,
+            message: "missing or invalid 'name' in params".into(),
+            data: None,
+        })?;
+
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
+
+    // Forward to the HTTP service.
+    let request_body = serde_json::json!({
+        "name": name,
+        "arguments": arguments,
+    });
+
+    let body_str = serde_json::to_string(&request_body).map_err(|e| JsonRpcErrorObj {
+        code: INTERNAL_ERROR,
+        message: format!("failed to serialize request: {e}"),
+        data: None,
+    })?;
+
+    let (status_code, response_body) =
+        client
+            .post("/tools/call", &body_str)
+            .map_err(|e| JsonRpcErrorObj {
+                code: INTERNAL_ERROR,
+                message: format!("service request failed: {e}"),
+                data: None,
+            })?;
+
+    // The service returns different shapes depending on HTTP status:
+    // - 200: full MCP response envelope ({"status":..,"payload":..,"_meta":..})
+    // - 500: bare infrastructure error ({"error":"..."})
+    //
+    // On 500 we surface the error as a JSON-RPC INTERNAL_ERROR so clients
+    // get the same error shape as if the direct MCP server had an internal
+    // failure, rather than wrapping a bare {"error":"..."} as tool content.
+    if status_code >= 500 {
+        let error_msg = serde_json::from_str::<Value>(&response_body)
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+            .unwrap_or_else(|| format!("service returned HTTP {status_code}"));
+
+        return Err(JsonRpcErrorObj {
+            code: INTERNAL_ERROR,
+            message: format!("service error: {error_msg}"),
+            data: None,
+        });
+    }
+
+    // 200 path: the body is the full MCP response envelope.
+    let mcp_response: Value =
+        serde_json::from_str(&response_body).map_err(|e| JsonRpcErrorObj {
+            code: INTERNAL_ERROR,
+            message: format!("failed to parse service response: {e}"),
+            data: None,
+        })?;
+
+    let is_error = mcp_response.get("error").is_some_and(|e| !e.is_null());
+
+    let text = serde_json::to_string(&mcp_response).map_err(|e| JsonRpcErrorObj {
+        code: INTERNAL_ERROR,
+        message: format!("failed to serialize tool response: {e}"),
+        data: None,
+    })?;
+
+    Ok(serde_json::json!({
+        "content": [{
+            "type": "text",
+            "text": text
+        }],
+        "isError": is_error
+    }))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn messages(lines: &[&str]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for line in lines {
+            buf.extend_from_slice(line.as_bytes());
+            buf.push(b'\n');
+        }
+        buf
+    }
+
+    fn parse_responses(output: &[u8]) -> Vec<Value> {
+        String::from_utf8_lossy(output)
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("parse response"))
+            .collect()
+    }
+
+    #[test]
+    fn bridge_initialize_handshake() {
+        // Use a dummy client — initialize doesn't hit the service.
+        let client = ServiceClient::new("127.0.0.1:0".into());
+
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#]);
+
+        let mut output = Vec::new();
+        serve(&client, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0]["result"]["protocolVersion"], "2025-11-25");
+        assert_eq!(responses[0]["result"]["serverInfo"]["name"], "codeatlas");
+    }
+
+    #[test]
+    fn bridge_tools_list() {
+        let client = ServiceClient::new("127.0.0.1:0".into());
+
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#]);
+
+        let mut output = Vec::new();
+        serve(&client, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        let tools = responses[0]["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), TOOL_NAMES.len());
+
+        // Verify all registered tools appear.
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        for tool_name in TOOL_NAMES {
+            assert!(names.contains(tool_name), "missing tool: {tool_name}");
+        }
+    }
+
+    #[test]
+    fn bridge_ping() {
+        let client = ServiceClient::new("127.0.0.1:0".into());
+
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#]);
+
+        let mut output = Vec::new();
+        serve(&client, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0]["result"].is_object());
+    }
+
+    #[test]
+    fn bridge_tools_call_service_unreachable() {
+        // Point at a port nothing is listening on.
+        let client = ServiceClient::new("127.0.0.1:1".into());
+
+        let input = messages(&[
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_repos","arguments":{}}}"#,
+        ]);
+
+        let mut output = Vec::new();
+        serve(&client, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        // Should get a JSON-RPC error (not crash).
+        assert!(responses[0]["error"].is_object());
+        assert!(responses[0]["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("service request failed"),);
+    }
+
+    #[test]
+    fn bridge_compat_shims() {
+        let client = ServiceClient::new("127.0.0.1:0".into());
+
+        let input = messages(&[
+            r#"{"jsonrpc":"2.0","id":1,"method":"resources/list"}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"prompts/list"}"#,
+        ]);
+
+        let mut output = Vec::new();
+        serve(&client, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 2);
+        assert!(responses[0]["result"]["resources"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+        assert!(responses[1]["result"]["prompts"]
+            .as_array()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn bridge_unknown_method() {
+        let client = ServiceClient::new("127.0.0.1:0".into());
+
+        let input = messages(&[r#"{"jsonrpc":"2.0","id":1,"method":"unknown/method"}"#]);
+
+        let mut output = Vec::new();
+        serve(&client, &input[..], &mut output).unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+        assert!(responses[0]["error"].is_object());
+        assert_eq!(responses[0]["error"]["code"], METHOD_NOT_FOUND);
+    }
+
+    #[test]
+    fn bridge_tools_call_service_500_returns_jsonrpc_error() {
+        // Start a mock HTTP server that always returns 500.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let mock_addr = listener.local_addr().unwrap().to_string();
+
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                // Read the request (consume it).
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+
+                // Respond with HTTP 500 and a bare error JSON body.
+                let body = r#"{"error":"database lock poisoned"}"#;
+                let response = format!(
+                    "HTTP/1.1 500 Internal Server Error\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        let client = ServiceClient::new(mock_addr);
+        let input = messages(&[
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_repos","arguments":{}}}"#,
+        ]);
+
+        let mut output = Vec::new();
+        serve(&client, &input[..], &mut output).unwrap();
+
+        handle.join().unwrap();
+
+        let responses = parse_responses(&output);
+        assert_eq!(responses.len(), 1);
+
+        // Should be a JSON-RPC error, not a tools/call success wrapping
+        // the bare {"error":"..."} as content.
+        assert!(
+            responses[0]["error"].is_object(),
+            "500 should produce a JSON-RPC error, not a result: {:?}",
+            responses[0]
+        );
+        assert_eq!(responses[0]["error"]["code"], INTERNAL_ERROR);
+        let msg = responses[0]["error"]["message"].as_str().unwrap();
+        assert!(
+            msg.contains("database lock poisoned"),
+            "error should surface the service error message: {msg}"
+        );
+        // Must NOT have a "result" with "content" — that would mean the
+        // bare error was incorrectly wrapped as tool output.
+        assert!(responses[0]["result"].is_null());
+    }
+}

--- a/crates/cli/src/mcp_stdio.rs
+++ b/crates/cli/src/mcp_stdio.rs
@@ -360,7 +360,7 @@ fn handle_tools_call(
     }))
 }
 
-fn tool_description(name: &str) -> &'static str {
+pub(crate) fn tool_description(name: &str) -> &'static str {
     match name {
         "search_symbols" => "Search for symbols by name with optional filters",
         "get_symbol" => "Get a symbol by its unique ID",
@@ -382,7 +382,7 @@ fn tool_description(name: &str) -> &'static str {
 /// `crates/server-mcp/src/tools.rs`. Required fields mirror non-`Option`
 /// struct fields; optional fields and those with `#[serde(default)]` are
 /// listed only in `properties`.
-fn tool_input_schema(name: &str) -> Value {
+pub(crate) fn tool_input_schema(name: &str) -> Value {
     match name {
         "search_symbols" => serde_json::json!({
             "type": "object",

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -1817,3 +1817,155 @@ fn serve_status_endpoint_returns_json() {
     assert!(json["uptime_secs"].is_number());
     assert!(json["repo_count"].is_number());
 }
+
+// ---------------------------------------------------------------------------
+// MCP bridge tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mcp_bridge_help_shows_usage() {
+    let output = Command::new(codeatlas_bin())
+        .args(["mcp", "bridge", "--help"])
+        .output()
+        .expect("bridge help");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--service-url"));
+    assert!(stderr.contains("codeatlas mcp bridge"));
+}
+
+/// Helper: send MCP messages to a bridge subprocess and collect responses.
+fn run_bridge_with_messages(service_addr: &str, mcp_messages: &[&str]) -> Vec<serde_json::Value> {
+    let mut input = String::new();
+    for msg in mcp_messages {
+        input.push_str(msg);
+        input.push('\n');
+    }
+
+    let output = Command::new(codeatlas_bin())
+        .args(["mcp", "bridge", "--service-url", service_addr])
+        .env("CODEATLAS_LOG_FORMAT", "compact")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(input.as_bytes()).ok();
+                // Close stdin to signal EOF so the bridge exits.
+                drop(stdin);
+            }
+            child.wait_with_output()
+        })
+        .expect("run bridge");
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("parse bridge response"))
+        .collect()
+}
+
+#[test]
+fn mcp_bridge_end_to_end_with_service() {
+    let db_dir = TempDir::new().expect("temp dir");
+    let (mut service_child, service_addr) = start_serve(&db_dir);
+
+    let responses = run_bridge_with_messages(
+        &service_addr,
+        &[
+            // initialize
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#,
+            // tools/list
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+            // tools/call list_repos (proxied to service)
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_repos","arguments":{}}}"#,
+        ],
+    );
+
+    let _ = service_child.kill();
+    let _ = service_child.wait();
+
+    assert_eq!(responses.len(), 3, "expected 3 responses: {responses:?}");
+
+    // Initialize response.
+    assert_eq!(responses[0]["result"]["protocolVersion"], "2025-11-25");
+    assert_eq!(responses[0]["result"]["serverInfo"]["name"], "codeatlas");
+
+    // Tools list.
+    let tools = responses[1]["result"]["tools"].as_array().unwrap();
+    assert!(tools.len() >= 10, "should list all tools");
+
+    // Tools call (proxied through service).
+    let content = responses[2]["result"]["content"]
+        .as_array()
+        .expect("content array");
+    assert_eq!(content[0]["type"], "text");
+
+    // Parse the inner MCP response envelope.
+    let mcp_text = content[0]["text"].as_str().unwrap();
+    let mcp_resp: serde_json::Value = serde_json::from_str(mcp_text).expect("parse MCP envelope");
+    assert_eq!(mcp_resp["status"], "success");
+}
+
+#[test]
+fn mcp_bridge_service_unreachable_fails_at_startup() {
+    // Point bridge at a port nothing is listening on.
+    let output = Command::new(codeatlas_bin())
+        .args(["mcp", "bridge", "--service-url", "127.0.0.1:1"])
+        .env("CODEATLAS_LOG_FORMAT", "compact")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run bridge");
+
+    assert!(
+        !output.status.success(),
+        "bridge should fail when service is unreachable"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot reach CodeAtlas service"),
+        "stderr should explain the failure: {stderr}"
+    );
+}
+
+#[test]
+fn mcp_bridge_stdout_is_protocol_only() {
+    let db_dir = TempDir::new().expect("temp dir");
+    let (mut service_child, service_addr) = start_serve(&db_dir);
+
+    let mut bridge_child = Command::new(codeatlas_bin())
+        .args(["mcp", "bridge", "--service-url", &service_addr])
+        .env("CODEATLAS_LOG_FORMAT", "compact")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bridge");
+
+    // Send initialize then close stdin.
+    if let Some(mut stdin) = bridge_child.stdin.take() {
+        stdin
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n")
+            .ok();
+        drop(stdin);
+    }
+
+    let output = bridge_child.wait_with_output().expect("bridge output");
+
+    let _ = service_child.kill();
+    let _ = service_child.wait();
+
+    // Stdout should contain only valid JSON-RPC lines.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        assert!(
+            serde_json::from_str::<serde_json::Value>(line).is_ok(),
+            "stdout line is not valid JSON: {line}"
+        );
+    }
+}

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -9,7 +9,7 @@
 mod routes;
 mod state;
 
-pub use state::ServiceConfig;
+pub use state::{ServiceConfig, DEFAULT_HOST, DEFAULT_PORT};
 
 use std::net::SocketAddr;
 


### PR DESCRIPTION
## Summary

  - Issue: Closes #153
  - Scope: add an MCP bridge that proxies stdio MCP requests to the persistent local HTTP service while preserving the existing MCP client setup model

  ## Changes

  - Added codeatlas mcp bridge as a new MCP entrypoint for the persistent service model.
  - Implemented a new mcp_bridge module that handles newline-delimited stdio JSON-RPC and MCP request routing for the bridge process.
  - Preserved the existing MCP compatibility shims in the bridge, including ping, resources/list, prompts/list, and notification handling.
  - Reused the existing MCP tool catalog metadata by exposing tool descriptions and JSON Schemas from mcp_stdio.
  - Added startup connectivity validation so the bridge fails fast with a clear error when the service is not reachable.
  - Proxied tools/call requests to the HTTP service via POST /tools/call.
  - Preserved the direct MCP error contract by converting service-side infrastructure 5xx responses into JSON-RPC internal errors instead of wrapping raw service error JSON as tool output.
  - Updated codeatlas mcp help text to distinguish direct-store serve from service-backed bridge.
  - Re-exported the canonical service host/port defaults from the service crate for bridge-side default discovery.
  - Added bridge unit tests for handshake, tools list, compatibility shims, unknown methods, unreachable service behavior, and service 500 handling.
  - Added CLI integration tests for bridge help, unreachable-service startup failure, stdout protocol discipline, and end-to-end bridge/service flow.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: AI clients can use the persistent service without one CodeAtlas runtime per repo
  - [x] Criterion 2: the integration path is documented clearly enough for real setup
  - [x] Criterion 3: the intended user-facing MCP setup flow is explicit, not implicit
  - [x] Criterion 4: repo targeting and discovery are understandable in the client workflow
  - [x] Criterion 5: the implementation preserves clean separation between transport and query semantics
  - [x] Criterion 6: bridge behavior is explicit rather than hidden in ambiguous auto-detection

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional tests run:

  - cargo test -p cli mcp_bridge_service_unreachable_fails_at_startup -- --nocapture
  - cargo test -p cli bridge_tools_call_service_unreachable -- --nocapture

  Notes:

  - The new subprocess end-to-end bridge test is in place, but I could not use it as strong evidence in the current sandbox because localhost bind calls are blocked here.

  ## Risk and Mitigation

  - Risk: the bridge introduces a second MCP-serving path that could drift from the direct stdio MCP server in protocol behavior or error semantics.
  - Mitigation: the bridge reuses the same tool registry names, descriptions, and JSON Schemas, mirrors the same compatibility shims, and explicitly converts service 5xx failures into JSON-RPC errors so clients see the
    expected MCP-side contract.

  ## Security/Observability Impact

  - Security: the bridge does not expose a new network surface; it remains a local stdio process that talks only to the localhost CodeAtlas service.
  - Logs/Metrics/Tracing: bridge startup and shutdown diagnostics go to stderr only, preserving stdout for protocol traffic; startup failures surface explicit “cannot reach CodeAtlas service” messaging for operator
    troubleshooting.