### PR TITLE
Update docs and canonical usage guidance for the persistent local model

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ re-reading the whole codebase every time.
 - [How To Use It With AI Today](#how-to-use-it-with-ai-today)
 - [MCP Integration Shape](#mcp-integration-shape)
 - [AI Usage Examples](#ai-usage-examples)
+- [Service Architecture](#service-architecture)
 - [Current Status](#current-status)
 - [Design Principles](#design-principles)
 - [Roadmap](#roadmap)
@@ -35,27 +36,49 @@ CodeAtlas gives you:
 
 Today, this repository provides:
 
-- a local CLI you can run now
-- a built-in MCP server: `codeatlas mcp serve --db <path>`
-- a reusable MCP library surface (`server-mcp`)
+- a persistent local service: `codeatlas serve`
+- a multi-repo catalog with lifecycle operations: `codeatlas repo add/list/status/refresh/remove`
+- an MCP bridge for AI clients: `codeatlas mcp bridge`
+- a direct MCP server for simple single-repo use: `codeatlas mcp serve`
+- a local CLI for indexing and querying
 - a local-first architecture with hosted-ready boundaries
 
 Today, this repository does **not** provide:
 
 - a standalone hosted deployment
-- HTTP/gRPC product APIs
+- auth, tenancy, or multi-user controls
+- Docker packaging (deferred follow-up)
 
-You can use CodeAtlas immediately through the CLI or by pointing any stdio
-MCP-capable AI client at `codeatlas mcp serve --db <path>`.
+The canonical local usage model is one persistent service managing multiple
+repositories. AI clients connect through the MCP bridge.
 
 ## What You Can Do With It
 
-- `index`: build or update a local index for a repository
+### Service and repo management
+
+- `serve`: start the persistent local HTTP service
+- `repo add <path>`: register and index a repository
+- `repo list`: list all registered repositories with status
+- `repo status <repo_id>`: show detailed status for a repository
+- `repo refresh <repo_id>`: re-index a registered repository
+- `repo remove <repo_id>`: de-register a repository and clean up data
+
+### Querying
+
 - `search-symbols`: find functions, classes, methods, types, and constants
 - `get-symbol`: fetch an exact symbol by stable ID (CLI uses hyphens; MCP uses underscores, e.g. `get_symbol` / `get_symbols`)
 - `file-outline`: inspect symbols in a file
 - `file-tree`: inspect indexed files in a repo
 - `repo-outline`: inspect repository structure and counts
+
+### AI integration
+
+- `mcp bridge`: start the MCP bridge to the persistent service (recommended)
+- `mcp serve`: start a direct stdio MCP server (simple single-repo use)
+
+### Other
+
+- `index`: build or update a local index (lower-level; prefer `repo add`)
 - `quality-report`: inspect semantic coverage and merge quality metrics
 
 ## Installation
@@ -104,85 +127,68 @@ These may be added in future releases based on demand.
 See [Installation](#installation) above. The examples below assume `codeatlas`
 is in your `PATH`.
 
-### 2. Index a Repository
+### 2. Start the service and add repositories
 
 ```bash
-codeatlas index /absolute/path/to/repo
+# Start the persistent service (runs in foreground).
+codeatlas serve &
+
+# Add repositories to the catalog.
+codeatlas repo add /absolute/path/to/my-app
+codeatlas repo add /absolute/path/to/billing
+
+# Check what's registered.
+codeatlas repo list
 ```
 
-Useful options:
+The service stores data in `~/.codeatlas/` by default (override with
+`--data-root <path>` or `CODEATLAS_DATA_ROOT`). The `repo_id` is derived from
+the directory name — indexing `/Users/alex/work/my-app` produces `repo_id`
+`my-app`.
 
-```bash
-codeatlas index /absolute/path/to/repo --db /tmp/codeatlas.db
-codeatlas index /absolute/path/to/repo --git-diff
+### 3. Connect an AI client
+
+Configure your AI client to use the MCP bridge:
+
+```json
+{
+  "mcpServers": {
+    "codeatlas": {
+      "command": "codeatlas",
+      "args": ["mcp", "bridge"]
+    }
+  }
+}
 ```
 
-The CLI stores the index in a shared storage root. By default the DB lives at:
+That's it. The bridge connects to the running service and exposes all indexed
+repositories through the standard MCP tool interface. See
+[MCP Server Setup](#mcp-server-setup) for client-specific examples.
 
-```text
-~/.codeatlas/metadata.db
-```
-
-This shared store supports multiple repositories — each `codeatlas index`
-invocation adds or updates a repository in the same database. You can override
-the path with `--db <path>` or by setting `CODEATLAS_DATA_ROOT`.
-
-### 3. Find the Repo ID
-
-The CLI derives `repo_id` from the indexed directory name.
-
-Example:
-
-- repo path: `/Users/alex/work/my-app`
-- repo id: `my-app`
-
-You will need that `repo_id` for query commands and symbol IDs.
-
-### 4. Query the Index
+### 4. Query from the CLI
 
 All query commands default to the shared store at `~/.codeatlas/metadata.db`.
 Use `--db <path>` to override.
 
-Search for symbols:
-
 ```bash
 codeatlas search-symbols greet --repo my-app
-```
-
-Search with filters:
-
-```bash
-codeatlas search-symbols service --repo my-app --kind class --language typescript --limit 10
-```
-
-Get a symbol by ID (symbol IDs include the repo prefix):
-
-```bash
 codeatlas get-symbol 'my-app//src/lib.rs::greet#function'
-```
-
-Get a file outline:
-
-```bash
 codeatlas file-outline src/lib.rs --repo my-app
-```
-
-Get a file tree:
-
-```bash
 codeatlas file-tree --repo my-app
-```
-
-Get a repository outline:
-
-```bash
 codeatlas repo-outline --repo my-app
 ```
 
-Generate a quality report:
+### 5. Manage repositories
 
 ```bash
-codeatlas quality-report /absolute/path/to/repo
+# Re-index after code changes.
+codeatlas repo refresh my-app
+
+# Check status.
+codeatlas repo status my-app
+
+# Remove a repo and clean up its data.
+codeatlas repo remove my-app
 ```
 
 ## Semantic Adapter Setup
@@ -212,29 +218,29 @@ policy allows.
 
 ## MCP Server Setup
 
-CodeAtlas includes a built-in MCP server that works with any stdio MCP client.
+CodeAtlas provides two MCP integration paths:
 
-### Prerequisites
+1. **MCP bridge** (recommended) — a thin stdio process that proxies tool calls
+   to the persistent CodeAtlas service. One service, many repos, one client
+   config.
+2. **Direct MCP server** — a standalone stdio server for simple single-repo
+   workflows. No service needed.
+
+Both speak newline-delimited JSON-RPC 2.0 (MCP spec 2025-11-25). Compatibility
+notes and interoperability shims are documented in
+[docs/architecture/mcp-client-compatibility.md](docs/architecture/mcp-client-compatibility.md).
+
+### Option 1: MCP bridge (recommended)
+
+Prerequisites:
 
 1. Install `codeatlas` (see [Installation](#installation)).
-2. Index a repository so an index database exists.
+2. Start the service: `codeatlas serve`
+3. Add at least one repo: `codeatlas repo add /path/to/repo`
 
-### Launch the MCP server
+#### Client configuration
 
-```bash
-codeatlas mcp serve --db ~/.codeatlas/metadata.db
-```
-
-The server communicates over stdio using newline-delimited JSON-RPC 2.0
-(MCP spec 2025-11-25). All diagnostics go to stderr; stdout is reserved for
-protocol messages only.
-
-Compatibility notes for documented clients and additive interoperability shims
-live in [docs/architecture/mcp-client-compatibility.md](docs/architecture/mcp-client-compatibility.md).
-
-### Client configuration
-
-#### Claude Desktop
+##### Claude Desktop
 
 Add to your Claude Desktop MCP config (`claude_desktop_config.json`):
 
@@ -242,57 +248,70 @@ Add to your Claude Desktop MCP config (`claude_desktop_config.json`):
 {
   "mcpServers": {
     "codeatlas": {
-      "command": "/path/to/codeatlas",
-      "args": ["mcp", "serve", "--db", "/path/to/.codeatlas/metadata.db"]
+      "command": "codeatlas",
+      "args": ["mcp", "bridge"]
     }
   }
 }
 ```
 
-#### Cursor
+##### Cursor
 
-Add to your Cursor MCP settings (`.cursor/mcp.json` in your project or global
-config):
+Add to your Cursor MCP settings (`.cursor/mcp.json`):
 
 ```json
 {
   "mcpServers": {
     "codeatlas": {
-      "command": "/path/to/codeatlas",
-      "args": ["mcp", "serve", "--db", "/path/to/.codeatlas/metadata.db"]
+      "command": "codeatlas",
+      "args": ["mcp", "bridge"]
     }
   }
 }
 ```
 
-#### OpenAI Codex CLI
+##### OpenAI Codex CLI
 
-Create or edit `.codex/config.json` in your project root:
+Create or edit `.codex/config.json`:
 
 ```json
 {
   "mcpServers": {
     "codeatlas": {
-      "command": "/path/to/codeatlas",
-      "args": ["mcp", "serve", "--db", "/path/to/.codeatlas/metadata.db"]
+      "command": "codeatlas",
+      "args": ["mcp", "bridge"]
     }
   }
 }
 ```
 
-#### Generic stdio MCP client
+##### Generic stdio MCP client
 
-Any client that speaks newline-delimited JSON-RPC over stdio can use CodeAtlas.
 Configure it to spawn:
 
 ```
-/path/to/codeatlas mcp serve --db /path/to/.codeatlas/metadata.db
+codeatlas mcp bridge
 ```
+
+The bridge connects to the service at `127.0.0.1:52337` by default. Override
+with `--service-url <host:port>` or the `CODEATLAS_PORT`/`CODEATLAS_HOST`
+environment variables.
+
+### Option 2: Direct MCP server
+
+For simple single-repo use without running the persistent service:
+
+```bash
+codeatlas mcp serve --db ~/.codeatlas/metadata.db
+```
+
+Client configuration is the same as above but uses `["mcp", "serve"]` (or
+`["mcp", "serve", "--db", "/path/to/metadata.db"]`) instead of
+`["mcp", "bridge"]`.
 
 ### Available tools
 
-The MCP server exposes these tools via `tools/list`, each with full JSON Schema
-input definitions:
+Both the bridge and direct server expose these tools via `tools/list`:
 
 | Tool | Description |
 |------|-------------|
@@ -304,57 +323,43 @@ input definitions:
 | `get_file_tree` | List files in a repository or subtree |
 | `get_repo_outline` | Show repository structure and file summary |
 | `search_text` | Search for text patterns across indexed files |
+| `list_repos` | List all indexed repositories with status |
+| `get_repo_status` | Get detailed status for a specific repository |
 
 Repository-scoped tools accept `repo_id` as a parameter. Symbol IDs include
 the repo prefix (e.g., `my-app//src/lib.rs::Config#class`). The `repo_id` is
 derived from the indexed directory name (e.g., indexing `/home/user/my-app`
 produces `repo_id` `my-app`).
 
-### Verify the server starts
-
-```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}' | codeatlas mcp serve --db ~/.codeatlas/metadata.db
-```
-
-You should see a JSON response containing `"protocolVersion":"2025-11-25"` and
-`"serverInfo":{"name":"codeatlas",...}`.
-
 ### Troubleshooting
 
-**"database not found"** — The `--db` path does not exist. Run
-`codeatlas index <repo-path>` first to create the index (default:
-`~/.codeatlas/metadata.db`).
+**"cannot reach CodeAtlas service"** (bridge) — The service is not running.
+Start it with `codeatlas serve`.
 
-**"database is not readable"** — The file exists but cannot be read. Check
-file permissions (`ls -la` on the DB path).
+**"database not found"** (direct server) — The `--db` path does not exist.
+Run `codeatlas repo add <path>` or `codeatlas index <path>` first.
 
-**"failed to open database"** — The file exists and is readable but is not a
-valid CodeAtlas index (possibly corrupt or not a SQLite database). Re-run
-`codeatlas index <repo-path>` to rebuild.
-
-**"database path is a directory"** — The `--db` path points to a directory
-instead of a file. Point it at the `.db` file inside the directory.
+**Empty tool results** — Verify the `repo_id` matches an indexed repository.
+Use `codeatlas repo list` or the `list_repos` tool to see available repos.
 
 **No response on stdout** — Ensure the client uses newline-delimited JSON-RPC,
-not Content-Length framing. CodeAtlas will reject Content-Length headers with a
-clear error.
-
-**Empty tool results** — Verify the `repo_id` matches the indexed repository.
-The `repo_id` is derived from the directory name used during indexing.
+not Content-Length framing.
 
 ### What is not supported
 
-- HTTP, gRPC, or WebSocket transports (stdio only)
 - Content-Length framed MCP (2024-11-05 transport)
 - Authentication, tenancy, or multi-user access
 - Remote/hosted serving
+- The service HTTP API (`/tools/call`, `/repos`, etc.) is internal to the
+  local machine. AI clients should use the MCP bridge, not the HTTP endpoints
+  directly.
 
 ## How To Use It With AI Today
 
-### Option 1: MCP server (recommended)
+### Option 1: MCP bridge with persistent service (recommended)
 
-The simplest path is to use the built-in MCP server. See
-[MCP Server Setup](#mcp-server-setup) above.
+Start the service, add your repos, and configure your AI client to use the
+bridge. See [Quick Start](#quick-start) and [MCP Server Setup](#mcp-server-setup).
 
 ### Option 2: Use the CLI as a retrieval tool in your agent workflow
 
@@ -433,6 +438,42 @@ codeatlas quality-report /absolute/path/to/repo
 Use that output to decide whether the agent should trust semantic results or
 fall back to broader file reads.
 
+## Service Architecture
+
+The canonical local deployment is one persistent CodeAtlas service managing
+multiple repositories:
+
+```
+AI Client (Claude, Cursor)
+    |  stdio MCP
+MCP Bridge (codeatlas mcp bridge)
+    |  HTTP (localhost)
+CodeAtlas Service (codeatlas serve)
+    |
+Shared Store (~/.codeatlas/)
+    ├── metadata.db
+    ├── blobs/
+    ├── repo: my-app
+    ├── repo: billing
+    └── repo: shared-lib
+```
+
+The service listens on `127.0.0.1:52337` by default and exposes:
+
+- `GET /health` — health check
+- `GET /status` — service metadata (version, uptime, repo count)
+- `GET /repos` — list all repositories
+- `GET /repos/{repo_id}` — repository details
+- `DELETE /repos/{repo_id}` — remove a repository
+- `POST /tools/call` — execute a query tool
+
+The direct-store commands (`codeatlas index`, `codeatlas mcp serve --db`,
+`codeatlas search-symbols --repo`, etc.) continue to work for low-level
+workflows. The service model is the recommended path for daily multi-repo use.
+
+For architecture decisions and the relationship to future hosted deployment,
+see `docs/architecture/persistent-local-service.md`.
+
 ## Current Status
 
 Milestones M0-M9 are complete:
@@ -458,7 +499,8 @@ Milestones M0-M9 are complete:
 | `indexer` | End-to-end indexing pipeline (discovery -> parse -> enrich -> persist) | Complete |
 | `query-engine` | Symbol/text search, symbol lookup, file/repo outline retrieval | Complete |
 | `server-mcp` | MCP tool registry, structured response/error envelopes, integration + E2E tests | Complete |
-| `cli` | Local commands, MCP stdio server (`codeatlas mcp serve`), indexing, search/get symbol, file/repo outline | Complete |
+| `service` | Persistent local HTTP service runtime (`codeatlas serve`), repo catalog and query APIs | Complete |
+| `cli` | Local commands, MCP stdio server, MCP bridge, repo lifecycle, service startup, indexing, querying | Complete |
 
 ### Infrastructure
 
@@ -478,7 +520,8 @@ Milestones M0-M9 are complete:
 
 - Watcher/local file-system triggered update mode.
 - Semantic adapters beyond the current TypeScript and Kotlin implementations.
-- Hosted/server API surface (HTTP/gRPC), auth, quotas, and multi-tenant controls.
+- Docker packaging for the persistent service.
+- Hosted auth, quotas, and multi-tenant controls.
 - Production observability dashboards and hosted telemetry/export integrations beyond the local CLI baseline.
 
 ### Semantic Adapter Runtime Discovery

--- a/docs/architecture/deployment-modes.md
+++ b/docs/architecture/deployment-modes.md
@@ -22,22 +22,39 @@ This document answers:
 - which controls apply in each mode
 - what assumptions operators should make when running the system
 
-## Current Supported Mode
+## Current Supported Modes
 
-### Local-Only (direct-store)
+### Persistent Local Service (canonical)
 
-This is the current production mode implemented in the repository.
+This is the canonical local deployment model, implemented in Epic 13
+(#148-#154). The architecture is documented in
+`docs/architecture/persistent-local-service.md`.
 
 Characteristics:
 
-- indexing runs on a local checkout
-- metadata is stored in local SQLite
-- content blobs are stored on local disk
-- MCP and CLI are the primary interfaces
-- semantic adapters execute as local child processes
-- no hosted auth, tenancy, or remote storage is required
+- one long-running CodeAtlas service process per developer machine
+- shared storage root (`~/.codeatlas/`) for multiple repositories
+- HTTP transport for service communication (localhost only, port 52337)
+- MCP bridge process so AI clients connect to the service
+- repo catalog with lifecycle operations (add, list, status, refresh, remove)
+- no hosted auth, tenancy, or remote storage required
 
-Current entry points:
+Service entry points:
+
+- `codeatlas serve` (start the persistent HTTP service)
+- `codeatlas repo add <path>` (register and index a repository)
+- `codeatlas repo list` (list registered repositories)
+- `codeatlas repo status <repo_id>` (inspect a repository)
+- `codeatlas repo refresh <repo_id>` (re-index a repository)
+- `codeatlas repo remove <repo_id>` (de-register and clean up)
+- `codeatlas mcp bridge` (MCP bridge for AI clients)
+
+### Direct-Store (legacy, still supported)
+
+The direct-store mode remains available for simple single-repo workflows and
+low-level operations. It does not require the persistent service.
+
+Direct-store entry points:
 
 - `codeatlas index`
 - `codeatlas search-symbols`
@@ -47,25 +64,6 @@ Current entry points:
 - `codeatlas repo-outline`
 - `codeatlas quality-report`
 - `codeatlas mcp serve --db <path>` (stdio MCP server for AI clients)
-
-## Planned: Persistent Local Service
-
-Epic 13 (#148) defines a transition toward a persistent multi-repo local
-service as the canonical local deployment model. The architecture for that
-model is documented in `docs/architecture/persistent-local-service.md`.
-
-When implemented, the persistent service model will:
-
-- run one long-running CodeAtlas service process per developer machine
-- use a shared storage root for multiple repositories
-- expose an HTTP transport for service communication (localhost only)
-- provide an MCP bridge process so AI clients can connect to the service
-
-The current direct-store commands listed above will continue to work during
-and after the transition. See `docs/architecture/persistent-local-service.md`
-for the full architecture direction and decision records.
-
-Implementation status: not yet started (Epic 13, #148-#154).
 
 ### Hosted-Ready Architecture Path
 
@@ -102,8 +100,11 @@ Not implemented yet:
 2. `indexer` routes files to syntax and semantic adapters.
 3. `store` persists metadata and content blobs locally.
 4. `query-engine` answers lookup and search requests from the local index.
-5. CodeAtlas exposes the query surface to agent clients through CLI queries
-   and through the local stdio MCP server (`codeatlas mcp serve --db <path>`).
+5. CodeAtlas exposes the query surface through:
+   - the persistent HTTP service (`codeatlas serve`)
+   - the MCP bridge (`codeatlas mcp bridge`) for AI client integration
+   - CLI query commands (`search-symbols`, `get-symbol`, etc.)
+   - the direct stdio MCP server (`codeatlas mcp serve`) for legacy use
 
 ### Semantic adapter processes
 
@@ -157,11 +158,12 @@ Stored content:
 
 ### Storage root
 
-Current default: per-repo database at `<repo>/.codeatlas/index.db`, with each
-repo having its own database and blob directory.
+Current default: shared storage root at `~/.codeatlas/` containing one
+`metadata.db` for all repos and a shared `blobs/` directory. Override with
+`CODEATLAS_DATA_ROOT` or `--data-root` (service) / `--db` (direct commands).
 
-The persistent local service plan proposes moving to a shared storage root; see
-`docs/architecture/persistent-local-service.md` for that direction.
+Legacy per-repo paths (`<repo>/.codeatlas/index.db`) still work with
+direct-store commands using `--db`.
 
 ### Hosted-ready boundary
 
@@ -204,17 +206,17 @@ for any hosted deployment.
 
 ## Operational Assumptions by Mode
 
-### Local-only operators should assume
+### Local operators should assume
 
-- the index lives with the checkout unless `--db` changes the location
+- the canonical model is one persistent service per developer machine
+- the shared store lives at `~/.codeatlas/` unless overridden
+- AI clients connect through the MCP bridge, not by spawning per-repo processes
 - semantic coverage depends on local runtime availability
 - local logs may contain operational metadata but should not contain raw source
   in structured fields
 - schema/version upgrades are handled by store migration logic and may require
   reindex decisions based on schema compatibility rules
-- the MCP serving model is local stdio transport launched by the user or AI
-  client from the same machine as the indexed checkout
-  (`codeatlas mcp serve --db <path>`)
+- the service binds to localhost only (127.0.0.1) with no authentication
 
 ### Future hosted operators should assume
 
@@ -227,11 +229,11 @@ for any hosted deployment.
 
 Current reality:
 
-- CodeAtlas is publishable and actionable as a local-first system.
+- CodeAtlas is publishable and actionable as a local-first system with a
+  persistent multi-repo service model.
+- The persistent local service (Epic 13, #148-#154) is implemented. Architecture
+  decisions are recorded in `docs/architecture/persistent-local-service.md`.
 - The repository is not yet publishable as a hosted service implementation.
-- The persistent local service model is the planned next architectural
-  direction (Epic 13, #148). Architecture decisions for that initiative are
-  recorded in `docs/architecture/persistent-local-service.md`.
 
 Hosted-ready claim means:
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -9,9 +9,10 @@ It is intended to be actionable for maintainers and local operators.
 
 This runbook covers:
 
-- local environment preparation
-- indexing and query workflows
-- MCP server setup and troubleshooting
+- persistent service startup and management
+- repo catalog lifecycle operations
+- MCP bridge setup for AI clients
+- direct-store indexing and query workflows
 - semantic adapter setup and diagnosis
 - quality KPI reporting
 - schema/index maintenance workflows
@@ -45,109 +46,153 @@ from source).
 
 ### Useful environment variables
 
-- `TSSERVER_PATH`
-- `JAVA_HOME`
-- `KOTLIN_BRIDGE_JAR`
-- `CODEATLAS_LOG`
-- `CODEATLAS_LOG_FORMAT`
-- `CODEATLAS_OTEL`
+- `CODEATLAS_DATA_ROOT` — override the shared storage root (default: `~/.codeatlas`)
+- `CODEATLAS_PORT` — override the service port (default: `52337`)
+- `CODEATLAS_HOST` — override the service bind address (default: `127.0.0.1`)
+- `CODEATLAS_LOG` — set log level (e.g. `debug`, `info`)
+- `CODEATLAS_LOG_FORMAT` — `json` (default) or `compact`
+- `CODEATLAS_OTEL` — set to `1` to enable OpenTelemetry export
+- `TSSERVER_PATH` — explicit path to `tsserver` binary
+- `JAVA_HOME` — JDK location for Kotlin semantic adapter
+- `KOTLIN_BRIDGE_JAR` — path to Kotlin analysis bridge JAR
 
-## 2. Index a Repository
+## 2. Start the Persistent Service
 
-Full index:
+The canonical local model is one persistent service managing multiple repos.
 
-```bash
-cargo run -p cli -- index <repo-path>
-```
-
-Optional custom DB path:
-
-```bash
-cargo run -p cli -- index <repo-path> --db <db-path>
-```
-
-Optional git-diff acceleration:
+### Start the service
 
 ```bash
-cargo run -p cli -- index <repo-path> --git-diff
+codeatlas serve
 ```
 
-Expected output includes:
-
-- files discovered / parsed / errored
-- symbols extracted
-- semantic coverage summary
-- confidence summary
-- per-adapter breakdown when available
-
-## 3. Query the Local Index
-
-Query commands default to the shared store at `~/.codeatlas/metadata.db`.
-Use `--db <path>` to override. Commands that scope results to a repository
-require `--repo <repo-id>`.
-
-Examples:
+The service listens on `127.0.0.1:52337` by default. Override with:
 
 ```bash
-cargo run -p cli -- search-symbols <query> --repo <repo-id>
-cargo run -p cli -- get-symbol <symbol-id>
-cargo run -p cli -- file-outline <path> --repo <repo-id>
-cargo run -p cli -- file-tree --repo <repo-id>
-cargo run -p cli -- repo-outline --repo <repo-id>
+codeatlas serve --port 8080
+codeatlas serve --data-root /path/to/store
+codeatlas serve --host 0.0.0.0  # caution: exposes to network
 ```
 
-Note: `get-symbol` does not require `--repo` — symbol IDs include the repo
-prefix (e.g. `my-app//src/lib.rs::Config#class`) so they are globally unique.
+### Verify it's running
 
-Use the MCP server path when integrating with agent clients instead of direct
-CLI query commands.
+```bash
+curl http://127.0.0.1:52337/health    # 200 OK
+curl http://127.0.0.1:52337/status    # JSON with version, uptime, repo count
+```
 
-## 4. Run the MCP Server
+### Stop the service
 
-### Start the server
+Send SIGINT (Ctrl-C) or SIGTERM. The service shuts down gracefully.
+
+## 3. Manage Repositories
+
+### Add a repository
+
+```bash
+codeatlas repo add /absolute/path/to/my-app
+codeatlas repo add /absolute/path/to/billing --repo-id billing-v2
+codeatlas repo add /absolute/path/to/my-app --git-diff  # incremental
+```
+
+### List repositories
+
+```bash
+codeatlas repo list
+```
+
+### Check status
+
+```bash
+codeatlas repo status my-app
+```
+
+### Re-index after code changes
+
+```bash
+codeatlas repo refresh my-app
+codeatlas repo refresh my-app --git-diff  # incremental
+```
+
+### Remove a repository
+
+```bash
+codeatlas repo remove my-app
+```
+
+This deletes metadata, files, symbols, and orphaned blobs.
+
+## 4. Connect AI Clients (MCP Bridge)
+
+The MCP bridge proxies tool calls from AI clients to the persistent service.
+
+### Configure the client
+
+Add to your AI client's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "codeatlas": {
+      "command": "codeatlas",
+      "args": ["mcp", "bridge"]
+    }
+  }
+}
+```
+
+See the [README MCP Server Setup](../../README.md#mcp-server-setup) for
+client-specific examples (Claude Desktop, Cursor, OpenAI Codex CLI).
+
+### Override the service address
+
+```bash
+codeatlas mcp bridge --service-url 127.0.0.1:8080
+```
+
+Or via environment: `CODEATLAS_PORT`, `CODEATLAS_HOST`.
+
+### Troubleshoot bridge issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `cannot reach CodeAtlas service` | Service not running | Start with `codeatlas serve` |
+| Empty tool results | Wrong `repo_id` | Use `list_repos` tool or `codeatlas repo list` |
+| No stdout response | Client uses wrong framing | Bridge uses newline-delimited JSON-RPC |
+
+## 5. Direct-Store Workflows (Legacy)
+
+The direct-store commands still work for simple single-repo use or low-level
+operations without the persistent service.
+
+### Index a repository
+
+```bash
+codeatlas index <repo-path>
+codeatlas index <repo-path> --db <db-path>
+codeatlas index <repo-path> --git-diff
+```
+
+### Query the local index
+
+```bash
+codeatlas search-symbols <query> --repo <repo-id>
+codeatlas get-symbol <symbol-id>
+codeatlas file-outline <path> --repo <repo-id>
+codeatlas file-tree --repo <repo-id>
+codeatlas repo-outline --repo <repo-id>
+```
+
+### Run the direct MCP server
 
 ```bash
 codeatlas mcp serve --db ~/.codeatlas/metadata.db
 ```
 
-The server reads newline-delimited JSON-RPC from stdin and writes responses to
-stdout. All diagnostics go to stderr.
-
-### Verify it works
-
-```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}' | codeatlas mcp serve --db ~/.codeatlas/metadata.db
-```
-
-Expected: a JSON response with `"protocolVersion":"2025-11-25"`.
-
-### Configure an AI client
-
-See the [README MCP Server Setup](../../README.md#mcp-server-setup) for
-copy-paste configuration examples for Claude Desktop, Cursor, and OpenAI Codex CLI.
 See [MCP Client Compatibility Notes](../architecture/mcp-client-compatibility.md)
-for the currently documented interoperability shims and rationale.
+for interoperability shims and rationale.
 
-### Troubleshoot startup failures
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `database not found` | DB path does not exist | Run `codeatlas index <repo>` first (default: `~/.codeatlas/metadata.db`) |
-| `database is not readable` | Permission denied | Check file permissions |
-| `failed to open database` | Corrupt or non-SQLite file | Re-run `codeatlas index <repo>` |
-| `database path is a directory` | Path points to directory | Use the `.db` file path |
-| `--db <path> is required` | Missing `--db` flag | Add `--db /path/to/index.db` |
-| No stdout response | Client uses Content-Length framing | Use newline-delimited JSON-RPC |
-| Empty tool results | Wrong `repo_id` | `repo_id` is derived from the directory name used during indexing |
-
-### What the server does not support
-
-- HTTP, gRPC, or WebSocket transports
-- Content-Length framed MCP (2024-11-05 transport)
-- Authentication or multi-user access
-- Remote/hosted serving
-
-## 5. Generate a Repository Quality Report
+## 6. Generate a Repository Quality Report
 
 For live repository coverage metrics:
 
@@ -170,7 +215,7 @@ The report includes:
 - per-adapter contribution breakdown
 - pass/fail summary against KPI thresholds
 
-## 6. Diagnose Semantic Adapter Availability
+## 7. Diagnose Semantic Adapter Availability
 
 For runtime discovery order and setup instructions, see the
 [README semantic adapter setup](../../README.md#semantic-adapter-setup).
@@ -197,7 +242,7 @@ If Kotlin semantic coverage is unexpectedly absent:
 If semantic runtimes are missing, indexing should still succeed with syntax
 adapters where policy allows fallback.
 
-## 7. Run the Main Quality Gates Locally
+## 8. Run the Main Quality Gates Locally
 
 Format:
 
@@ -217,7 +262,7 @@ Tests:
 cargo test --workspace --all-features
 ```
 
-## 8. Inspect Regression KPIs
+## 9. Inspect Regression KPIs
 
 Fixture-based semantic regression suites:
 
@@ -234,7 +279,7 @@ Indexer metrics-focused tests:
 cargo test -p indexer metrics:: -- --nocapture
 ```
 
-## 9. CI KPI Artifact Workflow
+## 10. CI KPI Artifact Workflow
 
 The CI job `rust-quality-kpi`:
 
@@ -245,7 +290,7 @@ The CI job `rust-quality-kpi`:
 
 Use this when reviewing semantic quality changes or milestone closeout work.
 
-## 10. Schema and Reindex Workflow
+## 11. Schema and Reindex Workflow
 
 Current state:
 
@@ -258,7 +303,15 @@ Operator guidance:
   continue with normal indexing
 - if compatibility rules require reindex, rebuild the local index from source
 
-Recommended clean rebuild path:
+Recommended clean rebuild path (service mode):
+
+1. stop the service
+2. for each repo: `codeatlas repo refresh <repo_id>`
+3. if a full rebuild is needed: `codeatlas repo remove <repo_id>` then
+   `codeatlas repo add <path>` for each repository
+4. verify with `codeatlas repo list` and `codeatlas repo status <repo_id>`
+
+Recommended clean rebuild path (direct-store mode):
 
 1. remove or relocate the shared database (default: `~/.codeatlas/metadata.db`)
 2. rerun `codeatlas index <repo-path>` for each repository
@@ -266,7 +319,7 @@ Recommended clean rebuild path:
 
 Do not manually edit SQLite schema state.
 
-## 11. Logging and Tracing
+## 12. Logging and Tracing
 
 Structured logging defaults:
 
@@ -286,7 +339,7 @@ OpenTelemetry export can be enabled with:
 CODEATLAS_OTEL=1 cargo run -p cli -- index <repo-path>
 ```
 
-## 12. Key Failure Modes
+## 13. Key Failure Modes
 
 ### No symbols extracted
 
@@ -321,10 +374,12 @@ Check:
 - workflow grep patterns still match the printed output
 - uploaded artifact path in CI workflow is unchanged
 
-## 13. Reference Documents
+## 14. Reference Documents
 
 - `README.md`
 - `docs/architecture/deployment-modes.md`
+- `docs/architecture/persistent-local-service.md`
+- `docs/architecture/mcp-client-compatibility.md`
 - `docs/specifications/rust-code-intelligence-platform-spec.md`
 - `docs/workflow/github-process.md`
 - `docs/benchmarks/corpus.md`

--- a/docs/planning/issue-backlog.md
+++ b/docs/planning/issue-backlog.md
@@ -117,33 +117,28 @@ Strategic roadmap themes after M10 live in:
 - `docs/planning/post-v1-roadmap.md`
 - `docs/planning/persistent-multi-repo-local-service.md`
 
-### Planned First Post-V1 Execution Slice
+### Epic 13: Persistent Multi-Repo Local Service (complete)
 
-The current concrete planning artifact for post-v1 implementation is:
+The first post-v1 execution slice is complete. Planning artifact:
+`docs/planning/persistent-multi-repo-local-service.md`.
 
-- Epic 13 persistent local service plan:
-  `docs/planning/persistent-multi-repo-local-service.md`
-- GitHub epic and tickets: #148, #149, #150, #151, #152, #153, #154
+GitHub epic and tickets (all complete):
 
-That plan defines the first execution slice for the broader multi-repo
-direction:
+- ~~#148 Epic 13: Persistent Multi-Repo Local Service~~
+- ~~#149 Ticket: Define the persistent multi-repo local service architecture~~
+- ~~#150 Ticket: Make shared-store usage canonical and add missing repo catalog metadata~~
+- ~~#151 Ticket: Add repo catalog and lifecycle operations for a persistent local service~~
+- ~~#152 Ticket: Implement a persistent local service runtime~~
+- ~~#153 Ticket: Adapt AI client integration for the persistent service model~~
+- ~~#154 Ticket: Update docs and canonical usage guidance for the persistent local model~~
 
-- architecture definition for a persistent local multi-repo service
-- canonical shared-store usage and repo catalog metadata
-- repo registration/listing/refresh/remove lifecycle
-- persistent local runtime
-- MCP bridge/client integration
+What was delivered:
+
+- persistent HTTP service (`codeatlas serve`)
+- repo catalog with lifecycle operations (`codeatlas repo add/list/status/refresh/remove`)
+- MCP bridge for AI client integration (`codeatlas mcp bridge`)
+- shared storage root and repo catalog metadata
 - canonical doc updates
-
-Open issue set:
-
-- #148 Epic 13: Persistent Multi-Repo Local Service
-- #149 Ticket: Define the persistent multi-repo local service architecture
-- #150 Ticket: Make shared-store usage canonical and add missing repo catalog metadata
-- #151 Ticket: Add repo catalog and lifecycle operations for a persistent local service
-- #152 Ticket: Implement a persistent local service runtime
-- #153 Ticket: Adapt AI client integration for the persistent service model
-- #154 Ticket: Update docs and canonical usage guidance for the persistent local model
 
 Deferred from the first slice:
 

--- a/docs/planning/post-v1-roadmap.md
+++ b/docs/planning/post-v1-roadmap.md
@@ -169,12 +169,14 @@ Planning note:
 
 Planning note:
 
-- The concrete first execution slice for Epic 13 is documented in
-  `docs/planning/persistent-multi-repo-local-service.md`.
-- The active GitHub issue set for that slice is #148 through #154.
-- That slice focuses on the persistent multi-repo local service model.
+- The first execution slice for Epic 13 is complete (#148 through #154).
+  It delivered the persistent multi-repo local service, repo catalog lifecycle,
+  MCP bridge, and canonical doc updates. See
+  `docs/planning/persistent-multi-repo-local-service.md` for the planning
+  artifact and `docs/architecture/persistent-local-service.md` for architecture
+  decisions.
 - Cross-repo search, dependency traversal, ownership metadata, and remote
-  connectors remain plausible follow-on work after the local service baseline.
+  connectors remain plausible follow-on work.
 
 ### Epic 14: Service APIs and Integrations
 


### PR DESCRIPTION
## Summary

  - Issue: Closes #154
  - Scope: update canonical docs and usage guidance so the persistent local service model is the primary local story, with MCP bridge setup and direct-store workflows documented as secondary/legacy paths

  ## Changes

  - Reworked README.md to present the persistent local service (codeatlas serve) as the canonical local deployment model.
  - Updated quick start guidance to start the service, add repositories through the repo catalog, and connect AI clients through codeatlas mcp bridge.
  - Expanded README command coverage to include service startup, repo lifecycle commands, MCP bridge usage, and the service architecture overview.
  - Updated MCP setup documentation to distinguish the recommended bridge path from the direct stdio MCP server path.
  - Added the new repo-catalog MCP tools (list_repos, get_repo_status) to the documented tool list.
  - Updated docs/architecture/deployment-modes.md to describe the persistent local service as the canonical supported local mode and direct-store usage as still-supported legacy mode.
  - Updated docs/operations/runbook.md to cover service startup, repo lifecycle operations, MCP bridge configuration, troubleshooting, and direct-store workflows separately.
  - Updated planning docs (docs/planning/issue-backlog.md, docs/planning/post-v1-roadmap.md) to reflect the completed first execution slice for the persistent local service initiative.
  - Preserved explicit boundaries around what is still not supported: hosted auth/tenancy, Docker packaging, and broader hosted/service controls.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: docs present the persistent local service as the canonical local model
  - [x] Criterion 2: docs explain how multi-repo usage works
  - [x] Criterion 3: docs explain the CLI migration story clearly enough to avoid user confusion
  - [x] Criterion 4: docs explain the relationship between local self-hosted and future managed deployment
  - [x] Criterion 5: docs remain honest about unsupported hosted features

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional review evidence:

  - Manual doc review against the implemented CLI/service/bridge/repo lifecycle surfaces.
  - Verified the current command/docs alignment for:
      - codeatlas serve
      - codeatlas repo add/list/status/refresh/remove
      - codeatlas mcp bridge
      - codeatlas mcp serve

  ## Risk and Mitigation

  - Risk: user-facing docs can drift during the transition period between direct-store and service-first workflows, causing setup confusion.
  - Mitigation: the docs now explicitly label the persistent service as canonical, the MCP bridge as recommended, and direct-store workflows as still supported but secondary/legacy.

  ## Security/Observability Impact

  - Security: docs now more clearly state that the local service binds to localhost by default and that hosted auth/tenancy controls are not implemented.
  - Logs/Metrics/Tracing: operator-facing docs now include service health/status endpoints, bridge troubleshooting guidance, and clearer local operational expectations.