### PR TITLE
Wire file-content retrieval and file-level query behavior to the fall…

### DIFF
--- a/crates/cli/src/commands/file_outline.rs
+++ b/crates/cli/src/commands/file_outline.rs
@@ -10,7 +10,13 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     let opts = parse_args(args)?;
 
     let db = store::MetadataStore::open(&opts.db_path)?;
-    let svc = StoreQueryService::new(&db);
+    let blob_path = opts
+        .db_path
+        .parent()
+        .map(|p| p.join("blobs"))
+        .unwrap_or_else(|| PathBuf::from("blobs"));
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let outline = svc.get_file_outline(&FileOutlineRequest {
         repo_id: opts.repo_id,

--- a/crates/cli/src/commands/file_tree.rs
+++ b/crates/cli/src/commands/file_tree.rs
@@ -10,7 +10,13 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     let opts = parse_args(args)?;
 
     let db = store::MetadataStore::open(&opts.db_path)?;
-    let svc = StoreQueryService::new(&db);
+    let blob_path = opts
+        .db_path
+        .parent()
+        .map(|p| p.join("blobs"))
+        .unwrap_or_else(|| PathBuf::from("blobs"));
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let entries = svc.get_file_tree(&FileTreeRequest {
         repo_id: opts.repo_id,

--- a/crates/cli/src/commands/get_symbol.rs
+++ b/crates/cli/src/commands/get_symbol.rs
@@ -10,7 +10,12 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     let (db_path, symbol_id) = parse_args(args)?;
 
     let db = store::MetadataStore::open(&db_path)?;
-    let svc = StoreQueryService::new(&db);
+    let blob_path = db_path
+        .parent()
+        .map(|p| p.join("blobs"))
+        .unwrap_or_else(|| PathBuf::from("blobs"));
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let record = svc.get_symbol(&symbol_id)?;
 

--- a/crates/cli/src/commands/mcp_serve.rs
+++ b/crates/cli/src/commands/mcp_serve.rs
@@ -90,7 +90,15 @@ fn run_serve(args: &[String]) -> Result<(), CliError> {
             )));
         }
     };
-    let svc = StoreQueryService::new(&db);
+    // Open blob store for file-content retrieval. The blob directory is a
+    // sibling of the metadata database file (same data-root convention).
+    let blob_path = opts
+        .db_path
+        .parent()
+        .map(|p| p.join("blobs"))
+        .unwrap_or_else(|| PathBuf::from("blobs"));
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let svc = StoreQueryService::new(&db, &blob_store);
     let registry = ToolRegistry::new(&svc);
 
     eprintln!(

--- a/crates/cli/src/commands/repo_outline.rs
+++ b/crates/cli/src/commands/repo_outline.rs
@@ -10,7 +10,13 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     let opts = parse_args(args)?;
 
     let db = store::MetadataStore::open(&opts.db_path)?;
-    let svc = StoreQueryService::new(&db);
+    let blob_path = opts
+        .db_path
+        .parent()
+        .map(|p| p.join("blobs"))
+        .unwrap_or_else(|| PathBuf::from("blobs"));
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let outline = svc.get_repo_outline(&RepoOutlineRequest {
         repo_id: opts.repo_id,

--- a/crates/cli/src/commands/search_symbols.rs
+++ b/crates/cli/src/commands/search_symbols.rs
@@ -11,7 +11,13 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     let opts = parse_args(args)?;
 
     let db = store::MetadataStore::open(&opts.db_path)?;
-    let svc = StoreQueryService::new(&db);
+    let blob_path = opts
+        .db_path
+        .parent()
+        .map(|p| p.join("blobs"))
+        .unwrap_or_else(|| PathBuf::from("blobs"));
+    let blob_store = store::BlobStore::open(&blob_path)?;
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let query = SymbolQuery {
         repo_id: opts.repo_id,

--- a/crates/cli/src/mcp_stdio.rs
+++ b/crates/cli/src/mcp_stdio.rs
@@ -705,10 +705,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.db");
         let db = store::MetadataStore::open(&db_path).unwrap();
-        // Leak dir to keep the temp directory alive for the test duration.
+        let blob_dir = tempfile::tempdir().unwrap();
+        let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+        // Leak dirs and blob store to keep them alive for the test duration.
         std::mem::forget(dir);
-        (db, |db: &store::MetadataStore| {
-            let svc = Box::new(query_engine::StoreQueryService::new(db));
+        std::mem::forget(blob_dir);
+        let blob_store_ref: &'static store::BlobStore = Box::leak(Box::new(blob_store));
+        (db, move |db: &store::MetadataStore| {
+            let svc = Box::new(query_engine::StoreQueryService::new(db, blob_store_ref));
             let svc_ptr = Box::into_raw(svc);
             // SAFETY: the heap allocation is intentionally leaked so the
             // ToolRegistry reference remains valid for the test duration.

--- a/crates/indexer/tests/determinism_regression.rs
+++ b/crates/indexer/tests/determinism_regression.rs
@@ -570,7 +570,7 @@ pub fn run_delta() {}
 
     // Run 1.
     run(&ctx, &mut db, &blob_store).expect("run 1");
-    let svc = StoreQueryService::new(&db);
+    let svc = StoreQueryService::new(&db, &blob_store);
     let query = SymbolQuery {
         repo_id: "tie-repo".into(),
         text: "run".into(),
@@ -595,7 +595,7 @@ pub fn run_delta() {}
 
     // Run 2.
     run(&ctx, &mut db, &blob_store).expect("run 2");
-    let svc = StoreQueryService::new(&db);
+    let svc = StoreQueryService::new(&db, &blob_store);
     let r2 = svc.search_symbols(&query).unwrap();
     let ids2: Vec<&str> = r2.items.iter().map(|s| s.record.id.as_str()).collect();
 

--- a/crates/query-engine/benches/queries.rs
+++ b/crates/query-engine/benches/queries.rs
@@ -54,6 +54,7 @@ impl AdapterRouter for TreeSitterRouter {
 
 struct BenchFixture {
     db: store::MetadataStore,
+    blob_store: store::BlobStore,
     _repo_dir: TempDir,
     _blob_dir: TempDir,
 }
@@ -96,6 +97,7 @@ fn create_populated_store(file_count: usize) -> BenchFixture {
 
     BenchFixture {
         db,
+        blob_store,
         _repo_dir: repo_dir,
         _blob_dir: blob_dir,
     }
@@ -110,7 +112,7 @@ fn bench_search_symbols(c: &mut Criterion) {
     group.sample_size(50);
 
     let fixture = create_populated_store(50);
-    let svc = StoreQueryService::new(&fixture.db);
+    let svc = StoreQueryService::new(&fixture.db, &fixture.blob_store);
 
     group.bench_function("exact_match", |b| {
         b.iter(|| {
@@ -161,7 +163,7 @@ fn bench_get_symbol(c: &mut Criterion) {
     group.sample_size(50);
 
     let fixture = create_populated_store(50);
-    let svc = StoreQueryService::new(&fixture.db);
+    let svc = StoreQueryService::new(&fixture.db, &fixture.blob_store);
 
     // Find a real symbol ID to query.
     let query = SymbolQuery {
@@ -194,7 +196,7 @@ fn bench_file_outline(c: &mut Criterion) {
     group.sample_size(50);
 
     let fixture = create_populated_store(50);
-    let svc = StoreQueryService::new(&fixture.db);
+    let svc = StoreQueryService::new(&fixture.db, &fixture.blob_store);
 
     group.bench_function("single_file", |b| {
         b.iter(|| {
@@ -215,7 +217,7 @@ fn bench_file_tree(c: &mut Criterion) {
     group.sample_size(50);
 
     let fixture = create_populated_store(50);
-    let svc = StoreQueryService::new(&fixture.db);
+    let svc = StoreQueryService::new(&fixture.db, &fixture.blob_store);
 
     group.bench_function("full_tree", |b| {
         b.iter(|| {
@@ -235,7 +237,7 @@ fn bench_repo_outline(c: &mut Criterion) {
     group.sample_size(50);
 
     let fixture = create_populated_store(50);
-    let svc = StoreQueryService::new(&fixture.db);
+    let svc = StoreQueryService::new(&fixture.db, &fixture.blob_store);
 
     group.bench_function("full_outline", |b| {
         b.iter(|| {
@@ -255,7 +257,7 @@ fn bench_search_text(c: &mut Criterion) {
     group.sample_size(50);
 
     let fixture = create_populated_store(50);
-    let svc = StoreQueryService::new(&fixture.db);
+    let svc = StoreQueryService::new(&fixture.db, &fixture.blob_store);
 
     group.bench_function("fts_query", |b| {
         b.iter(|| {

--- a/crates/query-engine/src/store_service.rs
+++ b/crates/query-engine/src/store_service.rs
@@ -1,6 +1,7 @@
-//! [`QueryService`] implementation backed by [`MetadataStore`].
+//! [`QueryService`] implementation backed by [`MetadataStore`] and
+//! [`BlobStore`].
 
-use store::MetadataStore;
+use store::{BlobStore, MetadataStore};
 use tracing::info_span;
 
 use crate::ranking::{score_symbol, sort_scored};
@@ -11,14 +12,16 @@ use crate::{
 };
 use core_model::SymbolRecord;
 
-/// Production [`QueryService`] implementation backed by a [`MetadataStore`].
+/// Production [`QueryService`] implementation backed by a [`MetadataStore`]
+/// and a [`BlobStore`] for file content retrieval.
 pub struct StoreQueryService<'a> {
     store: &'a MetadataStore,
+    blob_store: &'a BlobStore,
 }
 
 impl<'a> StoreQueryService<'a> {
-    pub fn new(store: &'a MetadataStore) -> Self {
-        Self { store }
+    pub fn new(store: &'a MetadataStore, blob_store: &'a BlobStore) -> Self {
+        Self { store, blob_store }
     }
 }
 
@@ -139,12 +142,22 @@ impl QueryService for StoreQueryService<'_> {
                 id: request.file_path.clone(),
             })?;
 
-        // File content retrieval is delegated to BlobStore in production.
-        // For now, return a placeholder indicating content is not yet wired.
-        Ok(FileContent {
-            file,
-            content: String::new(),
-        })
+        let bytes = self
+            .blob_store
+            .get(&file.file_hash)
+            .map_err(QueryError::Store)?
+            .ok_or_else(|| {
+                QueryError::Store(store::StoreError::Blob {
+                    path: None,
+                    reason: format!(
+                        "blob missing for file '{}' (hash {})",
+                        request.file_path, file.file_hash
+                    ),
+                })
+            })?;
+        let content = String::from_utf8_lossy(&bytes).into_owned();
+
+        Ok(FileContent { file, content })
     }
 
     fn get_file_tree(&self, request: &FileTreeRequest) -> Result<Vec<FileTreeEntry>, QueryError> {

--- a/crates/query-engine/tests/get_symbol_integration.rs
+++ b/crates/query-engine/tests/get_symbol_integration.rs
@@ -8,8 +8,9 @@ use core_model::{
 };
 use query_engine::{QueryError, QueryService, StoreQueryService};
 use store::MetadataStore;
+use tempfile::TempDir;
 
-fn seed_store() -> (MetadataStore, Vec<SymbolRecord>) {
+fn seed_store() -> (MetadataStore, store::BlobStore, TempDir, Vec<SymbolRecord>) {
     let store = MetadataStore::open_in_memory().unwrap();
 
     store
@@ -57,7 +58,9 @@ fn seed_store() -> (MetadataStore, Vec<SymbolRecord>) {
         store.symbols().upsert(sym).unwrap();
     }
 
-    (store, symbols)
+    let blob_dir = TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+    (store, blob_store, blob_dir, symbols)
 }
 
 fn make_symbol(
@@ -100,8 +103,8 @@ fn make_symbol(
 
 #[test]
 fn get_symbol_returns_matching_record() {
-    let (store, symbols) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, symbols) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.get_symbol(&symbols[0].id).unwrap();
     assert_eq!(result.id, symbols[0].id);
@@ -111,8 +114,8 @@ fn get_symbol_returns_matching_record() {
 
 #[test]
 fn get_symbol_returns_all_fields() {
-    let (store, symbols) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, symbols) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.get_symbol(&symbols[1].id).unwrap();
     assert_eq!(result.id, symbols[1].id);
@@ -129,8 +132,8 @@ fn get_symbol_returns_all_fields() {
 
 #[test]
 fn get_symbol_not_found_returns_error() {
-    let (store, _) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, _) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let err = svc.get_symbol("nonexistent::id#function").unwrap_err();
     match err {
@@ -141,8 +144,8 @@ fn get_symbol_not_found_returns_error() {
 
 #[test]
 fn get_symbol_empty_id_returns_not_found() {
-    let (store, _) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, _) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let err = svc.get_symbol("").unwrap_err();
     assert!(matches!(err, QueryError::NotFound { .. }));
@@ -152,8 +155,8 @@ fn get_symbol_empty_id_returns_not_found() {
 
 #[test]
 fn get_symbols_returns_all_found() {
-    let (store, symbols) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, symbols) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let ids: Vec<&str> = symbols.iter().map(|s| s.id.as_str()).collect();
     let results = svc.get_symbols(&ids).unwrap();
@@ -162,8 +165,8 @@ fn get_symbols_returns_all_found() {
 
 #[test]
 fn get_symbols_skips_missing_ids() {
-    let (store, symbols) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, symbols) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let ids = vec![symbols[0].id.as_str(), "missing::id#function"];
     let results = svc.get_symbols(&ids).unwrap();
@@ -173,8 +176,8 @@ fn get_symbols_skips_missing_ids() {
 
 #[test]
 fn get_symbols_empty_input_returns_empty() {
-    let (store, _) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, _) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let results = svc.get_symbols(&[]).unwrap();
     assert!(results.is_empty());
@@ -182,8 +185,8 @@ fn get_symbols_empty_input_returns_empty() {
 
 #[test]
 fn get_symbols_all_missing_returns_empty() {
-    let (store, _) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, _) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let results = svc
         .get_symbols(&["missing::a#function", "missing::b#type"])
@@ -193,8 +196,8 @@ fn get_symbols_all_missing_returns_empty() {
 
 #[test]
 fn get_symbols_preserves_request_order() {
-    let (store, symbols) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, symbols) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     // Request in reverse order.
     let ids = vec![symbols[2].id.as_str(), symbols[0].id.as_str()];
@@ -206,8 +209,8 @@ fn get_symbols_preserves_request_order() {
 
 #[test]
 fn get_symbols_duplicate_ids_returns_duplicates() {
-    let (store, symbols) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, symbols) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let ids = vec![symbols[0].id.as_str(), symbols[0].id.as_str()];
     let results = svc.get_symbols(&ids).unwrap();
@@ -217,8 +220,8 @@ fn get_symbols_duplicate_ids_returns_duplicates() {
 
 #[test]
 fn get_symbol_deterministic_across_calls() {
-    let (store, symbols) = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir, symbols) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let r1 = svc.get_symbol(&symbols[0].id).unwrap();
     let r2 = svc.get_symbol(&symbols[0].id).unwrap();

--- a/crates/query-engine/tests/outline_integration.rs
+++ b/crates/query-engine/tests/outline_integration.rs
@@ -11,8 +11,9 @@ use query_engine::{
     RepoOutlineRequest, StoreQueryService,
 };
 use store::MetadataStore;
+use tempfile::TempDir;
 
-fn seed_store() -> MetadataStore {
+fn seed_store() -> (MetadataStore, store::BlobStore, TempDir) {
     let store = MetadataStore::open_in_memory().unwrap();
 
     store
@@ -33,21 +34,26 @@ fn seed_store() -> MetadataStore {
         })
         .unwrap();
 
+    let blob_dir = TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+
     let files = vec![
-        ("src/lib.rs", "rust", 3),
-        ("src/server.rs", "rust", 2),
-        ("src/util/helpers.rs", "rust", 0),
-        ("Cargo.toml", "toml", 0),
+        ("src/lib.rs", "rust", 3, "pub fn run() {}\n"),
+        ("src/server.rs", "rust", 2, "pub fn handle() {}\n"),
+        ("src/util/helpers.rs", "rust", 0, "// helpers\n"),
+        ("Cargo.toml", "toml", 0, "[package]\nname = \"test\"\n"),
     ];
 
-    for (path, lang, sym_count) in &files {
+    for (path, lang, sym_count, content) in &files {
+        let hash = store::content_hash(content.as_bytes());
+        blob_store.put(content.as_bytes()).unwrap();
         store
             .files()
             .upsert(&FileRecord {
                 repo_id: "repo-1".into(),
                 file_path: (*path).into(),
                 language: (*lang).into(),
-                file_hash: format!("sha256:{path}"),
+                file_hash: hash,
                 summary: format!("{path} source file"),
                 symbol_count: *sym_count,
                 quality_mix: QualityMix {
@@ -82,7 +88,7 @@ fn seed_store() -> MetadataStore {
             .unwrap();
     }
 
-    store
+    (store, blob_store, blob_dir)
 }
 
 fn make_symbol(name: &str, kind: SymbolKind, file_path: &str) -> SymbolRecord {
@@ -119,8 +125,8 @@ fn make_symbol(name: &str, kind: SymbolKind, file_path: &str) -> SymbolRecord {
 
 #[test]
 fn file_outline_returns_file_and_symbols() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let outline = svc
         .get_file_outline(&FileOutlineRequest {
@@ -136,8 +142,8 @@ fn file_outline_returns_file_and_symbols() {
 
 #[test]
 fn file_outline_symbols_belong_to_requested_file() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let outline = svc
         .get_file_outline(&FileOutlineRequest {
@@ -154,8 +160,8 @@ fn file_outline_symbols_belong_to_requested_file() {
 
 #[test]
 fn file_outline_empty_file_returns_no_symbols() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let outline = svc
         .get_file_outline(&FileOutlineRequest {
@@ -170,8 +176,8 @@ fn file_outline_empty_file_returns_no_symbols() {
 
 #[test]
 fn file_outline_not_found() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let err = svc
         .get_file_outline(&FileOutlineRequest {
@@ -188,8 +194,8 @@ fn file_outline_not_found() {
 
 #[test]
 fn file_outline_wrong_repo_not_found() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let err = svc
         .get_file_outline(&FileOutlineRequest {
@@ -203,8 +209,8 @@ fn file_outline_wrong_repo_not_found() {
 
 #[test]
 fn file_outline_deterministic_across_calls() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let req = FileOutlineRequest {
         repo_id: "repo-1".into(),
         file_path: "src/lib.rs".into(),
@@ -221,9 +227,9 @@ fn file_outline_deterministic_across_calls() {
 // ── get_file_content ───────────────────────────────────────────────────
 
 #[test]
-fn file_content_returns_file_record() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+fn file_content_returns_file_record_and_content() {
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc
         .get_file_content(&FileContentRequest {
@@ -234,12 +240,16 @@ fn file_content_returns_file_record() {
 
     assert_eq!(result.file.file_path, "src/lib.rs");
     assert_eq!(result.file.language, "rust");
+    assert!(
+        result.content.contains("pub fn run()"),
+        "content should contain actual source code"
+    );
 }
 
 #[test]
 fn file_content_not_found() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let err = svc
         .get_file_content(&FileContentRequest {
@@ -255,8 +265,8 @@ fn file_content_not_found() {
 
 #[test]
 fn file_tree_returns_all_files() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let tree = svc
         .get_file_tree(&FileTreeRequest {
@@ -270,8 +280,8 @@ fn file_tree_returns_all_files() {
 
 #[test]
 fn file_tree_filters_by_prefix() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let tree = svc
         .get_file_tree(&FileTreeRequest {
@@ -288,8 +298,8 @@ fn file_tree_filters_by_prefix() {
 
 #[test]
 fn file_tree_nested_prefix() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let tree = svc
         .get_file_tree(&FileTreeRequest {
@@ -304,8 +314,8 @@ fn file_tree_nested_prefix() {
 
 #[test]
 fn file_tree_no_match_prefix_returns_empty() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let tree = svc
         .get_file_tree(&FileTreeRequest {
@@ -319,8 +329,8 @@ fn file_tree_no_match_prefix_returns_empty() {
 
 #[test]
 fn file_tree_wrong_repo_returns_empty() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let tree = svc
         .get_file_tree(&FileTreeRequest {
@@ -334,8 +344,8 @@ fn file_tree_wrong_repo_returns_empty() {
 
 #[test]
 fn file_tree_entries_carry_language_and_symbol_count() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let tree = svc
         .get_file_tree(&FileTreeRequest {
@@ -355,8 +365,8 @@ fn file_tree_entries_carry_language_and_symbol_count() {
 
 #[test]
 fn file_tree_order_is_deterministic() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let req = FileTreeRequest {
         repo_id: "repo-1".into(),
         path_prefix: None,
@@ -374,8 +384,8 @@ fn file_tree_order_is_deterministic() {
 
 #[test]
 fn repo_outline_returns_repo_and_all_files() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let outline = svc
         .get_repo_outline(&RepoOutlineRequest {
@@ -391,8 +401,8 @@ fn repo_outline_returns_repo_and_all_files() {
 
 #[test]
 fn repo_outline_carries_language_counts() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let outline = svc
         .get_repo_outline(&RepoOutlineRequest {
@@ -406,8 +416,8 @@ fn repo_outline_carries_language_counts() {
 
 #[test]
 fn repo_outline_not_found() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let err = svc
         .get_repo_outline(&RepoOutlineRequest {
@@ -423,8 +433,8 @@ fn repo_outline_not_found() {
 
 #[test]
 fn repo_outline_deterministic_across_calls() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let req = RepoOutlineRequest {
         repo_id: "repo-1".into(),
     };

--- a/crates/query-engine/tests/perf_thresholds.rs
+++ b/crates/query-engine/tests/perf_thresholds.rs
@@ -52,7 +52,9 @@ impl AdapterRouter for TreeSitterRouter {
 // Fixture setup
 // ---------------------------------------------------------------------------
 
-fn setup_populated_store(file_count: usize) -> (store::MetadataStore, TempDir, TempDir) {
+fn setup_populated_store(
+    file_count: usize,
+) -> (store::MetadataStore, store::BlobStore, TempDir, TempDir) {
     let repo_dir = TempDir::new().expect("create temp dir");
     let src = repo_dir.path().join("src");
     fs::create_dir_all(&src).expect("create src dir");
@@ -88,7 +90,7 @@ fn setup_populated_store(file_count: usize) -> (store::MetadataStore, TempDir, T
 
     run(&ctx, &mut db, &blob_store).expect("index should succeed");
 
-    (db, repo_dir, blob_dir)
+    (db, blob_store, repo_dir, blob_dir)
 }
 
 /// Runs `op` `n` times, returning all durations sorted.
@@ -115,8 +117,8 @@ fn p95(sorted: &[std::time::Duration]) -> std::time::Duration {
 
 #[test]
 fn search_symbols_p95_under_threshold() {
-    let (db, _repo, _blob) = setup_populated_store(50);
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     // Warm-up.
     for _ in 0..5 {
@@ -157,8 +159,8 @@ fn search_symbols_p95_under_threshold() {
 
 #[test]
 fn get_symbol_p95_under_threshold() {
-    let (db, _repo, _blob) = setup_populated_store(50);
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     // Find a real symbol ID.
     let result = svc
@@ -198,8 +200,8 @@ fn get_symbol_p95_under_threshold() {
 
 #[test]
 fn file_outline_p95_under_threshold() {
-    let (db, _repo, _blob) = setup_populated_store(50);
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let latencies = measure_latencies(
         || {
@@ -226,8 +228,8 @@ fn file_outline_p95_under_threshold() {
 
 #[test]
 fn file_tree_p95_under_threshold() {
-    let (db, _repo, _blob) = setup_populated_store(50);
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let latencies = measure_latencies(
         || {
@@ -254,8 +256,8 @@ fn file_tree_p95_under_threshold() {
 
 #[test]
 fn repo_outline_p95_under_threshold() {
-    let (db, _repo, _blob) = setup_populated_store(50);
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let latencies = measure_latencies(
         || {
@@ -281,8 +283,8 @@ fn repo_outline_p95_under_threshold() {
 
 #[test]
 fn search_text_p95_under_threshold() {
-    let (db, _repo, _blob) = setup_populated_store(50);
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _repo, _blob) = setup_populated_store(50);
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     let latencies = measure_latencies(
         || {

--- a/crates/query-engine/tests/search_symbols_integration.rs
+++ b/crates/query-engine/tests/search_symbols_integration.rs
@@ -8,8 +8,9 @@ use core_model::{
 };
 use query_engine::{QueryError, QueryFilters, QueryService, StoreQueryService, SymbolQuery};
 use store::MetadataStore;
+use tempfile::TempDir;
 
-fn seed_store() -> MetadataStore {
+fn seed_store() -> (MetadataStore, store::BlobStore, TempDir) {
     let store = MetadataStore::open_in_memory().unwrap();
 
     store
@@ -101,7 +102,9 @@ fn seed_store() -> MetadataStore {
         store.symbols().upsert(sym).unwrap();
     }
 
-    store
+    let blob_dir = TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+    (store, blob_store, blob_dir)
 }
 
 fn make_symbol(
@@ -144,8 +147,8 @@ fn make_symbol(
 
 #[test]
 fn empty_query_is_rejected() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let err = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -160,8 +163,8 @@ fn empty_query_is_rejected() {
 
 #[test]
 fn exact_name_match_ranks_first() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -181,8 +184,8 @@ fn exact_name_match_ranks_first() {
 
 #[test]
 fn exact_match_scores_higher_than_partial() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -213,8 +216,8 @@ fn exact_match_scores_higher_than_partial() {
 
 #[test]
 fn filter_by_kind() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -236,8 +239,8 @@ fn filter_by_kind() {
 
 #[test]
 fn filter_by_file_path() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -259,8 +262,8 @@ fn filter_by_file_path() {
 
 #[test]
 fn filter_by_quality_level() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -282,8 +285,8 @@ fn filter_by_quality_level() {
 
 #[test]
 fn truncation_metadata_when_limit_exceeded() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -301,8 +304,8 @@ fn truncation_metadata_when_limit_exceeded() {
 
 #[test]
 fn no_truncation_when_all_fit() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -318,8 +321,8 @@ fn no_truncation_when_all_fit() {
 
 #[test]
 fn deterministic_ordering_on_ties() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let query = SymbolQuery {
         repo_id: "repo-1".into(),
         text: "run".into(),
@@ -338,8 +341,8 @@ fn deterministic_ordering_on_ties() {
 
 #[test]
 fn no_match_returns_empty() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -357,8 +360,8 @@ fn no_match_returns_empty() {
 
 #[test]
 fn wrong_repo_returns_empty() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "nonexistent-repo".into(),
@@ -374,8 +377,8 @@ fn wrong_repo_returns_empty() {
 
 #[test]
 fn keyword_match_surfaces_symbol() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -398,8 +401,8 @@ fn keyword_match_surfaces_symbol() {
 
 #[test]
 fn results_carry_quality_and_confidence() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -420,8 +423,8 @@ fn results_carry_quality_and_confidence() {
 
 #[test]
 fn semantic_quality_boosts_ranking() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
     let result = svc
         .search_symbols(&SymbolQuery {
             repo_id: "repo-1".into(),
@@ -441,8 +444,8 @@ fn semantic_quality_boosts_ranking() {
 
 #[test]
 fn offset_skips_results() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let full = svc
         .search_symbols(&SymbolQuery {

--- a/crates/query-engine/tests/search_text_integration.rs
+++ b/crates/query-engine/tests/search_text_integration.rs
@@ -8,8 +8,9 @@ use core_model::{
 };
 use query_engine::{QueryError, QueryFilters, QueryService, StoreQueryService, TextQuery};
 use store::MetadataStore;
+use tempfile::TempDir;
 
-fn seed_store() -> MetadataStore {
+fn seed_store() -> (MetadataStore, store::BlobStore, TempDir) {
     let store = MetadataStore::open_in_memory().unwrap();
 
     store
@@ -96,7 +97,9 @@ fn seed_store() -> MetadataStore {
         store.symbols().upsert(sym).unwrap();
     }
 
-    store
+    let blob_dir = TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+    (store, blob_store, blob_dir)
 }
 
 fn make_symbol(
@@ -150,8 +153,8 @@ fn query(pattern: &str) -> TextQuery {
 
 #[test]
 fn search_text_matches_by_name() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("parse_config")).unwrap();
     assert!(!result.items.is_empty());
@@ -163,8 +166,8 @@ fn search_text_matches_by_name() {
 
 #[test]
 fn search_text_matches_by_docstring() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("TOML configuration")).unwrap();
     assert!(!result.items.is_empty());
@@ -176,8 +179,8 @@ fn search_text_matches_by_docstring() {
 
 #[test]
 fn search_text_matches_by_keyword() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("networking")).unwrap();
     assert!(!result.items.is_empty());
@@ -189,8 +192,8 @@ fn search_text_matches_by_keyword() {
 
 #[test]
 fn search_text_matches_by_signature() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("Request Response")).unwrap();
     assert!(!result.items.is_empty());
@@ -198,8 +201,8 @@ fn search_text_matches_by_signature() {
 
 #[test]
 fn search_text_matches_by_qualified_name() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("crate validate_input")).unwrap();
     assert!(!result.items.is_empty());
@@ -213,8 +216,8 @@ fn search_text_matches_by_qualified_name() {
 
 #[test]
 fn search_text_empty_query_rejected() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let err = svc
         .search_text(&TextQuery {
@@ -231,8 +234,8 @@ fn search_text_empty_query_rejected() {
 
 #[test]
 fn search_text_no_match_returns_empty() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc
         .search_text(&query("xyzzy_completely_unrelated"))
@@ -244,8 +247,8 @@ fn search_text_no_match_returns_empty() {
 
 #[test]
 fn search_text_wrong_repo_returns_empty() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc
         .search_text(&TextQuery {
@@ -264,8 +267,8 @@ fn search_text_wrong_repo_returns_empty() {
 
 #[test]
 fn search_text_results_carry_symbol_record() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("HttpServer")).unwrap();
     assert!(!result.items.is_empty());
@@ -281,8 +284,8 @@ fn search_text_results_carry_symbol_record() {
 
 #[test]
 fn search_text_results_include_line_number() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("parse_config")).unwrap();
     assert!(!result.items.is_empty());
@@ -292,8 +295,8 @@ fn search_text_results_include_line_number() {
 
 #[test]
 fn search_text_results_include_signature_as_line_content() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("parse_config")).unwrap();
     let hit = result
@@ -308,8 +311,8 @@ fn search_text_results_include_signature_as_line_content() {
 
 #[test]
 fn search_text_truncation_metadata() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     // "http" appears in keywords of both HttpServer and handle_request.
     let result = svc
@@ -329,8 +332,8 @@ fn search_text_truncation_metadata() {
 
 #[test]
 fn search_text_offset_pagination() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let full = svc.search_text(&query("http")).unwrap();
 
@@ -351,8 +354,8 @@ fn search_text_offset_pagination() {
 
 #[test]
 fn search_text_deterministic_ordering() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let r1 = svc.search_text(&query("http")).unwrap();
     let r2 = svc.search_text(&query("http")).unwrap();
@@ -411,7 +414,9 @@ fn fts_index_updated_on_symbol_insert() {
         })
         .unwrap();
 
-    let svc = StoreQueryService::new(&store);
+    let blob_dir2 = TempDir::new().unwrap();
+    let blob_store2 = store::BlobStore::open(&blob_dir2.path().join("blobs")).unwrap();
+    let svc = StoreQueryService::new(&store, &blob_store2);
 
     // Before insert: no results.
     let before = svc.search_text(&TextQuery {
@@ -474,8 +479,8 @@ fn fts_index_updated_on_symbol_insert() {
 
 #[test]
 fn fts_index_updated_on_symbol_delete() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     // Confirm match exists before delete.
     let before = svc.search_text(&query("parse_config")).unwrap();
@@ -493,8 +498,8 @@ fn fts_index_updated_on_symbol_delete() {
 
 #[test]
 fn search_text_malformed_fts_syntax_does_not_error() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     // FTS5 operators and special chars are normalized, not passed raw.
     // This must not produce an FTS5 syntax error.
@@ -511,8 +516,8 @@ fn search_text_malformed_fts_syntax_does_not_error() {
 
 #[test]
 fn search_text_only_special_chars_returns_empty() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     let result = svc.search_text(&query("*** ---")).unwrap();
     assert!(result.items.is_empty());
@@ -520,8 +525,8 @@ fn search_text_only_special_chars_returns_empty() {
 
 #[test]
 fn search_text_bare_fts_operator_does_not_error() {
-    let store = seed_store();
-    let svc = StoreQueryService::new(&store);
+    let (store, blob_store, _blob_dir) = seed_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
 
     // Bare FTS5 operators are lowercased to plain terms, not syntax errors.
     for op in ["OR", "AND", "NOT", "NEAR", "AND NOT"] {
@@ -605,7 +610,7 @@ struct HttpServer {
         assert!(result.metrics.symbols_extracted >= 2);
 
         // 3. Query via search_text and verify FTS index was populated.
-        let svc = StoreQueryService::new(&db);
+        let svc = StoreQueryService::new(&db, &blob_store);
 
         let config_results = svc
             .search_text(&TextQuery {

--- a/crates/query-engine/tests/span_emission.rs
+++ b/crates/query-engine/tests/span_emission.rs
@@ -98,7 +98,9 @@ fn store_query_service_emits_spans() {
     let subscriber = tracing_subscriber::registry().with(layer);
 
     let db = store::MetadataStore::open_in_memory().unwrap();
-    let svc = StoreQueryService::new(&db);
+    let blob_dir = tempfile::TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     tracing::subscriber::with_default(subscriber, || {
         // These will return errors/empty results but still emit spans.
@@ -163,7 +165,9 @@ fn query_spans_nest_under_caller_parent() {
     let subscriber = tracing_subscriber::registry().with(layer);
 
     let db = store::MetadataStore::open_in_memory().unwrap();
-    let svc = StoreQueryService::new(&db);
+    let blob_dir = tempfile::TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     tracing::subscriber::with_default(subscriber, || {
         // Simulate an outer request span (like mcp_tool_call).
@@ -207,7 +211,9 @@ fn each_query_call_gets_independent_span() {
     let subscriber = tracing_subscriber::registry().with(layer);
 
     let db = store::MetadataStore::open_in_memory().unwrap();
-    let svc = StoreQueryService::new(&db);
+    let blob_dir = tempfile::TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     tracing::subscriber::with_default(subscriber, || {
         let _ = svc.get_symbol("id-1");
@@ -240,7 +246,9 @@ fn query_spans_do_not_capture_raw_query_text() {
     let subscriber = tracing_subscriber::registry().with(layer);
 
     let db = store::MetadataStore::open_in_memory().unwrap();
-    let svc = StoreQueryService::new(&db);
+    let blob_dir = tempfile::TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+    let svc = StoreQueryService::new(&db, &blob_store);
 
     tracing::subscriber::with_default(subscriber, || {
         let _ = svc.search_symbols(&SymbolQuery {

--- a/crates/server-mcp/tests/e2e_integration.rs
+++ b/crates/server-mcp/tests/e2e_integration.rs
@@ -39,7 +39,14 @@ impl AdapterRouter for TestRouter {
 }
 
 /// Indexes a fixture repo and returns the store for querying.
-fn indexed_store() -> (store::MetadataStore, TempDir) {
+fn indexed_store() -> (store::MetadataStore, store::BlobStore, TempDir, TempDir) {
+    let (db, blob_store, blob_dir, repo_dir) = indexed_store_with_blobs();
+    (db, blob_store, blob_dir, repo_dir)
+}
+
+/// Indexes a fixture repo and returns the store, blob store, blob dir, and repo dir
+/// for tests that need blob-backed file content retrieval.
+fn indexed_store_with_blobs() -> (store::MetadataStore, store::BlobStore, TempDir, TempDir) {
     let repo_dir = TempDir::new().expect("repo temp dir");
     let src = repo_dir.path().join("src");
     std::fs::create_dir_all(&src).expect("create src dir");
@@ -86,15 +93,15 @@ fn indexed_store() -> (store::MetadataStore, TempDir) {
         "fixture repo should produce symbols"
     );
 
-    (db, repo_dir)
+    (db, blob_store, blob_dir, repo_dir)
 }
 
 // ── search_symbols E2E ───────────────────────────────────────────────────
 
 #[test]
 fn e2e_search_symbols_finds_indexed_function() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -110,8 +117,8 @@ fn e2e_search_symbols_finds_indexed_function() {
 
 #[test]
 fn e2e_search_symbols_no_match_returns_empty() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -125,8 +132,8 @@ fn e2e_search_symbols_no_match_returns_empty() {
 
 #[test]
 fn e2e_search_symbols_empty_query_error() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -139,8 +146,8 @@ fn e2e_search_symbols_empty_query_error() {
 
 #[test]
 fn e2e_search_symbols_with_kind_filter() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -157,8 +164,8 @@ fn e2e_search_symbols_with_kind_filter() {
 
 #[test]
 fn e2e_search_symbols_with_limit() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -175,8 +182,8 @@ fn e2e_search_symbols_with_limit() {
 
 #[test]
 fn e2e_get_symbol_retrieves_by_id() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     // First search to get a real ID.
@@ -198,8 +205,8 @@ fn e2e_get_symbol_retrieves_by_id() {
 
 #[test]
 fn e2e_get_symbol_not_found() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_symbol", json!({ "id": "nonexistent-id" }));
@@ -211,8 +218,8 @@ fn e2e_get_symbol_not_found() {
 
 #[test]
 fn e2e_get_symbols_batch_retrieval() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     // Search to get two real IDs.
@@ -236,8 +243,8 @@ fn e2e_get_symbols_batch_retrieval() {
 
 #[test]
 fn e2e_get_symbols_skips_missing() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let search = reg.call(
@@ -259,8 +266,8 @@ fn e2e_get_symbols_skips_missing() {
 
 #[test]
 fn e2e_get_file_outline_returns_symbols() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -279,8 +286,8 @@ fn e2e_get_file_outline_returns_symbols() {
 
 #[test]
 fn e2e_get_file_outline_not_found() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -295,8 +302,8 @@ fn e2e_get_file_outline_not_found() {
 
 #[test]
 fn e2e_get_file_content_returns_source() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_store_with_blobs();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -306,13 +313,21 @@ fn e2e_get_file_content_returns_source() {
     assert_eq!(resp.status, Status::Success);
     let payload = resp.payload.unwrap();
     assert_eq!(payload["file"]["file_path"], "src/lib.rs");
-    assert!(payload["content"].is_string());
+    let content = payload["content"].as_str().unwrap();
+    assert!(
+        !content.is_empty(),
+        "content should not be empty when blob store is wired"
+    );
+    assert!(
+        content.contains("pub fn greet"),
+        "content should contain the actual source code"
+    );
 }
 
 #[test]
 fn e2e_get_file_content_not_found() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -323,12 +338,34 @@ fn e2e_get_file_content_not_found() {
     assert_eq!(resp.error.unwrap().code, ErrorCode::NotFound);
 }
 
+#[test]
+fn e2e_get_file_content_missing_blob_returns_error() {
+    let (db, _blob_store, _blob_dir, _dir) = indexed_store();
+    // Use a separate empty blob store — the file record exists but
+    // the blob is missing, which is a data integrity error.
+    let empty_blob_dir = TempDir::new().unwrap();
+    let empty_blob_store =
+        store::BlobStore::open(&empty_blob_dir.path().join("blobs")).expect("open blob store");
+    let svc = StoreQueryService::new(&db, &empty_blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_content",
+        json!({ "repo_id": "e2e-repo", "file_path": "src/lib.rs" }),
+    );
+    assert_eq!(
+        resp.status,
+        Status::Error,
+        "missing blob should be an error"
+    );
+}
+
 // ── get_file_tree E2E ────────────────────────────────────────────────────
 
 #[test]
 fn e2e_get_file_tree_returns_all_files() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_file_tree", json!({ "repo_id": "e2e-repo" }));
@@ -339,8 +376,8 @@ fn e2e_get_file_tree_returns_all_files() {
 
 #[test]
 fn e2e_get_file_tree_with_prefix_filter() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -355,8 +392,8 @@ fn e2e_get_file_tree_with_prefix_filter() {
 
 #[test]
 fn e2e_get_file_tree_wrong_repo() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_file_tree", json!({ "repo_id": "unknown-repo" }));
@@ -369,8 +406,8 @@ fn e2e_get_file_tree_wrong_repo() {
 
 #[test]
 fn e2e_get_repo_outline_returns_repo_and_files() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_repo_outline", json!({ "repo_id": "e2e-repo" }));
@@ -384,8 +421,8 @@ fn e2e_get_repo_outline_returns_repo_and_files() {
 
 #[test]
 fn e2e_get_repo_outline_not_found() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_repo_outline", json!({ "repo_id": "unknown-repo" }));
@@ -397,8 +434,8 @@ fn e2e_get_repo_outline_not_found() {
 
 #[test]
 fn e2e_search_text_finds_content() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -413,8 +450,8 @@ fn e2e_search_text_finds_content() {
 
 #[test]
 fn e2e_search_text_empty_pattern_error() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -429,8 +466,8 @@ fn e2e_search_text_empty_pattern_error() {
 
 #[test]
 fn e2e_meta_envelope_present_on_success() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_file_tree", json!({ "repo_id": "e2e-repo" }));
@@ -442,8 +479,8 @@ fn e2e_meta_envelope_present_on_success() {
 
 #[test]
 fn e2e_meta_envelope_present_on_error() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_symbol", json!({ "id": "missing" }));
@@ -453,8 +490,8 @@ fn e2e_meta_envelope_present_on_error() {
 
 #[test]
 fn e2e_meta_quality_stats_from_real_index() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -470,8 +507,8 @@ fn e2e_meta_quality_stats_from_real_index() {
 
 #[test]
 fn e2e_unknown_tool_returns_error() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("nonexistent_tool", json!({}));
@@ -483,8 +520,8 @@ fn e2e_unknown_tool_returns_error() {
 
 #[test]
 fn e2e_error_retryable_flag_is_false_for_invalid_params() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -499,8 +536,8 @@ fn e2e_error_retryable_flag_is_false_for_invalid_params() {
 
 #[test]
 fn e2e_error_retryable_flag_is_false_for_not_found() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call("get_symbol", json!({ "id": "missing" }));
@@ -514,8 +551,8 @@ fn e2e_error_retryable_flag_is_false_for_not_found() {
 
 #[test]
 fn e2e_response_round_trips_through_json() {
-    let (db, _dir) = indexed_store();
-    let svc = StoreQueryService::new(&db);
+    let (db, blob_store, _blob_dir, _dir) = indexed_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
     let reg = ToolRegistry::new(&svc);
 
     let resp = reg.call(
@@ -526,4 +563,122 @@ fn e2e_response_round_trips_through_json() {
     let deserialized: server_mcp::McpResponse =
         serde_json::from_str(&json_str).expect("deserialize");
     assert_eq!(resp, deserialized);
+}
+
+// ── File-only repo E2E (#167) ───────────────────────────────────────────
+
+/// Indexes a repo with only file-only entries (no symbol adapters) and
+/// returns stores for testing file-level query behavior.
+fn indexed_file_only_store() -> (store::MetadataStore, store::BlobStore, TempDir, TempDir) {
+    let repo_dir = TempDir::new().expect("repo temp dir");
+    std::fs::write(repo_dir.path().join("app.py"), "print('hello')\n").expect("write py");
+    std::fs::write(repo_dir.path().join("lib.go"), "package main\n").expect("write go");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let router = TestRouter::new(); // Only Rust adapters — no Python/Go.
+    let ctx = indexer::PipelineContext {
+        repo_id: "file-only-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        router: &router,
+        policy_override: Some(AdapterPolicy::SyntaxOnly),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let result = indexer::run(&ctx, &mut db, &blob_store).expect("indexing should succeed");
+    assert_eq!(result.metrics.files_file_only, 2);
+    assert_eq!(result.metrics.symbols_extracted, 0);
+
+    (db, blob_store, blob_dir, repo_dir)
+}
+
+#[test]
+fn e2e_file_only_repo_file_content_retrieval() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_file_only_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_content",
+        json!({ "repo_id": "file-only-repo", "file_path": "app.py" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["file_path"], "app.py");
+    assert_eq!(payload["file"]["language"], "python");
+    assert_eq!(payload["file"]["symbol_count"], 0);
+    let content = payload["content"].as_str().unwrap();
+    assert!(
+        content.contains("print('hello')"),
+        "should return actual file content for file-only indexed file"
+    );
+}
+
+#[test]
+fn e2e_file_only_repo_file_tree_includes_all_files() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_file_only_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call("get_file_tree", json!({ "repo_id": "file-only-repo" }));
+    assert_eq!(resp.status, Status::Success);
+    let entries = resp.payload.unwrap()["entries"].as_array().unwrap().clone();
+    assert_eq!(
+        entries.len(),
+        2,
+        "both file-only files should appear in tree"
+    );
+}
+
+#[test]
+fn e2e_file_only_repo_file_outline_returns_empty_symbols() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_file_only_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_outline",
+        json!({ "repo_id": "file-only-repo", "file_path": "app.py" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["file_path"], "app.py");
+    let symbols = payload["symbols"].as_array().unwrap();
+    assert!(symbols.is_empty(), "file-only files should have no symbols");
+}
+
+#[test]
+fn e2e_file_only_repo_outline_reflects_file_only_entries() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_file_only_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call("get_repo_outline", json!({ "repo_id": "file-only-repo" }));
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["repo"]["file_count"], 2);
+    assert_eq!(payload["repo"]["symbol_count"], 0);
+    let files = payload["files"].as_array().unwrap();
+    assert_eq!(files.len(), 2);
+    for f in files {
+        assert_eq!(f["symbol_count"], 0);
+    }
+}
+
+#[test]
+fn e2e_file_only_repo_unknown_path_not_found() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_file_only_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_content",
+        json!({ "repo_id": "file-only-repo", "file_path": "nonexistent.py" }),
+    );
+    assert_eq!(resp.status, Status::Error);
+    assert_eq!(resp.error.unwrap().code, ErrorCode::NotFound);
 }

--- a/crates/service/src/routes.rs
+++ b/crates/service/src/routes.rs
@@ -8,7 +8,7 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use query_engine::{QueryService, StoreQueryService};
+use query_engine::StoreQueryService;
 use server_mcp::ToolRegistry;
 
 use crate::state::SharedState;
@@ -97,10 +97,7 @@ pub fn repo_routes() -> Router<SharedState> {
 }
 
 async fn list_repos(State(state): State<SharedState>) -> impl IntoResponse {
-    let result = state.with_db(|db| {
-        let svc = StoreQueryService::new(db);
-        svc.list_repos()
-    });
+    let result = state.with_db(|db| db.repos().list_all());
 
     match result {
         Ok(repos) => {
@@ -267,8 +264,13 @@ async fn tools_call(
     State(state): State<SharedState>,
     Json(req): Json<ToolCallRequest>,
 ) -> impl IntoResponse {
+    let blob_store = store::BlobStore::open(&state.config.blob_path());
     let result = state.with_db(|db| {
-        let svc = StoreQueryService::new(db);
+        let bs = blob_store.as_ref().map_err(|e| store::StoreError::Blob {
+            path: None,
+            reason: format!("failed to open blob store: {e}"),
+        })?;
+        let svc = StoreQueryService::new(db, bs);
         let registry = ToolRegistry::new(&svc);
         Ok::<_, store::StoreError>(registry.call(&req.name, req.arguments.clone()))
     });


### PR DESCRIPTION
## Summary

  - Issue: Closes #167
  - Scope: Wire blob-backed file content retrieval and ensure file-level query surfaces remain useful for repositories that only have file-level indexed artifacts.

  ## Changes

  - Updated StoreQueryService to depend on both MetadataStore and BlobStore.
  - Replaced placeholder get_file_content behavior with real blob-backed content retrieval.
  - Returned an explicit store error when a file record exists but its blob is missing.
  - Wired blob-store access through CLI query commands, direct MCP serving, and service tool calls.
  - Kept file-tree, file-outline, and repo-outline working for file-only indexed repositories.
  - Removed unnecessary blob-store dependency from GET /repos.
  - Expanded integration coverage for:
      - file-content retrieval returning actual source
      - missing-blob behavior surfacing as an error
      - file-only repos returning usable file tree / file outline / repo outline / file content
      - unknown file paths still returning not found

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: get_file_content returns stored content for indexed recognized files
  - [x] Criterion 2: file tree includes file-only indexed files
  - [x] Criterion 3: file outline returns file metadata plus an empty symbol list when no symbols exist
  - [x] Criterion 4: repo outline reflects file-only indexed files in counts and listings
  - [x] Criterion 5: service and MCP query flows work on a recognized-language repo with no current symbol adapter

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional tests run:

  - [x] cargo test -p query-engine --test outline_integration file_content_returns_file_record_and_content -- --nocapture

  Recommended before merge:

  - cargo test -p server-mcp --test e2e_integration -- --nocapture
  - cargo test -p query-engine --test outline_integration -- --nocapture
  - cargo test -p service -- --nocapture

  ## Risk and Mitigation

  - Risk: Blob-backed content retrieval introduces a new failure mode when metadata exists but blob data is missing.
  - Mitigation: The query path now fails explicitly on missing blobs, and tests cover that behavior so data-integrity problems are visible instead of silently returning empty content.

  ## Security/Observability Impact

  - Security: No new external trust boundary; this change reads persisted local blobs already produced by indexing.
  - Logs/Metrics/Tracing: File-content retrieval now exercises the real blob-backed production path; missing blobs surface as explicit store/query errors instead of silent placeholder output.