### PR TITLE
Implement Java syntax indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tree-sitter",
  "tree-sitter-go",
+ "tree-sitter-java",
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-rust",
@@ -1702,6 +1703,16 @@ name = "tree-sitter-go"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tempfile = "3.20.0"
 time = { version = "0.3.37", features = ["parsing", "formatting"] }
 tree-sitter = "0.25"
 tree-sitter-go = "0.25"
+tree-sitter-java = "0.23"
 tree-sitter-php = "0.24"
 tree-sitter-python = "0.25"
 tree-sitter-rust = "0.24"

--- a/crates/cli/src/router.rs
+++ b/crates/cli/src/router.rs
@@ -16,7 +16,9 @@ use semantic_typescript::adapter::TypeScriptSemanticAdapter;
 use semantic_typescript::config::TsServerConfig;
 use semantic_typescript::process::TsServerProcess;
 use semantic_typescript::runtime::SemanticRuntime;
-use syntax_platform::{GoSyntaxBackend, PhpSyntaxBackend, PythonSyntaxBackend, RustSyntaxBackend};
+use syntax_platform::{
+    GoSyntaxBackend, JavaSyntaxBackend, PhpSyntaxBackend, PythonSyntaxBackend, RustSyntaxBackend,
+};
 use tracing::{debug, info, warn};
 
 /// Builds the production backend registry for the given repository root.
@@ -36,6 +38,9 @@ pub fn build_router(source_root: &Path) -> DefaultBackendRegistry {
 
     let go_id = GoSyntaxBackend::backend_id();
     registry.register_syntax(go_id, Box::new(GoSyntaxBackend::new()));
+
+    let java_id = JavaSyntaxBackend::backend_id();
+    registry.register_syntax(java_id, Box::new(JavaSyntaxBackend::new()));
 
     let php_id = PhpSyntaxBackend::backend_id();
     registry.register_syntax(php_id, Box::new(PhpSyntaxBackend::new()));

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -2595,3 +2595,187 @@ fn go_search_symbols_finds_method() {
         "should find Start method.\nstdout: {stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Java integration tests
+// ---------------------------------------------------------------------------
+
+fn setup_java_test_repo() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let src = dir.path().join("src/main/java");
+    std::fs::create_dir_all(&src).expect("create java dir");
+
+    std::fs::write(
+        src.join("UserController.java"),
+        r#"
+/**
+ * Handles user HTTP requests.
+ */
+public class UserController {
+    public List<User> index() {
+        return null;
+    }
+
+    public User show(Long id) {
+        return null;
+    }
+}
+
+public enum Role {
+    ADMIN,
+    USER;
+}
+"#,
+    )
+    .expect("write java");
+
+    dir
+}
+
+fn indexed_java_test_repo() -> (TempDir, TempDir, String) {
+    let repo_dir = setup_java_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("index.db");
+
+    let index_output = Command::new(codeatlas_bin())
+        .args(["index", repo_dir.path().to_str().unwrap(), "--db"])
+        .arg(&db_path)
+        .output()
+        .expect("index");
+
+    let stdout = String::from_utf8_lossy(&index_output.stdout);
+    let stderr = String::from_utf8_lossy(&index_output.stderr);
+    assert!(
+        index_output.status.success(),
+        "index should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let repo_id = repo_dir
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+
+    (repo_dir, db_dir, repo_id)
+}
+
+#[test]
+fn java_index_discovers_files_with_symbols() {
+    let repo_dir = setup_java_test_repo();
+    let db_dir = TempDir::new().expect("db temp dir");
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args(["index", repo_dir.path().to_str().unwrap(), "--db"])
+        .arg(&db_path)
+        .output()
+        .expect("index");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "index should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(stdout.contains("symbols_extracted:"));
+}
+
+#[test]
+fn java_file_outline_shows_symbols() {
+    let (_repo_dir, db_dir, repo_id) = indexed_java_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "file-outline",
+            "src/main/java/UserController.java",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("file-outline");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "file-outline should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("UserController"),
+        "should show UserController.\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("index"),
+        "should show index method.\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Role"),
+        "should show Role enum.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn java_search_symbols_finds_class() {
+    let (_repo_dir, db_dir, repo_id) = indexed_java_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "search-symbols",
+            "UserController",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("search-symbols");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "search should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("UserController"),
+        "should find UserController.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn java_search_symbols_finds_method() {
+    let (_repo_dir, db_dir, repo_id) = indexed_java_test_repo();
+    let db_path = db_dir.path().join("index.db");
+
+    let output = Command::new(codeatlas_bin())
+        .args([
+            "search-symbols",
+            "show",
+            "--db",
+            db_path.to_str().unwrap(),
+            "--repo",
+            &repo_id,
+        ])
+        .output()
+        .expect("search-symbols");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "search should succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("show"),
+        "should find show method.\nstdout: {stdout}"
+    );
+}

--- a/crates/indexer/tests/pipeline_integration.rs
+++ b/crates/indexer/tests/pipeline_integration.rs
@@ -12,8 +12,9 @@ use indexer::{
     SyntaxPolicy,
 };
 use syntax_platform::{
-    GoSyntaxBackend, PhpSyntaxBackend, PreparedFile, PythonSyntaxBackend, RustSyntaxBackend,
-    SyntaxBackend, SyntaxCapability, SyntaxError, SyntaxExtraction, SyntaxSymbol,
+    GoSyntaxBackend, JavaSyntaxBackend, PhpSyntaxBackend, PreparedFile, PythonSyntaxBackend,
+    RustSyntaxBackend, SyntaxBackend, SyntaxCapability, SyntaxError, SyntaxExtraction,
+    SyntaxSymbol,
 };
 use tempfile::TempDir;
 
@@ -2821,6 +2822,164 @@ fn pipeline_go_mixed_with_rust() {
     assert!(go_file.symbol_count >= 1);
     assert_eq!(
         go_file.capability_tier,
+        core_model::CapabilityTier::SyntaxOnly
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Java syntax backend integration tests
+// ---------------------------------------------------------------------------
+
+fn make_registry_with_java() -> DefaultBackendRegistry {
+    let mut registry = DefaultBackendRegistry::new();
+    registry.register_syntax(
+        RustSyntaxBackend::backend_id(),
+        Box::new(RustSyntaxBackend::new()),
+    );
+    registry.register_syntax(
+        JavaSyntaxBackend::backend_id(),
+        Box::new(JavaSyntaxBackend::new()),
+    );
+    registry
+}
+
+#[test]
+fn pipeline_java_spring_controller_end_to_end() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+    let src = repo_dir.path().join("src/main/java");
+    std::fs::create_dir_all(&src).expect("create java dir");
+
+    std::fs::write(
+        src.join("UserController.java"),
+        r#"
+/**
+ * Handles user HTTP requests.
+ */
+public class UserController {
+    public UserController() {}
+
+    public List<User> index() {
+        return userService.findAll();
+    }
+
+    public User show(Long id) {
+        return userService.findById(id);
+    }
+}
+
+public interface UserService {
+    List<User> findAll();
+}
+
+public enum Role {
+    ADMIN,
+    USER;
+}
+"#,
+    )
+    .expect("write java");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let registry = make_registry_with_java();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "java-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        registry: &registry,
+        dispatch_context: DispatchContext::default(),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+    assert!(result.metrics.files_parsed >= 1);
+    assert!(result.file_errors.is_empty());
+
+    let file = db
+        .files()
+        .get("java-repo", "src/main/java/UserController.java")
+        .expect("query file")
+        .expect("UserController.java file record");
+    assert_eq!(file.language, "java");
+    // UserController class + constructor + index + show + UserService + findAll + Role + ADMIN + USER = 9
+    assert!(
+        file.symbol_count >= 5,
+        "expected at least 5 symbols, got {}",
+        file.symbol_count
+    );
+    assert_eq!(file.capability_tier, core_model::CapabilityTier::SyntaxOnly);
+
+    let symbol_ids = db
+        .symbols()
+        .list_ids_for_file("java-repo", "src/main/java/UserController.java")
+        .expect("list symbols");
+    let all_syms: Vec<_> = symbol_ids
+        .iter()
+        .filter_map(|id| db.symbols().get(id).ok().flatten())
+        .collect();
+
+    let controller = all_syms
+        .iter()
+        .find(|s| s.name == "UserController" && s.kind == SymbolKind::Class)
+        .expect("UserController should exist");
+    assert!(controller.source_backend.contains("syntax-java"));
+
+    let index_method = all_syms
+        .iter()
+        .find(|s| s.name == "index")
+        .expect("index method should exist");
+    assert_eq!(index_method.kind, SymbolKind::Method);
+    assert!(
+        index_method
+            .qualified_name
+            .contains("UserController::index"),
+        "expected qualified name, got: {}",
+        index_method.qualified_name
+    );
+}
+
+#[test]
+fn pipeline_java_mixed_with_rust() {
+    let repo_dir = TempDir::new().expect("create temp dir");
+
+    std::fs::write(
+        repo_dir.path().join("Main.java"),
+        "public class Main {\n    public static void main(String[] args) {}\n}\n",
+    )
+    .expect("write java");
+
+    let src = repo_dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src");
+    std::fs::write(src.join("lib.rs"), "pub fn greet() {}\n").expect("write rs");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store = setup_blob_store(&blob_dir);
+    let registry = make_registry_with_java();
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let ctx = PipelineContext {
+        repo_id: "java-rs-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        registry: &registry,
+        dispatch_context: DispatchContext::default(),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let result = run(&ctx, &mut db, &blob_store).expect("pipeline should succeed");
+    assert!(result.metrics.files_parsed >= 2);
+
+    let java_file = db
+        .files()
+        .get("java-rs-repo", "Main.java")
+        .expect("query java")
+        .expect("Main.java record");
+    assert_eq!(java_file.language, "java");
+    assert!(java_file.symbol_count >= 2); // Main + main method
+    assert_eq!(
+        java_file.capability_tier,
         core_model::CapabilityTier::SyntaxOnly
     );
 }

--- a/crates/syntax-platform/Cargo.toml
+++ b/crates/syntax-platform/Cargo.toml
@@ -10,6 +10,7 @@ core-model.workspace = true
 thiserror = "2"
 tree-sitter.workspace = true
 tree-sitter-go.workspace = true
+tree-sitter-java.workspace = true
 tree-sitter-php.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-rust.workspace = true

--- a/crates/syntax-platform/src/extraction.rs
+++ b/crates/syntax-platform/src/extraction.rs
@@ -29,39 +29,46 @@ fn walk_node(
     // Check if this node is a symbol definition.
     if let Some(mapping) = profile.find_definition(node_type) {
         if let Some(name) = child_text(&node, mapping.name_field, source) {
-            let kind = if mapping.kind == SymbolKind::Function && is_method_context(&node) {
-                SymbolKind::Method
+            // Check modifier requirements (e.g. Java `static final` fields).
+            if !mapping.requires_modifiers.is_empty()
+                && !check_ancestor_modifiers(&node, mapping.requires_modifiers, source)
+            {
+                // Modifiers not satisfied — skip this node but continue walking children.
             } else {
-                mapping.kind
-            };
-
-            // Check for receiver-based parent (e.g. Go methods).
-            let receiver_type = profile
-                .find_method_receiver(node_type)
-                .and_then(|rm| extract_receiver_type(&node, rm.receiver_field, source));
-
-            let (qualified_name, parent) = if let Some(ref recv) = receiver_type {
-                let qn = format!("{recv}::{name}");
-                (qn, Some(recv.clone()))
-            } else {
-                let qn = build_qualified_name(scope_stack, &name);
-                let p = if scope_stack.is_empty() {
-                    None
+                let kind = if mapping.kind == SymbolKind::Function && is_method_context(&node) {
+                    SymbolKind::Method
                 } else {
-                    Some(scope_stack.join("::"))
+                    mapping.kind
                 };
-                (qn, p)
-            };
 
-            symbols.push(SyntaxSymbol {
-                name,
-                qualified_name,
-                kind,
-                span: node_to_span(&node),
-                signature: extract_signature(&node, source),
-                docstring: extract_docstring(&node, source),
-                parent_qualified_name: parent,
-            });
+                // Check for receiver-based parent (e.g. Go methods).
+                let receiver_type = profile
+                    .find_method_receiver(node_type)
+                    .and_then(|rm| extract_receiver_type(&node, rm.receiver_field, source));
+
+                let (qualified_name, parent) = if let Some(ref recv) = receiver_type {
+                    let qn = format!("{recv}::{name}");
+                    (qn, Some(recv.clone()))
+                } else {
+                    let qn = build_qualified_name(scope_stack, &name);
+                    let p = if scope_stack.is_empty() {
+                        None
+                    } else {
+                        Some(scope_stack.join("::"))
+                    };
+                    (qn, p)
+                };
+
+                symbols.push(SyntaxSymbol {
+                    name,
+                    qualified_name,
+                    kind,
+                    span: node_to_span(&node),
+                    signature: extract_signature(&node, source),
+                    docstring: extract_docstring(&node, source),
+                    parent_qualified_name: parent,
+                });
+            } // else (modifier check)
         }
     }
 
@@ -88,10 +95,8 @@ fn walk_node(
             // A sticky scope applies to all subsequent siblings. When we
             // encounter a new one, replace the previous sticky scope.
             if let Some(sticky) = profile.find_sticky_scope(child.kind()) {
-                if let Some(name) = child
-                    .child_by_field_name(sticky.name_field)
-                    .and_then(|n| n.utf8_text(source).ok())
-                    .map(normalize_scope_separator)
+                if let Some(name) = child_text(&child, sticky.name_field, source)
+                    .map(|s| normalize_scope_separator(&s))
                 {
                     // Only treat as sticky when the node has no body
                     // (statement form). Braced namespaces with a body are
@@ -129,6 +134,39 @@ fn walk_node(
     if pushed_scope {
         scope_stack.pop();
     }
+}
+
+/// Checks whether a node or its parent has a `modifiers` child containing
+/// all required keywords (e.g. `["static", "final"]` for Java constants).
+fn check_ancestor_modifiers(node: &Node, required: &[&str], source: &[u8]) -> bool {
+    // Check the node itself and its parent for a `modifiers` child.
+    for n in [Some(*node), node.parent()].into_iter().flatten() {
+        if let Some(mods) = n.child_by_field_name("modifiers") {
+            if let Ok(text) = mods.utf8_text(source) {
+                if required.iter().all(|kw| text.contains(kw)) {
+                    return true;
+                }
+            }
+        }
+        // Also check unnamed children of type "modifiers".
+        let mut cursor = n.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                if child.kind() == "modifiers" {
+                    if let Ok(text) = child.utf8_text(source) {
+                        if required.iter().all(|kw| text.contains(kw)) {
+                            return true;
+                        }
+                    }
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Returns `true` if a function node is inside a class, impl, or trait body.
@@ -188,9 +226,11 @@ fn extract_receiver_type(node: &Node, receiver_field: &str, source: &[u8]) -> Op
     }
 }
 
-/// Replaces language-specific namespace separators (e.g. PHP `\`) with `::`.
+/// Replaces language-specific namespace separators with `::`.
+///
+/// Handles PHP `\` and Java `.` separators.
 fn normalize_scope_separator(raw: &str) -> String {
-    raw.replace('\\', "::")
+    raw.replace(['\\', '.'], "::")
 }
 
 fn build_qualified_name(scope_stack: &[String], name: &str) -> String {

--- a/crates/syntax-platform/src/languages/go.rs
+++ b/crates/syntax-platform/src/languages/go.rs
@@ -11,6 +11,7 @@ static GO_DEFINITIONS: &[NodeMapping] = &[
         node_type: "function_declaration",
         kind: SymbolKind::Function,
         name_field: "name",
+        requires_modifiers: &[],
     },
     // Go has a dedicated `method_declaration` node with a receiver.
     // Mapped directly to Method; receiver-based parent is handled by
@@ -19,6 +20,7 @@ static GO_DEFINITIONS: &[NodeMapping] = &[
         node_type: "method_declaration",
         kind: SymbolKind::Method,
         name_field: "name",
+        requires_modifiers: &[],
     },
     // `type_spec` is the inner node of `type_declaration`. It carries
     // the name and the underlying type (struct, interface, alias, etc.).
@@ -26,12 +28,14 @@ static GO_DEFINITIONS: &[NodeMapping] = &[
         node_type: "type_spec",
         kind: SymbolKind::Type,
         name_field: "name",
+        requires_modifiers: &[],
     },
     // `const_spec` is the inner node of `const_declaration`.
     NodeMapping {
         node_type: "const_spec",
         kind: SymbolKind::Constant,
         name_field: "name",
+        requires_modifiers: &[],
     },
 ];
 

--- a/crates/syntax-platform/src/languages/java.rs
+++ b/crates/syntax-platform/src/languages/java.rs
@@ -1,0 +1,101 @@
+use core_model::SymbolKind;
+
+use super::{LanguageProfile, NodeMapping, ScopeMapping, StickyScopeMapping};
+
+fn java_language() -> tree_sitter::Language {
+    tree_sitter_java::LANGUAGE.into()
+}
+
+static JAVA_DEFINITIONS: &[NodeMapping] = &[
+    NodeMapping {
+        node_type: "class_declaration",
+        kind: SymbolKind::Class,
+        name_field: "name",
+        requires_modifiers: &[],
+    },
+    NodeMapping {
+        node_type: "interface_declaration",
+        kind: SymbolKind::Type,
+        name_field: "name",
+        requires_modifiers: &[],
+    },
+    NodeMapping {
+        node_type: "enum_declaration",
+        kind: SymbolKind::Type,
+        name_field: "name",
+        requires_modifiers: &[],
+    },
+    // Java records are value-based classes.
+    NodeMapping {
+        node_type: "record_declaration",
+        kind: SymbolKind::Class,
+        name_field: "name",
+        requires_modifiers: &[],
+    },
+    // Methods are always inside a class/interface/enum body.
+    NodeMapping {
+        node_type: "method_declaration",
+        kind: SymbolKind::Method,
+        name_field: "name",
+        requires_modifiers: &[],
+    },
+    NodeMapping {
+        node_type: "constructor_declaration",
+        kind: SymbolKind::Method,
+        name_field: "name",
+        requires_modifiers: &[],
+    },
+    NodeMapping {
+        node_type: "enum_constant",
+        kind: SymbolKind::Constant,
+        name_field: "name",
+        requires_modifiers: &[],
+    },
+    // Java `static final` field constants. The `variable_declarator` node
+    // carries the name; the `requires_modifiers` filter ensures we only
+    // extract fields that are declared `static final`, not regular fields.
+    NodeMapping {
+        node_type: "variable_declarator",
+        kind: SymbolKind::Constant,
+        name_field: "name",
+        requires_modifiers: &["static", "final"],
+    },
+];
+
+static JAVA_SCOPES: &[ScopeMapping] = &[
+    ScopeMapping {
+        node_type: "class_declaration",
+        name_field: "name",
+    },
+    ScopeMapping {
+        node_type: "interface_declaration",
+        name_field: "name",
+    },
+    ScopeMapping {
+        node_type: "enum_declaration",
+        name_field: "name",
+    },
+    ScopeMapping {
+        node_type: "record_declaration",
+        name_field: "name",
+    },
+];
+
+/// Java `package` declaration (`package com.example.app;`).
+///
+/// The package name is a `scoped_identifier` positional child (not a named
+/// field). The `child_text` fallback in the sticky scope handler resolves
+/// this by finding the first child of type `scoped_identifier`.
+static JAVA_STICKY_SCOPES: &[StickyScopeMapping] = &[StickyScopeMapping {
+    node_type: "package_declaration",
+    name_field: "scoped_identifier",
+}];
+
+pub static JAVA_PROFILE: LanguageProfile = LanguageProfile {
+    language_id: "java",
+    ts_language: java_language,
+    definitions: JAVA_DEFINITIONS,
+    scopes: JAVA_SCOPES,
+    sticky_scopes: JAVA_STICKY_SCOPES,
+    method_receivers: &[],
+};

--- a/crates/syntax-platform/src/languages/mod.rs
+++ b/crates/syntax-platform/src/languages/mod.rs
@@ -1,4 +1,5 @@
 pub mod go;
+pub mod java;
 pub mod php;
 pub mod python;
 pub mod rust;
@@ -10,6 +11,10 @@ pub struct NodeMapping {
     pub node_type: &'static str,
     pub kind: SymbolKind,
     pub name_field: &'static str,
+    /// When non-empty, only match if the parent node has a `modifiers` child
+    /// containing ALL of these keywords. Used to extract Java `static final`
+    /// field declarations as constants while ignoring regular fields.
+    pub requires_modifiers: &'static [&'static str],
 }
 
 /// Describes how to extract scope names from scope-creating nodes.
@@ -78,6 +83,7 @@ impl LanguageProfile {
 pub fn profile_for(language: &str) -> Option<&'static LanguageProfile> {
     match language {
         "go" => Some(&go::GO_PROFILE),
+        "java" => Some(&java::JAVA_PROFILE),
         "php" => Some(&php::PHP_PROFILE),
         "python" => Some(&python::PYTHON_PROFILE),
         "rust" => Some(&rust::RUST_PROFILE),
@@ -87,5 +93,5 @@ pub fn profile_for(language: &str) -> Option<&'static LanguageProfile> {
 
 /// Returns the list of languages with syntax backends on this platform.
 pub fn supported_languages() -> &'static [&'static str] {
-    &["go", "php", "python", "rust"]
+    &["go", "java", "php", "python", "rust"]
 }

--- a/crates/syntax-platform/src/languages/php.rs
+++ b/crates/syntax-platform/src/languages/php.rs
@@ -11,31 +11,37 @@ static PHP_DEFINITIONS: &[NodeMapping] = &[
         node_type: "function_definition",
         kind: SymbolKind::Function,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "method_declaration",
         kind: SymbolKind::Method,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "class_declaration",
         kind: SymbolKind::Class,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "interface_declaration",
         kind: SymbolKind::Type,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "trait_declaration",
         kind: SymbolKind::Type,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "enum_declaration",
         kind: SymbolKind::Type,
         name_field: "name",
+        requires_modifiers: &[],
     },
     // Constants: the name lives on `const_element` as a child of type
     // `name` (not a named field). The `child_text` fallback handles this.
@@ -43,6 +49,7 @@ static PHP_DEFINITIONS: &[NodeMapping] = &[
         node_type: "const_element",
         kind: SymbolKind::Constant,
         name_field: "name",
+        requires_modifiers: &[],
     },
 ];
 

--- a/crates/syntax-platform/src/languages/python.rs
+++ b/crates/syntax-platform/src/languages/python.rs
@@ -13,11 +13,13 @@ static PYTHON_DEFINITIONS: &[NodeMapping] = &[
         node_type: "function_definition",
         kind: SymbolKind::Function,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "class_definition",
         kind: SymbolKind::Class,
         name_field: "name",
+        requires_modifiers: &[],
     },
 ];
 

--- a/crates/syntax-platform/src/languages/rust.rs
+++ b/crates/syntax-platform/src/languages/rust.rs
@@ -11,41 +11,49 @@ static RUST_DEFINITIONS: &[NodeMapping] = &[
         node_type: "function_item",
         kind: SymbolKind::Function,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "function_signature_item",
         kind: SymbolKind::Function,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "struct_item",
         kind: SymbolKind::Class,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "enum_item",
         kind: SymbolKind::Type,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "trait_item",
         kind: SymbolKind::Type,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "type_item",
         kind: SymbolKind::Type,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "const_item",
         kind: SymbolKind::Constant,
         name_field: "name",
+        requires_modifiers: &[],
     },
     NodeMapping {
         node_type: "static_item",
         kind: SymbolKind::Constant,
         name_field: "name",
+        requires_modifiers: &[],
     },
 ];
 

--- a/crates/syntax-platform/src/lib.rs
+++ b/crates/syntax-platform/src/lib.rs
@@ -236,6 +236,88 @@ impl SyntaxBackend for GoSyntaxBackend {
 }
 
 // ---------------------------------------------------------------------------
+// JavaSyntaxBackend
+// ---------------------------------------------------------------------------
+
+/// Tree-sitter-based syntax backend for Java.
+pub struct JavaSyntaxBackend {
+    capability: SyntaxCapability,
+}
+
+impl JavaSyntaxBackend {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            capability: SyntaxCapability {
+                supported_kinds: vec![
+                    SymbolKind::Method,
+                    SymbolKind::Class,
+                    SymbolKind::Type,
+                    SymbolKind::Constant,
+                ],
+                supports_containers: true,
+                supports_docs: true,
+            },
+        }
+    }
+
+    /// Returns the [`BackendId`] for this backend.
+    #[must_use]
+    pub fn backend_id() -> BackendId {
+        BackendId("syntax-java".to_string())
+    }
+}
+
+impl Default for JavaSyntaxBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyntaxBackend for JavaSyntaxBackend {
+    fn language(&self) -> &str {
+        "java"
+    }
+
+    fn capability(&self) -> &SyntaxCapability {
+        &self.capability
+    }
+
+    fn extract_symbols(&self, file: &PreparedFile) -> Result<SyntaxExtraction, SyntaxError> {
+        if file.language != "java" {
+            return Err(SyntaxError::Unsupported {
+                language: file.language.clone(),
+            });
+        }
+
+        let profile = &languages::java::JAVA_PROFILE;
+
+        let mut parser = Parser::new();
+        parser
+            .set_language(&(profile.ts_language)())
+            .map_err(|err| SyntaxError::Parse {
+                path: file.relative_path.clone(),
+                reason: format!("failed to set language: {err}"),
+            })?;
+
+        let tree = parser
+            .parse(&file.content, None)
+            .ok_or_else(|| SyntaxError::Parse {
+                path: file.relative_path.clone(),
+                reason: "tree-sitter parse returned no tree".to_string(),
+            })?;
+
+        let symbols = extraction::extract_symbols(tree.root_node(), &file.content, profile);
+
+        Ok(SyntaxExtraction {
+            language: "java".to_string(),
+            symbols,
+            backend_id: Self::backend_id(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // PhpSyntaxBackend
 // ---------------------------------------------------------------------------
 
@@ -1868,6 +1950,421 @@ func helper(x int) int {
         let get_name = find_symbol(&output1.symbols, "GetName");
         assert_eq!(get_name.qualified_name, "Config::GetName");
         assert_eq!(get_name.parent_qualified_name.as_deref(), Some("Config"));
+
+        let config = find_symbol(&output1.symbols, "Config");
+        assert!(config.docstring.is_some());
+    }
+
+    // ===================================================================
+    // Java tests
+    // ===================================================================
+
+    fn extract_java(source: &str) -> SyntaxExtraction {
+        let backend = JavaSyntaxBackend::new();
+        let file = PreparedFile {
+            relative_path: PathBuf::from("src/main/java/User.java"),
+            absolute_path: PathBuf::from("/tmp/test/src/main/java/User.java"),
+            language: "java".to_string(),
+            content: source.as_bytes().to_vec(),
+        };
+        backend.extract_symbols(&file).expect("extraction failed")
+    }
+
+    // -- Java backend identity --
+
+    #[test]
+    fn java_backend_id_follows_naming_convention() {
+        let backend = JavaSyntaxBackend::new();
+        assert_eq!(backend.language(), "java");
+        assert_eq!(JavaSyntaxBackend::backend_id().0, "syntax-java");
+    }
+
+    #[test]
+    fn java_capability_reports_expected_kinds() {
+        let backend = JavaSyntaxBackend::new();
+        let cap = backend.capability();
+        assert!(cap.supported_kinds.contains(&SymbolKind::Method));
+        assert!(cap.supported_kinds.contains(&SymbolKind::Class));
+        assert!(cap.supported_kinds.contains(&SymbolKind::Type));
+        assert!(cap.supported_kinds.contains(&SymbolKind::Constant));
+        assert!(cap.supports_containers);
+        assert!(cap.supports_docs);
+    }
+
+    #[test]
+    fn java_unsupported_language_returns_error() {
+        let backend = JavaSyntaxBackend::new();
+        let file = PreparedFile {
+            relative_path: PathBuf::from("main.py"),
+            absolute_path: PathBuf::from("/tmp/main.py"),
+            language: "python".to_string(),
+            content: b"def foo(): pass".to_vec(),
+        };
+        let err = backend.extract_symbols(&file).expect_err("wrong language");
+        assert!(err.to_string().contains("unsupported language"));
+    }
+
+    // -- Java extraction output --
+
+    #[test]
+    fn java_extraction_carries_backend_id() {
+        let result = extract_java("public class Foo {}\n");
+        assert_eq!(result.backend_id.0, "syntax-java");
+        assert_eq!(result.language, "java");
+    }
+
+    // -- Java class extraction --
+
+    #[test]
+    fn java_extracts_class() {
+        let result = extract_java("public class User {}\n");
+        let sym = find_symbol(&result.symbols, "User");
+        assert_eq!(sym.kind, SymbolKind::Class);
+        assert_eq!(sym.qualified_name, "User");
+    }
+
+    // -- Java package behavior --
+
+    #[test]
+    fn java_package_qualifies_class() {
+        let source = "package com.example.app;\npublic class User {}\n";
+        let result = extract_java(source);
+        let sym = find_symbol(&result.symbols, "User");
+        assert_eq!(sym.kind, SymbolKind::Class);
+        assert_eq!(sym.qualified_name, "com::example::app::User");
+        assert_eq!(
+            sym.parent_qualified_name.as_deref(),
+            Some("com::example::app")
+        );
+    }
+
+    #[test]
+    fn java_package_qualifies_methods() {
+        let source = "package com.example;\npublic class Svc {\n    public void run() {}\n}\n";
+        let result = extract_java(source);
+        let sym = find_symbol(&result.symbols, "run");
+        assert_eq!(sym.qualified_name, "com::example::Svc::run");
+    }
+
+    #[test]
+    fn java_no_package_produces_unqualified_names() {
+        let result = extract_java("public class User {}\n");
+        let sym = find_symbol(&result.symbols, "User");
+        assert_eq!(sym.qualified_name, "User");
+    }
+
+    // -- Java static final constant extraction --
+
+    #[test]
+    fn java_extracts_static_final_constant() {
+        let source =
+            "public class Config {\n    public static final String APP_NAME = \"myapp\";\n}\n";
+        let result = extract_java(source);
+        let sym = find_symbol(&result.symbols, "APP_NAME");
+        assert_eq!(sym.kind, SymbolKind::Constant);
+        assert_eq!(sym.qualified_name, "Config::APP_NAME");
+    }
+
+    #[test]
+    fn java_extracts_multiple_static_final_constants() {
+        let source = "public class Limits {\n    public static final int MAX = 100;\n    public static final int MIN = 0;\n}\n";
+        let result = extract_java(source);
+        let max = find_symbol(&result.symbols, "MAX");
+        assert_eq!(max.kind, SymbolKind::Constant);
+        let min = find_symbol(&result.symbols, "MIN");
+        assert_eq!(min.kind, SymbolKind::Constant);
+    }
+
+    #[test]
+    fn java_skips_non_constant_fields() {
+        let source = "public class User {\n    private String name;\n    protected int count;\n    public static final String TABLE = \"users\";\n}\n";
+        let result = extract_java(source);
+        // Only TABLE should be a Constant; name and count are regular fields.
+        let constants: Vec<_> = result
+            .symbols
+            .iter()
+            .filter(|s| s.kind == SymbolKind::Constant)
+            .collect();
+        assert_eq!(constants.len(), 1);
+        assert_eq!(constants[0].name, "TABLE");
+    }
+
+    // -- Java method extraction --
+
+    #[test]
+    fn java_extracts_methods_with_qualified_names() {
+        let source = "public class User {\n    public String getName() {\n        return this.name;\n    }\n}\n";
+        let result = extract_java(source);
+        let sym = find_symbol(&result.symbols, "getName");
+        assert_eq!(sym.kind, SymbolKind::Method);
+        assert_eq!(sym.qualified_name, "User::getName");
+        assert_eq!(sym.parent_qualified_name.as_deref(), Some("User"));
+    }
+
+    #[test]
+    fn java_extracts_constructor() {
+        let source = "public class User {\n    public User(String name) {\n        this.name = name;\n    }\n}\n";
+        let result = extract_java(source);
+        // Both the class and constructor are named "User"
+        let constructors: Vec<_> = result
+            .symbols
+            .iter()
+            .filter(|s| s.name == "User" && s.kind == SymbolKind::Method)
+            .collect();
+        assert_eq!(constructors.len(), 1);
+        assert_eq!(constructors[0].qualified_name, "User::User");
+    }
+
+    #[test]
+    fn java_extracts_static_method() {
+        let source = "public class User {\n    public static User create(String name) {\n        return new User(name);\n    }\n}\n";
+        let result = extract_java(source);
+        let sym = find_symbol(&result.symbols, "create");
+        assert_eq!(sym.kind, SymbolKind::Method);
+        assert_eq!(sym.qualified_name, "User::create");
+    }
+
+    // -- Java interface extraction --
+
+    #[test]
+    fn java_extracts_interface() {
+        let source = "public interface Handler {\n    void handle(String input);\n}\n";
+        let result = extract_java(source);
+        let iface = find_symbol(&result.symbols, "Handler");
+        assert_eq!(iface.kind, SymbolKind::Type);
+
+        let method = find_symbol(&result.symbols, "handle");
+        assert_eq!(method.kind, SymbolKind::Method);
+        assert_eq!(method.qualified_name, "Handler::handle");
+    }
+
+    // -- Java enum extraction --
+
+    #[test]
+    fn java_extracts_enum() {
+        let source = "public enum Status {\n    ACTIVE,\n    INACTIVE;\n\n    public String label() {\n        return this.name();\n    }\n}\n";
+        let result = extract_java(source);
+
+        let e = find_symbol(&result.symbols, "Status");
+        assert_eq!(e.kind, SymbolKind::Type);
+
+        let active = find_symbol(&result.symbols, "ACTIVE");
+        assert_eq!(active.kind, SymbolKind::Constant);
+        assert_eq!(active.qualified_name, "Status::ACTIVE");
+
+        let label = find_symbol(&result.symbols, "label");
+        assert_eq!(label.kind, SymbolKind::Method);
+        assert_eq!(label.qualified_name, "Status::label");
+    }
+
+    // -- Java record extraction --
+
+    #[test]
+    fn java_extracts_record() {
+        let source = "public record Point(int x, int y) {\n    public double distance() {\n        return Math.sqrt(x * x + y * y);\n    }\n}\n";
+        let result = extract_java(source);
+
+        let point = find_symbol(&result.symbols, "Point");
+        assert_eq!(point.kind, SymbolKind::Class);
+
+        let distance = find_symbol(&result.symbols, "distance");
+        assert_eq!(distance.kind, SymbolKind::Method);
+        assert_eq!(distance.qualified_name, "Point::distance");
+    }
+
+    // -- Java docstrings --
+
+    #[test]
+    fn java_extracts_javadoc() {
+        let source = "/**\n * Represents a user.\n */\npublic class User {}\n";
+        let result = extract_java(source);
+        let sym = find_symbol(&result.symbols, "User");
+        assert!(sym.docstring.is_some(), "expected Javadoc");
+        assert!(
+            sym.docstring
+                .as_deref()
+                .unwrap()
+                .contains("Represents a user"),
+            "unexpected doc: {:?}",
+            sym.docstring
+        );
+    }
+
+    #[test]
+    fn java_extracts_method_javadoc() {
+        let source = "public class User {\n    /**\n     * Gets the name.\n     */\n    public String getName() {\n        return name;\n    }\n}\n";
+        let result = extract_java(source);
+        let sym = find_symbol(&result.symbols, "getName");
+        assert!(sym.docstring.is_some(), "expected method Javadoc");
+    }
+
+    #[test]
+    fn java_no_docstring_when_absent() {
+        let result = extract_java("public class Bare {}\n");
+        let sym = find_symbol(&result.symbols, "Bare");
+        assert!(sym.docstring.is_none());
+    }
+
+    // -- Java edge cases --
+
+    #[test]
+    fn java_empty_file_produces_no_symbols() {
+        let result = extract_java("");
+        assert!(result.symbols.is_empty());
+    }
+
+    #[test]
+    fn java_nested_class() {
+        let source = "public class Outer {\n    public class Inner {\n        public void method() {}\n    }\n}\n";
+        let result = extract_java(source);
+
+        let outer = find_symbol(&result.symbols, "Outer");
+        assert_eq!(outer.kind, SymbolKind::Class);
+
+        let inner = find_symbol(&result.symbols, "Inner");
+        assert_eq!(inner.kind, SymbolKind::Class);
+        assert_eq!(inner.qualified_name, "Outer::Inner");
+
+        let method = find_symbol(&result.symbols, "method");
+        assert_eq!(method.kind, SymbolKind::Method);
+        assert_eq!(method.qualified_name, "Outer::Inner::method");
+    }
+
+    // -- Java representative fixture --
+
+    #[test]
+    fn java_spring_style_controller_fixture() {
+        let source = r#"
+package com.example.controllers;
+
+/**
+ * Handles user-related HTTP requests.
+ */
+public class UserController {
+    public static final String BASE_PATH = "/users";
+
+    /**
+     * List all users.
+     */
+    public List<User> index() {
+        return userService.findAll();
+    }
+
+    public User show(Long id) {
+        return userService.findById(id);
+    }
+
+    public User create(CreateUserRequest request) {
+        return userService.create(request);
+    }
+}
+"#;
+        let result = extract_java(source);
+
+        let controller = find_symbol(&result.symbols, "UserController");
+        assert_eq!(controller.kind, SymbolKind::Class);
+        assert_eq!(
+            controller.qualified_name,
+            "com::example::controllers::UserController"
+        );
+        assert!(controller.docstring.is_some());
+
+        let index = find_symbol(&result.symbols, "index");
+        assert_eq!(index.kind, SymbolKind::Method);
+        assert_eq!(
+            index.qualified_name,
+            "com::example::controllers::UserController::index"
+        );
+        assert!(index.docstring.is_some());
+
+        let base_path = find_symbol(&result.symbols, "BASE_PATH");
+        assert_eq!(base_path.kind, SymbolKind::Constant);
+        assert_eq!(
+            base_path.qualified_name,
+            "com::example::controllers::UserController::BASE_PATH"
+        );
+
+        let show = find_symbol(&result.symbols, "show");
+        assert_eq!(show.kind, SymbolKind::Method);
+
+        let create = find_symbol(&result.symbols, "create");
+        assert_eq!(create.kind, SymbolKind::Method);
+    }
+
+    #[test]
+    fn java_comprehensive_extraction_is_deterministic() {
+        let source = r#"
+package com.example;
+
+/**
+ * Application configuration.
+ */
+public class Config {
+    public static final int VERSION = 1;
+
+    /**
+     * Creates a new config.
+     */
+    public Config(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}
+
+public interface Service {
+    void start();
+    void stop();
+}
+
+public enum Priority {
+    HIGH,
+    MEDIUM,
+    LOW;
+}
+
+public record Pair(Object first, Object second) {}
+"#;
+
+        let output1 = extract_java(source);
+        let output2 = extract_java(source);
+
+        assert_eq!(output1.symbols.len(), output2.symbols.len());
+        for (a, b) in output1.symbols.iter().zip(output2.symbols.iter()) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.qualified_name, b.qualified_name);
+            assert_eq!(a.span, b.span);
+        }
+
+        let names: Vec<(&str, SymbolKind)> = output1
+            .symbols
+            .iter()
+            .map(|s| (s.name.as_str(), s.kind))
+            .collect();
+
+        assert!(names.contains(&("Config", SymbolKind::Class)));
+        assert!(names.contains(&("VERSION", SymbolKind::Constant)));
+        assert!(names.contains(&("getName", SymbolKind::Method)));
+        assert!(names.contains(&("Service", SymbolKind::Type)));
+        assert!(names.contains(&("start", SymbolKind::Method)));
+        assert!(names.contains(&("stop", SymbolKind::Method)));
+        assert!(names.contains(&("Priority", SymbolKind::Type)));
+        assert!(names.contains(&("HIGH", SymbolKind::Constant)));
+        assert!(names.contains(&("Pair", SymbolKind::Class)));
+
+        // Verify package-qualified names.
+        let get_name = find_symbol(&output1.symbols, "getName");
+        assert_eq!(get_name.qualified_name, "com::example::Config::getName");
+        assert_eq!(
+            get_name.parent_qualified_name.as_deref(),
+            Some("com::example::Config")
+        );
+
+        let version = find_symbol(&output1.symbols, "VERSION");
+        assert_eq!(version.qualified_name, "com::example::Config::VERSION");
 
         let config = find_symbol(&output1.symbols, "Config");
         assert!(config.docstring.is_some());


### PR DESCRIPTION
## Summary

  - Issue: Closes #180
  - Scope: Add Java syntax indexing on the shared syntax subsystem, wire it into the production backend registry, and add representative Java extraction and integration coverage.

  ## Changes

  - Added tree-sitter-java to the workspace and syntax-platform.
  - Implemented JavaSyntaxBackend and registered it in the CLI backend router.
  - Added a Java language profile covering:
      - classes
      - interfaces
      - enums
      - records
      - methods
      - constructors
      - enum constants
      - static final field constants
  - Extended shared extraction behavior to support Java-specific cases:
      - package-qualified names via package declaration sticky scope handling
      - extraction of static final fields as constants using modifier-aware filtering
      - shared separator normalization for Java package paths
  - Added Java unit coverage in syntax-platform for:
      - classes, nested classes, interfaces, enums, and records
      - methods, constructors, and static methods
      - package-qualified names
      - static final constants and filtering of non-constant fields
      - Javadoc extraction
      - deterministic extraction
      - representative Spring-style controller fixture coverage
  - Added indexer integration tests for:
      - end-to-end Java indexing on a representative controller/service/enum fixture
      - mixed Java/Rust repository behavior
  - Added CLI integration tests for:
      - Java indexing
      - file-outline
      - search-symbols

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Java repositories gain meaningful symbol coverage through syntax indexing.
    Evidence: Java backend is registered in the production router and covered by syntax-platform, indexer, and CLI tests.
  - [x] Criterion 2: file outline is useful on representative Java repositories.
    Evidence: CLI integration test covers file-outline on a representative Java fixture and asserts class/method/enum presence.
  - [x] Criterion 3: symbol search returns useful results on representative Java repositories.
    Evidence: CLI integration tests cover search-symbols for both a Java class and a method.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional tests run:

  - cargo test -p syntax-platform java_ -- --nocapture
  - cargo test -p indexer pipeline_java -- --nocapture
  - cargo test -p cli java_ --test cli_integration

  ## Risk and Mitigation

  - Risk: Java package qualification and static final constant handling are easy to mis-model, which can lead to weak symbol disambiguation or missing high-value symbols.
  - Mitigation: Added package-aware extraction, modifier-aware constant filtering, and targeted unit/indexer/CLI coverage for those Java-specific cases.

  ## Security/Observability Impact

  - Security: No new external runtime or process integration; Java extraction is deterministic in-process tree-sitter parsing.
  - Logs/Metrics/Tracing: Java files now participate in normal syntax indexing metrics and backend attribution via syntax-java.