### PR TITLE
Update metrics, docs, and benchmark guidance for file-level indexing coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ CodeAtlas gives you:
 
 - Fast symbol search across indexed repositories.
 - File and repository structure views.
+- File content retrieval from the local index.
 - Semantic-first extraction where language-native analysis is available.
 - Syntax fallback where semantic runtimes are unavailable.
+- File-level indexing baseline for recognized languages even without symbol adapters.
 - Deterministic outputs suitable for automation and AI tooling.
 
 Today, this repository provides:
@@ -193,8 +195,10 @@ codeatlas repo remove my-app
 
 ## Semantic Adapter Setup
 
-Semantic coverage is optional. Indexing still works without it. For detailed
-diagnosis steps, see the [operations runbook](docs/operations/runbook.md#5-diagnose-semantic-adapter-availability).
+Semantic coverage is optional. Indexing still works without it — recognized
+files are always indexed at the file level (file tree, file content retrieval,
+repo outline) even when no symbol adapter is available. For detailed diagnosis
+steps, see the [operations runbook](docs/operations/runbook.md#5-diagnose-semantic-adapter-availability).
 
 ### TypeScript semantic adapter
 
@@ -516,10 +520,29 @@ Milestones M0-M9 are complete:
 - Security regression coverage for malicious inputs, traversal/symlink escape, malformed files, and resource limits.
 - Benchmark and threshold coverage in CI for discovery, indexing, and query latency regressions.
 
+### Language coverage
+
+CodeAtlas recognizes many languages during discovery (Rust, TypeScript,
+JavaScript, Kotlin, Java, Python, PHP, Go, Ruby, C, C++, C#, Swift, Shell,
+JSON, YAML, TOML, Markdown, SQL, Dockerfile). The indexing depth depends on
+adapter availability:
+
+| Level | Languages | What works |
+|-------|-----------|------------|
+| Semantic + syntax | TypeScript, Kotlin (when runtimes are available) | Symbol search, file outline, file tree, file content, repo outline |
+| Syntax only | Rust | Symbol search, file outline, file tree, file content, repo outline |
+| File-level only | All other recognized languages | File tree, file content, repo outline (zero symbols) |
+| Not indexed | Unrecognized files (`Language::Unknown`) | Excluded at discovery |
+
+File-level indexing is the baseline — every recognized file gets a file record,
+stored content blob, and appears in file tree and repo outline queries. Symbol
+extraction is additive on top of that baseline when adapters are available.
+
 ### What does not exist yet
 
 - Watcher/local file-system triggered update mode.
 - Semantic adapters beyond the current TypeScript and Kotlin implementations.
+- Syntax adapters beyond Rust (other recognized languages are file-level only).
 - Docker packaging for the persistent service.
 - Hosted auth, quotas, and multi-tenant controls.
 - Production observability dashboards and hosted telemetry/export integrations beyond the local CLI baseline.
@@ -538,9 +561,10 @@ dependencies are available, and otherwise fall back to syntax-only parsing.
   - `KOTLIN_BRIDGE_JAR`
   - repo-local `.codeatlas/kotlin-bridge.jar`
 
-If those dependencies are not present, indexing still succeeds with syntax
-adapters and the router keeps the semantic-preferred policy behavior where
-available.
+If those dependencies are not present, indexing still succeeds. Languages with
+syntax adapters fall back to syntax-only extraction. Recognized languages
+without any adapter are still indexed at the file level — file tree, file
+content retrieval, and repo outline remain useful even with zero symbols.
 
 ## Design Principles
 

--- a/crates/cli/src/commands/index.rs
+++ b/crates/cli/src/commands/index.rs
@@ -89,7 +89,7 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     let result = indexer::run(&ctx, &mut db, &blob_store)?;
 
     println!("files_discovered: {}", result.metrics.files_discovered);
-    println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_with_symbols: {}", result.metrics.files_parsed);
     println!("files_file_only: {}", result.metrics.files_file_only);
     println!("files_unchanged: {}", result.metrics.files_unchanged);
     println!("files_deleted: {}", result.metrics.files_deleted);

--- a/crates/cli/src/commands/quality_report.rs
+++ b/crates/cli/src/commands/quality_report.rs
@@ -101,13 +101,23 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     // Repository overview
     println!("Repository: {repo_id}");
     println!(
-        "Files:      {} discovered, {} parsed ({} file-only), {} errored",
+        "Files:      {} discovered, {} with symbols, {} file-only, {} errored",
         result.metrics.files_discovered,
         result.metrics.files_parsed,
         result.metrics.files_file_only,
         result.metrics.files_errored,
     );
     println!("Symbols:    {}", result.metrics.symbols_extracted);
+    let total_indexed = result.metrics.files_parsed + result.metrics.files_file_only;
+    if total_indexed > 0 {
+        println!(
+            "Index coverage: {} of {} discovered files indexed ({} with symbols, {} file-only)",
+            total_indexed,
+            result.metrics.files_discovered,
+            result.metrics.files_parsed,
+            result.metrics.files_file_only,
+        );
+    }
     println!();
 
     // Semantic coverage
@@ -163,43 +173,55 @@ pub fn run(args: &[String]) -> Result<(), CliError> {
     println!("KPI Status");
     println!("----------");
 
-    let mut all_pass = true;
-
+    // Symbol quality KPIs are not applicable when no symbols were extracted.
+    // File-only indexing is useful but should not masquerade as a passing
+    // symbol quality gate.
     if c.total_symbols == 0 {
-        println!("[WARN] No symbols extracted");
-        all_pass = false;
+        if result.metrics.files_file_only > 0 {
+            println!(
+                "[INFO] No symbols extracted ({} files indexed at file level only)",
+                result.metrics.files_file_only
+            );
+            println!("[INFO] Symbol quality KPIs are not applicable for file-only repos");
+        } else {
+            println!("[WARN] No symbols extracted and no files indexed");
+        }
+        println!();
+        println!("Result: NOT APPLICABLE");
     } else {
+        let mut all_pass = true;
+
         println!("[PASS] Symbols extracted: {}", c.total_symbols);
-    }
 
-    if c.avg_confidence >= 0.85 {
-        println!("[PASS] Avg confidence: {:.3} (>= 0.850)", c.avg_confidence);
-    } else if c.total_symbols > 0 {
-        println!(
-            "[WARN] Avg confidence: {:.3} (below 0.850)",
-            c.avg_confidence
-        );
-    }
+        if c.avg_confidence >= 0.85 {
+            println!("[PASS] Avg confidence: {:.3} (>= 0.850)", c.avg_confidence);
+        } else {
+            println!(
+                "[WARN] Avg confidence: {:.3} (below 0.850)",
+                c.avg_confidence
+            );
+        }
 
-    if c.losses == 0 {
-        println!("[PASS] No semantic-vs-syntax losses");
-    } else {
-        println!("[FAIL] {} semantic-vs-syntax losses", c.losses);
-        all_pass = false;
-    }
+        if c.losses == 0 {
+            println!("[PASS] No semantic-vs-syntax losses");
+        } else {
+            println!("[FAIL] {} semantic-vs-syntax losses", c.losses);
+            all_pass = false;
+        }
 
-    if overlap_total > 0 && c.win_rate >= 0.8 {
-        println!("[PASS] Win rate: {:.1}% (>= 80.0%)", c.win_rate * 100.0);
-    } else if overlap_total > 0 {
-        println!("[FAIL] Win rate: {:.1}% (below 80.0%)", c.win_rate * 100.0);
-        all_pass = false;
-    }
+        if overlap_total > 0 && c.win_rate >= 0.8 {
+            println!("[PASS] Win rate: {:.1}% (>= 80.0%)", c.win_rate * 100.0);
+        } else if overlap_total > 0 {
+            println!("[FAIL] Win rate: {:.1}% (below 80.0%)", c.win_rate * 100.0);
+            all_pass = false;
+        }
 
-    println!();
-    if all_pass {
-        println!("Result: PASS");
-    } else {
-        println!("Result: FAIL");
+        println!();
+        if all_pass {
+            println!("Result: PASS");
+        } else {
+            println!("Result: FAIL");
+        }
     }
 
     if !result.file_errors.is_empty() {

--- a/crates/cli/src/commands/repo.rs
+++ b/crates/cli/src/commands/repo.rs
@@ -163,7 +163,7 @@ fn run_add(args: &[String]) -> Result<(), CliError> {
 
     println!("registered: {repo_id}");
     println!("files_discovered: {}", result.metrics.files_discovered);
-    println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_with_symbols: {}", result.metrics.files_parsed);
     println!("files_file_only: {}", result.metrics.files_file_only);
     println!("symbols_extracted: {}", result.metrics.symbols_extracted);
 
@@ -391,7 +391,7 @@ fn run_refresh(args: &[String]) -> Result<(), CliError> {
 
     println!("refreshed: {repo_id}");
     println!("files_discovered: {}", result.metrics.files_discovered);
-    println!("files_parsed: {}", result.metrics.files_parsed);
+    println!("files_with_symbols: {}", result.metrics.files_parsed);
     println!("files_file_only: {}", result.metrics.files_file_only);
     println!("files_unchanged: {}", result.metrics.files_unchanged);
     println!("files_deleted: {}", result.metrics.files_deleted);

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -58,7 +58,7 @@ fn index_command_succeeds_on_valid_repo() {
         "index should succeed.\nstdout: {stdout}\nstderr: {stderr}"
     );
     assert!(stdout.contains("files_discovered:"));
-    assert!(stdout.contains("files_parsed:"));
+    assert!(stdout.contains("files_with_symbols:"));
     assert!(stdout.contains("symbols_extracted:"));
 }
 

--- a/docs/benchmarks/blog-benchmark-kit.md
+++ b/docs/benchmarks/blog-benchmark-kit.md
@@ -18,12 +18,13 @@ Use this kit to collect evidence for:
 
 ## Recommended Repo Matrix
 
-Use 4-6 repositories with distinct characteristics:
+Use 4-7 repositories with distinct characteristics:
 
-- Rust-heavy repo
-- TypeScript repo with `tsserver` available
-- Kotlin repo with JVM bridge available
-- mixed-language application repo
+- Rust-heavy repo (syntax adapter coverage)
+- TypeScript repo with `tsserver` available (semantic adapter coverage)
+- Kotlin repo with JVM bridge available (semantic adapter coverage)
+- mixed-language application repo (mix of symbol-bearing and file-only files)
+- recognized-language repo with no current adapter (e.g. Python, Go — file-level only)
 - medium/large service or app repo
 - repo with frequent small edits for incremental-refresh demos
 
@@ -58,8 +59,9 @@ The script writes CSV outputs under a timestamped directory.
 Collected from `codeatlas quality-report`:
 
 - files discovered
-- files parsed
-- files errored
+- files with symbols (symbol-bearing adapter output)
+- files file-only (indexed without symbols)
+- files errored (real adapter failures)
 - symbols extracted
 - semantic symbols
 - syntax symbols
@@ -69,6 +71,12 @@ Collected from `codeatlas quality-report`:
 - semantic win rate
 - wins, losses, ties
 - final KPI result (`PASS` / `FAIL`)
+
+File-level coverage is a first-class metric. Index coverage
+(`files_with_symbols + files_file_only` as a fraction of `files_discovered`)
+can be derived from the collected columns. A repository can have high index
+coverage (most files indexed) but low symbol coverage (few files have symbol
+adapters). Both numbers are useful for understanding the quality of the index.
 
 ### Query timing metrics
 
@@ -177,14 +185,18 @@ The prompt pair should answer the same question with different context shapes.
 - local-first, not hosted
 - exact token counts vary by model
 - semantic quality depends on adapter availability
+- most recognized languages are currently file-level only (no symbol extraction)
+- symbol search is only useful on languages with working adapters (Rust, TypeScript, Kotlin)
 
 ## Example Claims You Can Back With Data
 
 - "One CodeAtlas service handled N repos with one MCP configuration."
 - "Semantic coverage reached X% on repo Y."
+- "File-level index coverage reached X% on repo Z (a Python/Go repo with no symbol adapter)."
 - "A repo refresh after a small edit was X times faster than a fresh index."
 - "The CodeAtlas-assisted prompt was X% smaller by estimated token count."
 - "Symbol lookup and file-outline queries stayed below X ms on repo Y."
+- "File tree and file content retrieval worked on repo Z even with zero symbol coverage."
 
 ## Run Flow
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -207,12 +207,18 @@ cargo run -p cli -- quality-report <repo-path> --db <db-path> --git-diff
 
 The report includes:
 
+- index coverage: files with symbols vs file-only indexed files
 - semantic vs syntax symbol counts
 - semantic coverage percentage
 - average confidence
 - semantic-vs-syntax win rate from merge outcomes
 - per-adapter contribution breakdown
 - pass/fail summary against KPI thresholds
+
+Note: a repository with zero symbols is not necessarily broken. Recognized
+languages without symbol adapters are indexed at the file level — file tree,
+file content retrieval, and repo outline remain useful. The quality report
+distinguishes file-only indexed files from files with symbol extraction.
 
 ## 7. Diagnose Semantic Adapter Availability
 
@@ -240,6 +246,11 @@ If Kotlin semantic coverage is unexpectedly absent:
 
 If semantic runtimes are missing, indexing should still succeed with syntax
 adapters where policy allows fallback.
+
+If no adapter exists at all for a recognized language, the file is still indexed
+at the file level — it receives a file record and stored content blob, and
+appears in file tree and repo outline queries. This is not an error; it is an
+expected capability boundary.
 
 ## 8. Run the Main Quality Gates Locally
 
@@ -342,10 +353,15 @@ CODEATLAS_OTEL=1 cargo run -p cli -- index <repo-path>
 
 ### No symbols extracted
 
-Check:
+This is expected for repositories in recognized languages that lack symbol
+adapters (e.g. Python, Go, Java without semantic runtimes). File-level indexing
+still provides file tree, file content retrieval, and repo outline.
+
+If you expected symbols, check:
 
 - repo path is valid
 - files are supported by current language detection and adapters
+- the quality report's "files with symbols" vs "file-only" breakdown
 - file errors printed by the CLI
 
 ### Semantic coverage unexpectedly zero
@@ -358,9 +374,11 @@ Check:
 
 ### High file error count
 
+File errors indicate real adapter failures, not missing adapters. Missing
+adapters produce file-only indexed records instead of errors.
+
 Check:
 
-- unsupported languages
 - malformed inputs
 - adapter subprocess startup failures
 - resource or timeout failures

--- a/scripts/blog/collect_blog_metrics.sh
+++ b/scripts/blog/collect_blog_metrics.sh
@@ -137,7 +137,7 @@ collect_repo_metrics() {
   local repo_metrics_csv="$out_dir/repo_metrics.csv"
   local summary_file="$out_dir/summary.txt"
 
-  printf "timestamp,repo_id,repo_path,git_sha,file_count,line_count,files_discovered,files_parsed,files_errored,symbols_extracted,total_symbols,semantic_symbols,syntax_symbols,semantic_coverage_percent,avg_confidence,files_with_semantic,total_files,win_rate,wins,losses,ties,kpi_result,notes\n" >"$repo_metrics_csv"
+  printf "timestamp,repo_id,repo_path,git_sha,file_count,line_count,files_discovered,files_with_symbols,files_file_only,files_errored,symbols_extracted,total_symbols,semantic_symbols,syntax_symbols,semantic_coverage_percent,avg_confidence,files_with_semantic,total_files,win_rate,wins,losses,ties,kpi_result,notes\n" >"$repo_metrics_csv"
 
   local delimiter
   delimiter=$(manifest_delimiter "$repos_csv")
@@ -180,12 +180,14 @@ collect_repo_metrics() {
     symbols_line=$(grep -F "Symbols:" "$repo_tmp" | head -n 1 || true)
 
     local files_discovered
-    local files_parsed
+    local files_with_symbols
+    local files_file_only
     local files_errored
     local symbols_extracted
     files_discovered=$(printf "%s\n" "$files_line" | sed -E 's/.*Files:[[:space:]]*([0-9]+) discovered.*/\1/' )
-    files_parsed=$(printf "%s\n" "$files_line" | sed -E 's/.*discovered, ([0-9]+) parsed.*/\1/' )
-    files_errored=$(printf "%s\n" "$files_line" | sed -E 's/.*parsed, ([0-9]+) errored.*/\1/' )
+    files_with_symbols=$(printf "%s\n" "$files_line" | sed -E 's/.*discovered, ([0-9]+) with symbols.*/\1/' )
+    files_file_only=$(printf "%s\n" "$files_line" | sed -E 's/.*with symbols, ([0-9]+) file-only.*/\1/' )
+    files_errored=$(printf "%s\n" "$files_line" | sed -E 's/.*file-only, ([0-9]+) errored.*/\1/' )
     symbols_extracted=$(printf "%s\n" "$symbols_line" | sed -E 's/.*Symbols:[[:space:]]*([0-9]+).*/\1/' )
 
     local total_symbols
@@ -214,7 +216,7 @@ collect_repo_metrics() {
     ties=$(extract_value_after_colon "Ties:" "$repo_tmp")
     kpi_result=$(grep -F "Result:" "$repo_tmp" | head -n 1 | awk '{print $2}' || true)
 
-    printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n" \
+    printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n" \
       "$(timestamp_utc)" \
       "$(csv_escape "$repo_id")" \
       "$(csv_escape "$repo_path")" \
@@ -222,7 +224,8 @@ collect_repo_metrics() {
       "$file_count" \
       "$line_count" \
       "${files_discovered:-0}" \
-      "${files_parsed:-0}" \
+      "${files_with_symbols:-0}" \
+      "${files_file_only:-0}" \
       "${files_errored:-0}" \
       "${symbols_extracted:-0}" \
       "${total_symbols:-0}" \


### PR DESCRIPTION
## Summary

  - Issue: Closes #165
  - Scope: Update docs, CLI metrics wording, and benchmark guidance so file-level indexing is treated as a first-class baseline without overstating current symbol coverage.

  ## Changes

  - Updated README language and capability guidance to describe file-level indexing as the baseline for all recognized languages.
  - Added a language coverage section to README that distinguishes semantic+syntax, syntax-only, file-level-only, and unrecognized files.
  - Updated CLI output for index, repo add, and repo refresh to label symbol-bearing files as files_with_symbols.
  - Updated quality-report wording to distinguish:
      - files with symbols
      - file-only indexed files
      - real adapter failures
  - Added index coverage reporting to quality-report as a derived file-level metric.
  - Changed zero-symbol quality-report behavior so file-only repos return Result: NOT APPLICABLE instead of misleading PASS.
  - Updated the operations runbook to explain that:
      - zero symbols does not necessarily mean indexing failed
      - missing adapters are expected capability boundaries, not ordinary file errors
      - file tree, file content retrieval, and repo outline remain useful for file-only repos
  - Updated blog benchmark guidance and the metrics collection script to use files_with_symbols and files_file_only, and to describe index coverage as derived from collected columns.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: docs explain that recognized files are indexed even when symbols are unavailable
  - [x] Criterion 2: docs explain which query surfaces remain useful for file-only indexed repos
  - [x] Criterion 3: quality-report wording does not imply that zero symbols means zero index value
  - [x] Criterion 4: benchmark guidance includes file-level coverage as a first-class metric
  - [x] Criterion 5: docs remain honest about current symbol coverage limits by language

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional checks run:

  - [x] bash -n scripts/blog/collect_blog_metrics.sh
  - [x] cargo test -p cli cli_integration -- --nocapture

  ## Risk and Mitigation

  - Risk: Renaming CLI-facing metrics and changing quality-report result semantics could break downstream scripts or expectations if they relied on old field names or interpreted zero-symbol repos as failures/passes.
  - Mitigation: Updated the benchmark collection script alongside the CLI wording, and made zero-symbol/file-only behavior explicit in both docs and quality-report output.

  ## Security/Observability Impact

  - Security: No security boundary changes; this is docs/CLI/reporting work only.
  - Logs/Metrics/Tracing: Improves observability semantics by separating symbol-bearing files from file-only indexed files and by making zero-symbol/file-only repos clearly non-failing but not KPI-passing