### PR TITLE
Persist file records and blobs for recognized files without symbol ad…

### DIFF
--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -90,6 +90,7 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
 
     println!("files_discovered: {}", result.metrics.files_discovered);
     println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_file_only: {}", result.metrics.files_file_only);
     println!("files_unchanged: {}", result.metrics.files_unchanged);
     println!("files_deleted: {}", result.metrics.files_deleted);
     println!("files_errored: {}", result.metrics.files_errored);

--- a/crates/cli/src/commands/quality_report.rs
+++ b/crates/cli/src/commands/quality_report.rs
@@ -101,8 +101,11 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     // Repository overview
     println!("Repository: {repo_id}");
     println!(
-        "Files:      {} discovered, {} parsed, {} errored",
-        result.metrics.files_discovered, result.metrics.files_parsed, result.metrics.files_errored,
+        "Files:      {} discovered, {} parsed ({} file-only), {} errored",
+        result.metrics.files_discovered,
+        result.metrics.files_parsed,
+        result.metrics.files_file_only,
+        result.metrics.files_errored,
     );
     println!("Symbols:    {}", result.metrics.symbols_extracted);
     println!();

--- a/crates/cli/src/commands/repo.rs
+++ b/crates/cli/src/commands/repo.rs
@@ -164,6 +164,7 @@ fn run_add(args: &[String]) -> Result<(), CliError> {
     println!("registered: {repo_id}");
     println!("files_discovered: {}", result.metrics.files_discovered);
     println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_file_only: {}", result.metrics.files_file_only);
     println!("symbols_extracted: {}", result.metrics.symbols_extracted);
 
     Ok(())
@@ -391,6 +392,7 @@ fn run_refresh(args: &[String]) -> Result<(), CliError> {
     println!("refreshed: {repo_id}");
     println!("files_discovered: {}", result.metrics.files_discovered);
     println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_file_only: {}", result.metrics.files_file_only);
     println!("files_unchanged: {}", result.metrics.files_unchanged);
     println!("files_deleted: {}", result.metrics.files_deleted);
     println!("symbols_extracted: {}", result.metrics.symbols_extracted);

--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -21,6 +21,8 @@ pub struct IndexMetrics {
     pub files_unchanged: usize,
     /// Files removed from the index because they were deleted from disk.
     pub files_deleted: usize,
+    /// Files indexed at file level only (no symbols extracted).
+    pub files_file_only: usize,
     /// Semantic coverage metrics computed from parse output.
     pub coverage: SemanticCoverageMetrics,
 }
@@ -151,9 +153,19 @@ pub fn run(
     // changed/new files for upserts.
     stage::persist(ctx, store, blob_store, &discovery, &parse_output)?;
 
+    let files_file_only = parse_output
+        .parsed_files
+        .iter()
+        .filter(|f| f.output.symbols.is_empty())
+        .count();
+
+    // files_parsed means files that produced symbol-bearing adapter output.
+    // File-only records are tracked separately via files_file_only.
+    let files_parsed = parse_output.parsed_files.len() - files_file_only;
+
     let metrics = IndexMetrics {
         files_discovered: discovery.metrics.files_discovered,
-        files_parsed: parse_output.parsed_files.len(),
+        files_parsed,
         files_errored: parse_output
             .file_errors
             .iter()
@@ -163,12 +175,14 @@ pub fn run(
         symbols_extracted,
         files_unchanged,
         files_deleted,
+        files_file_only,
         coverage,
     };
 
     info!(
         files_discovered = metrics.files_discovered,
         files_parsed = metrics.files_parsed,
+        files_file_only = metrics.files_file_only,
         files_errored = metrics.files_errored,
         files_unchanged = metrics.files_unchanged,
         files_deleted = metrics.files_deleted,

--- a/crates/indexer/src/stage.rs
+++ b/crates/indexer/src/stage.rs
@@ -167,12 +167,24 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
             debug!(
                 path = %file.relative_path.display(),
                 language = %file.language,
-                "no adapter available, skipping"
+                "no adapter available, indexing file-only"
             );
-            file_errors.push(FileError {
-                path: file.relative_path.clone(),
-                adapter_id: None,
-                error: format!("no adapter for language '{}'", file.language),
+
+            // File-only fallback: persist file record and blob even without
+            // symbols. This is not an error — it is an expected capability
+            // boundary for recognized languages without adapters.
+            let content_hash = file_content_hash(&file.content);
+            parsed_files.push(ParsedFile {
+                relative_path: file.relative_path.clone(),
+                language: file.language.clone(),
+                output: AdapterOutput {
+                    symbols: vec![],
+                    source_adapter: "file-only".to_string(),
+                    quality_level: QualityLevel::Syntax,
+                },
+                symbol_provenance: vec![],
+                content_hash,
+                content: file.content.clone(),
             });
             continue;
         }
@@ -236,14 +248,33 @@ pub fn parse(ctx: &PipelineContext<'_>, discovery: &DiscoveryOutput) -> ParseOut
             // Do not append them to file_errors when the file was
             // successfully parsed — file_errors drives the files_errored
             // metric and should only contain files with no usable output.
-        } else if per_file_errors.is_empty() {
-            file_errors.push(FileError {
-                path: file.relative_path.clone(),
-                adapter_id: None,
-                error: "all adapters returned unsupported".to_string(),
-            });
         } else {
-            file_errors.append(&mut per_file_errors);
+            // No adapter produced symbols. Record real adapter failures
+            // as file_errors (distinct from the missing-adapter path above)
+            // but still persist a file-only record so the file does not
+            // disappear from the index.
+            if per_file_errors.is_empty() {
+                debug!(
+                    path = %file.relative_path.display(),
+                    "all adapters returned unsupported, indexing file-only"
+                );
+            } else {
+                file_errors.append(&mut per_file_errors);
+            }
+
+            let content_hash = file_content_hash(&file.content);
+            parsed_files.push(ParsedFile {
+                relative_path: file.relative_path.clone(),
+                language: file.language.clone(),
+                output: AdapterOutput {
+                    symbols: vec![],
+                    source_adapter: "file-only".to_string(),
+                    quality_level: QualityLevel::Syntax,
+                },
+                symbol_provenance: vec![],
+                content_hash,
+                content: file.content.clone(),
+            });
         }
     }
 

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -386,37 +386,42 @@ fn pipeline_treesitter_unsupported_language_reports_error_with_provenance() {
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
 
-    // Rust file parsed successfully.
+    // Rust file produced symbols (files_parsed), Python is file-only.
     assert_eq!(result.metrics.files_parsed, 1);
+    assert_eq!(result.metrics.files_file_only, 1);
 
-    // Python file recorded as an error (no adapter available).
+    // Python file is NOT an error — missing adapter produces a file-only record.
     let py_errors: Vec<_> = result
         .file_errors
         .iter()
         .filter(|e| e.path.to_string_lossy().contains("script.py"))
         .collect();
     assert!(
-        !py_errors.is_empty(),
-        "expected error for unsupported Python file"
-    );
-    assert!(
-        py_errors[0].error.contains("no adapter"),
-        "error should indicate no adapter: {}",
-        py_errors[0].error
-    );
-    // No adapter was tried, so adapter_id should be None.
-    assert!(
-        py_errors[0].adapter_id.is_none(),
-        "adapter_id should be None when no adapters available"
+        py_errors.is_empty(),
+        "missing adapter should not produce a file error"
     );
 
-    // Repo still persisted with the successful file.
+    // Repo persisted with both files.
     let repo = db
         .repos()
         .get("mixed-repo")
         .expect("query repo")
         .expect("repo record");
-    assert_eq!(repo.file_count, 1);
+    assert_eq!(repo.file_count, 2);
+
+    // Python file has a file record with zero symbols.
+    let py_file = db
+        .files()
+        .get("mixed-repo", "script.py")
+        .expect("query file")
+        .expect("Python file record should exist");
+    assert_eq!(py_file.language, "python");
+    assert_eq!(py_file.symbol_count, 0);
+
+    // Python file blob was persisted.
+    let py_content = std::fs::read(repo_dir.path().join("script.py")).expect("read py");
+    let py_hash = store::content_hash(&py_content);
+    assert!(blob_store.exists(&py_hash).expect("blob exists"));
 }
 
 // ---------------------------------------------------------------------------
@@ -571,10 +576,12 @@ fn adapter_error_carries_adapter_id_provenance() {
 
     let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
 
-    // No files parsed.
+    // Adapter failed — file gets a file-only record, not counted as "parsed".
     assert_eq!(result.metrics.files_parsed, 0);
+    assert_eq!(result.metrics.files_file_only, 1);
 
-    // Error carries the adapter ID for provenance.
+    // Error carries the adapter ID for provenance — real adapter failures
+    // are still recorded in file_errors even though the file gets a record.
     let rs_errors: Vec<_> = result
         .file_errors
         .iter()
@@ -591,6 +598,19 @@ fn adapter_error_carries_adapter_id_provenance() {
         "error message should contain adapter error: {}",
         rs_errors[0].error
     );
+
+    // File record still exists with zero symbols.
+    let file = db
+        .files()
+        .get("fail-repo", "src/main.rs")
+        .expect("query file")
+        .expect("file record should exist despite adapter failure");
+    assert_eq!(file.symbol_count, 0);
+
+    // Blob was persisted.
+    let content = std::fs::read(repo_dir.path().join("src/main.rs")).expect("read file");
+    let hash = store::content_hash(&content);
+    assert!(blob_store.exists(&hash).expect("blob exists"));
 }
 
 // ---------------------------------------------------------------------------
@@ -689,16 +709,30 @@ fn parse_stage_handles_no_adapter() {
     let discovery = stage::discover(&ctx).expect("discovery ok");
     let parse_output = stage::parse(&ctx, &discovery);
 
-    // The Python file should appear in file_errors.
+    // The Python file should NOT appear in file_errors — missing adapter
+    // is not an error, it produces a file-only record.
     let py_errors: Vec<_> = parse_output
         .file_errors
         .iter()
         .filter(|e| e.path.to_string_lossy().contains("script.py"))
         .collect();
     assert!(
-        !py_errors.is_empty(),
-        "expected error for unsupported Python file"
+        py_errors.is_empty(),
+        "missing adapter should not produce a file error"
     );
+
+    // The Python file should appear in parsed_files as file-only.
+    let py_parsed: Vec<_> = parse_output
+        .parsed_files
+        .iter()
+        .filter(|f| f.relative_path.to_string_lossy().contains("script.py"))
+        .collect();
+    assert!(
+        !py_parsed.is_empty(),
+        "Python file should be in parsed_files as file-only"
+    );
+    assert_eq!(py_parsed[0].output.symbols.len(), 0);
+    assert_eq!(py_parsed[0].output.source_adapter, "file-only");
 }
 
 #[test]
@@ -2104,4 +2138,290 @@ fn git_diff_first_run_indexes_all_files() {
         "all files should be parsed on first run"
     );
     assert_eq!(r.metrics.files_unchanged, 0);
+}
+
+// ---------------------------------------------------------------------------
+// File-only indexing: recognized files without symbol adapters (#166)
+// ---------------------------------------------------------------------------
+
+/// A recognized-language repo with no adapters at all should produce file
+/// records and blobs for all discovered files (non-empty index).
+#[test]
+fn file_only_indexing_recognized_repo_no_adapters() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("app.py"), "print('hello')\n").expect("write py");
+    std::fs::write(repo_dir.path().join("lib.go"), "package main\n").expect("write go");
+    std::fs::write(repo_dir.path().join("index.js"), "console.log('hi');\n").expect("write js");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    // TreeSitterRouter only has Rust adapters — no adapters for Python/Go/JS.
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "no-adapter-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        policy_override: Some(AdapterPolicy::SyntaxOnly),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    // All 3 files indexed as file-only — no symbol-bearing adapter output.
+    assert_eq!(result.metrics.files_parsed, 0);
+    assert_eq!(result.metrics.files_file_only, 3);
+    assert_eq!(result.metrics.symbols_extracted, 0);
+    assert!(
+        result.file_errors.is_empty(),
+        "no errors expected for missing adapters"
+    );
+
+    // Repo has all 3 file records.
+    let repo = db
+        .repos()
+        .get("no-adapter-repo")
+        .expect("query repo")
+        .expect("repo record");
+    assert_eq!(repo.file_count, 3);
+    assert_eq!(repo.symbol_count, 0);
+
+    // Each file has a file record with zero symbols.
+    for (path, lang) in &[
+        ("app.py", "python"),
+        ("lib.go", "go"),
+        ("index.js", "javascript"),
+    ] {
+        let file = db
+            .files()
+            .get("no-adapter-repo", path)
+            .expect("query file")
+            .unwrap_or_else(|| panic!("file record for {} should exist", path));
+        assert_eq!(file.language, *lang);
+        assert_eq!(file.symbol_count, 0);
+    }
+
+    // Blobs were persisted for all files.
+    for name in &["app.py", "lib.go", "index.js"] {
+        let content = std::fs::read(repo_dir.path().join(name)).expect("read file");
+        let hash = store::content_hash(&content);
+        assert!(
+            blob_store.exists(&hash).expect("blob exists"),
+            "blob for {} should be persisted",
+            name
+        );
+    }
+}
+
+/// A mixed repo with both symbol-bearing and file-only files should persist
+/// both correctly.
+#[test]
+fn file_only_indexing_mixed_repo() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+
+    // Rust file — will get symbols from tree-sitter.
+    std::fs::write(src.join("main.rs"), "fn main() {}\n").expect("write rs");
+    // Python file — no adapter, will be file-only.
+    std::fs::write(repo_dir.path().join("script.py"), "import sys\n").expect("write py");
+    // SQL file — recognized language, no adapter.
+    std::fs::write(
+        repo_dir.path().join("schema.sql"),
+        "CREATE TABLE t (id INT);\n",
+    )
+    .expect("write sql");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "mixed-file-only".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        policy_override: Some(AdapterPolicy::SyntaxOnly),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    // 1 with symbols (Rust), 2 file-only (Python, SQL).
+    assert_eq!(result.metrics.files_parsed, 1);
+    assert_eq!(result.metrics.files_file_only, 2);
+    assert!(
+        result.metrics.symbols_extracted >= 1,
+        "Rust should have symbols"
+    );
+
+    // Repo aggregates.
+    let repo = db
+        .repos()
+        .get("mixed-file-only")
+        .expect("query repo")
+        .expect("repo record");
+    assert_eq!(repo.file_count, 3);
+    assert!(repo.symbol_count >= 1);
+
+    // Rust file has symbols.
+    let rs_file = db
+        .files()
+        .get("mixed-file-only", "src/main.rs")
+        .expect("query file")
+        .expect("Rust file record");
+    assert!(rs_file.symbol_count >= 1);
+
+    // Python file is file-only.
+    let py_file = db
+        .files()
+        .get("mixed-file-only", "script.py")
+        .expect("query file")
+        .expect("Python file record");
+    assert_eq!(py_file.symbol_count, 0);
+}
+
+/// Stale file cleanup should not delete file-only indexed entries on
+/// re-index when the file is still present on disk.
+#[test]
+fn file_only_stale_cleanup_preserves_file_only_records() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("app.py"), "print('v1')\n").expect("write py");
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "stale-test".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        policy_override: Some(AdapterPolicy::SyntaxOnly),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    // First index: 1 symbol-bearing (Rust), 1 file-only (Python).
+    let r1 = run(&ctx, &mut db, &blob_store).expect("first run");
+    assert_eq!(r1.metrics.files_parsed, 1);
+    assert_eq!(r1.metrics.files_file_only, 1);
+
+    // Re-index without changes: file-only record should survive.
+    let _r2 = run(&ctx, &mut db, &blob_store).expect("second run");
+
+    let repo = db
+        .repos()
+        .get("stale-test")
+        .expect("query repo")
+        .expect("repo record");
+    assert_eq!(repo.file_count, 2, "both files should still be in index");
+
+    let py_file = db
+        .files()
+        .get("stale-test", "app.py")
+        .expect("query file")
+        .expect("Python file record should survive re-index");
+    assert_eq!(py_file.symbol_count, 0);
+}
+
+/// Verify that file-only records use the same content_hash contract as
+/// symbol-bearing files (store::content_hash SHA-256).
+#[test]
+fn file_only_uses_same_content_hash_contract() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    std::fs::write(repo_dir.path().join("app.py"), "x = 1\n").expect("write py");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = TreeSitterRouter::new();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "hash-test".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        policy_override: Some(AdapterPolicy::SyntaxOnly),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    let content = std::fs::read(repo_dir.path().join("app.py")).expect("read file");
+    let expected_hash = store::content_hash(&content);
+
+    let file = db
+        .files()
+        .get("hash-test", "app.py")
+        .expect("query file")
+        .expect("file record");
+    assert_eq!(
+        file.file_hash, expected_hash,
+        "file-only record should use the same content_hash as blob store"
+    );
+
+    // Blob retrievable by that hash.
+    let blob = blob_store
+        .get(&expected_hash)
+        .expect("get blob")
+        .expect("blob should exist");
+    assert_eq!(blob, content);
+}
+
+/// Missing-adapter and adapter-failure produce different diagnostic states.
+#[test]
+fn file_only_distinguishes_missing_adapter_from_adapter_failure() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    // Python — no adapter at all (missing adapter).
+    std::fs::write(repo_dir.path().join("script.py"), "print('hi')\n").expect("write py");
+    // Rust — adapter exists but fails (adapter failure).
+    std::fs::write(repo_dir.path().join("main.rs"), "fn main() {}\n").expect("write rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let router = FailOnlyRouter::new(); // Only returns FailingAdapter for Rust.
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "diag-test".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        policy_override: Some(AdapterPolicy::SyntaxOnly),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+
+    // Both files get file-only records — neither produced symbols.
+    assert_eq!(result.metrics.files_parsed, 0);
+    assert_eq!(result.metrics.files_file_only, 2);
+
+    // Missing adapter (Python): no file_error.
+    let py_errors: Vec<_> = result
+        .file_errors
+        .iter()
+        .filter(|e| e.path.to_string_lossy().contains("script.py"))
+        .collect();
+    assert!(
+        py_errors.is_empty(),
+        "missing adapter should not produce a file error"
+    );
+
+    // Adapter failure (Rust): file_error WITH adapter_id.
+    let rs_errors: Vec<_> = result
+        .file_errors
+        .iter()
+        .filter(|e| e.path.to_string_lossy().contains("main.rs"))
+        .collect();
+    assert!(
+        !rs_errors.is_empty(),
+        "adapter failure should still produce a file error"
+    );
+    assert_eq!(rs_errors[0].adapter_id.as_deref(), Some("failing-adapter"));
 }


### PR DESCRIPTION
## Summary

  - Issue: Closes #166
  - Scope: Persist recognized files as file-level index entries, with blobs and file records, even when no symbol adapter exists or adapter execution fails.

  ## Changes

  - Added file-only fallback handling in the parse stage for recognized files with no available adapters.
  - Added file-only fallback persistence for recognized files when adapters exist but produce no symbols or fail.
  - Preserved adapter-failure diagnostics in file_errors while keeping missing-adapter paths non-erroring.
  - Added files_file_only pipeline metric and kept files_parsed scoped to symbol-bearing adapter output.
  - Updated CLI output to surface the new files_file_only metric in index, repo add, repo refresh, and quality-report.
  - Added regression coverage for:
      - recognized-language repos with no adapters producing non-empty indexes
      - mixed symbol-bearing and file-only repos
      - stale cleanup preserving file-only entries
      - file-only records using the canonical store::content_hash contract
      - missing-adapter vs adapter-failure diagnostic distinction

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: recognized files without adapters receive file records and stored blobs
  - [x] Criterion 2: recognized files with real adapter failures still receive file records and stored blobs
  - [x] Criterion 3: missing-adapter cases are not counted as ordinary parse errors
  - [x] Criterion 4: file-only indexed records use the same content-hash contract as symbol-bearing files
  - [x] Criterion 5: the implementation handles the current empty-merge rejection path explicitly
  - [x] Criterion 6: stale-file cleanup remains correct for mixed file-only and symbol-bearing repos
  - [x] Criterion 7: tests prove non-empty index behavior on a repository with recognized languages but no current symbol adapter

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional tests run:

  - [x] cargo test -p indexer --test pipeline_integration file_only_indexing_recognized_repo_no_adapters -- --nocapture
  - [x] cargo test -p indexer --test pipeline_integration file_only_indexing_mixed_repo -- --nocapture
  - [x] cargo test -p indexer --test pipeline_integration file_only_distinguishes_missing_adapter_from_adapter_failure -- --nocapture

  ## Risk and Mitigation

  - Risk: File-only fallback could blur the distinction between successful symbol extraction and baseline file-level indexing if metrics are interpreted loosely.
  - Mitigation: files_parsed remains symbol-bearing only, files_file_only is reported separately, and adapter failures still surface through file_errors.

  ## Security/Observability Impact

  - Security: No new external I/O or trust boundary changes; this work only ensures recognized files already discovered by the walker are persisted at file level.
  - Logs/Metrics/Tracing: Added files_file_only to pipeline/CLI reporting and preserved diagnostic separation between missing-adapter and adapter-failure paths.