### PR TITLE
Rework query surfaces for broad syntax coverage

### DIFF
--- a/crates/cli/src/mcp_stdio.rs
+++ b/crates/cli/src/mcp_stdio.rs
@@ -404,6 +404,11 @@ pub(crate) fn tool_input_schema(name: &str) -> Value {
                     "type": "string",
                     "description": "Filter by programming language"
                 },
+                "capability_tier": {
+                    "type": "string",
+                    "description": "Filter by capability tier",
+                    "enum": ["file_only", "syntax_only", "syntax_plus_semantic", "semantic_only"]
+                },
                 "limit": {
                     "type": "integer",
                     "description": "Maximum number of results to return",
@@ -806,12 +811,16 @@ mod tests {
         assert!(props.contains_key("query"));
         assert!(props.contains_key("kind"));
         assert!(props.contains_key("language"));
+        assert!(props.contains_key("capability_tier"));
         assert!(props.contains_key("limit"));
         assert!(props.contains_key("offset"));
-        assert_eq!(props.len(), 6);
+        assert_eq!(props.len(), 7);
 
         // kind has enum constraint
         assert!(schema["properties"]["kind"]["enum"].is_array());
+
+        // capability_tier has enum constraint
+        assert!(schema["properties"]["capability_tier"]["enum"].is_array());
 
         // limit/offset have minimum and default matching usize semantics
         assert_eq!(schema["properties"]["limit"]["default"], 20);

--- a/crates/query-engine/src/lib.rs
+++ b/crates/query-engine/src/lib.rs
@@ -129,6 +129,7 @@ pub struct FileTreeEntry {
     pub path: String,
     pub language: String,
     pub symbol_count: u64,
+    pub capability_tier: CapabilityTier,
 }
 
 #[derive(Debug, Clone)]
@@ -444,6 +445,7 @@ pub mod test_support {
                     path: f.file_path.clone(),
                     language: f.language.clone(),
                     symbol_count: f.symbol_count,
+                    capability_tier: f.capability_tier,
                 })
                 .collect();
             Ok(entries)
@@ -466,6 +468,7 @@ pub mod test_support {
                     path: f.file_path.clone(),
                     language: f.language.clone(),
                     symbol_count: f.symbol_count,
+                    capability_tier: f.capability_tier,
                 })
                 .collect();
             Ok(RepoOutline {

--- a/crates/query-engine/src/store_service.rs
+++ b/crates/query-engine/src/store_service.rs
@@ -181,6 +181,7 @@ impl QueryService for StoreQueryService<'_> {
                     path: file.file_path,
                     language: file.language,
                     symbol_count: file.symbol_count,
+                    capability_tier: file.capability_tier,
                 });
             }
         }

--- a/crates/query-engine/tests/capability_tier_integration.rs
+++ b/crates/query-engine/tests/capability_tier_integration.rs
@@ -1,0 +1,429 @@
+//! Integration tests for query behavior across capability tiers.
+//!
+//! Validates that file outline, symbol search, file tree, and repo outline
+//! behave correctly when a repo contains files at different capability tiers:
+//! file-only, syntax-only, and syntax-plus-semantic.
+
+use std::collections::BTreeMap;
+
+use core_model::{
+    CapabilityTier, FileRecord, FreshnessStatus, IndexingStatus, RepoRecord, SymbolKind,
+    SymbolRecord,
+};
+use query_engine::{
+    FileContentRequest, FileOutlineRequest, FileTreeRequest, QueryFilters, QueryService,
+    RepoOutlineRequest, StoreQueryService, SymbolQuery,
+};
+use store::MetadataStore;
+use tempfile::TempDir;
+
+/// Seeds a store with a mixed-tier repository:
+///
+/// - `README.md`: file-only (no symbols)
+/// - `src/main.rs`: syntax-only (Rust symbols)
+/// - `src/app.ts`: syntax-plus-semantic (TypeScript symbols with semantic enrichment)
+fn seed_multi_tier_store() -> (MetadataStore, store::BlobStore, TempDir) {
+    let store = MetadataStore::open_in_memory().unwrap();
+
+    store
+        .repos()
+        .upsert(&RepoRecord {
+            repo_id: "multi-tier".into(),
+            display_name: "MultiTier".into(),
+            source_root: "/tmp/multi".into(),
+            indexed_at: "2026-03-16T00:00:00Z".into(),
+            index_version: "1.1.0".into(),
+            language_counts: BTreeMap::from([
+                ("rust".into(), 1),
+                ("typescript".into(), 1),
+                ("markdown".into(), 1),
+            ]),
+            file_count: 3,
+            symbol_count: 4,
+            git_head: None,
+            registered_at: Some("2026-03-16T00:00:00Z".to_string()),
+            indexing_status: IndexingStatus::Ready,
+            freshness_status: FreshnessStatus::Fresh,
+        })
+        .unwrap();
+
+    let blob_dir = TempDir::new().unwrap();
+    let blob_store = store::BlobStore::open(&blob_dir.path().join("blobs")).unwrap();
+
+    // File-only file (no syntax backend for markdown).
+    let readme_content = b"# Hello\n";
+    let readme_hash = store::content_hash(readme_content);
+    blob_store.put(readme_content).unwrap();
+    store
+        .files()
+        .upsert(&FileRecord {
+            repo_id: "multi-tier".into(),
+            file_path: "README.md".into(),
+            language: "markdown".into(),
+            file_hash: readme_hash,
+            summary: "Readme file".into(),
+            symbol_count: 0,
+            capability_tier: CapabilityTier::FileOnly,
+            updated_at: "2026-03-16T00:00:00Z".into(),
+        })
+        .unwrap();
+
+    // Syntax-only file (Rust).
+    let rs_content = b"pub fn greet() {}\npub struct Config {}\n";
+    let rs_hash = store::content_hash(rs_content);
+    blob_store.put(rs_content).unwrap();
+    store
+        .files()
+        .upsert(&FileRecord {
+            repo_id: "multi-tier".into(),
+            file_path: "src/main.rs".into(),
+            language: "rust".into(),
+            file_hash: rs_hash,
+            summary: "Main source".into(),
+            symbol_count: 2,
+            capability_tier: CapabilityTier::SyntaxOnly,
+            updated_at: "2026-03-16T00:00:00Z".into(),
+        })
+        .unwrap();
+
+    // Syntax-plus-semantic file (TypeScript).
+    let ts_content = b"export function hello() {}\nexport class App {}\n";
+    let ts_hash = store::content_hash(ts_content);
+    blob_store.put(ts_content).unwrap();
+    store
+        .files()
+        .upsert(&FileRecord {
+            repo_id: "multi-tier".into(),
+            file_path: "src/app.ts".into(),
+            language: "typescript".into(),
+            file_hash: ts_hash,
+            summary: "App source".into(),
+            symbol_count: 2,
+            capability_tier: CapabilityTier::SyntaxPlusSemantic,
+            updated_at: "2026-03-16T00:00:00Z".into(),
+        })
+        .unwrap();
+
+    // Syntax-only symbols for Rust.
+    for (name, kind) in [
+        ("greet", SymbolKind::Function),
+        ("Config", SymbolKind::Class),
+    ] {
+        store
+            .symbols()
+            .upsert(&make_symbol(
+                name,
+                kind,
+                "src/main.rs",
+                "rust",
+                CapabilityTier::SyntaxOnly,
+                0.8,
+                "syntax-rust",
+            ))
+            .unwrap();
+    }
+
+    // Syntax-plus-semantic symbols for TypeScript.
+    for (name, kind) in [("hello", SymbolKind::Function), ("App", SymbolKind::Class)] {
+        store
+            .symbols()
+            .upsert(&make_symbol(
+                name,
+                kind,
+                "src/app.ts",
+                "typescript",
+                CapabilityTier::SyntaxPlusSemantic,
+                0.95,
+                "semantic-typescript",
+            ))
+            .unwrap();
+    }
+
+    (store, blob_store, blob_dir)
+}
+
+fn make_symbol(
+    name: &str,
+    kind: SymbolKind,
+    file_path: &str,
+    language: &str,
+    capability_tier: CapabilityTier,
+    confidence: f32,
+    source_backend: &str,
+) -> SymbolRecord {
+    let qualified_name = format!("crate::{name}");
+    SymbolRecord {
+        id: core_model::build_symbol_id("multi-tier", file_path, &qualified_name, kind)
+            .expect("build id"),
+        repo_id: "multi-tier".into(),
+        file_path: file_path.into(),
+        language: language.into(),
+        kind,
+        name: name.into(),
+        qualified_name,
+        signature: format!("fn {name}()"),
+        start_line: 1,
+        end_line: 5,
+        start_byte: 0,
+        byte_length: 50,
+        content_hash: format!("hash-{name}"),
+        capability_tier,
+        confidence_score: confidence,
+        source_backend: source_backend.into(),
+        indexed_at: "2026-03-16T00:00:00Z".into(),
+        docstring: None,
+        summary: None,
+        parent_symbol_id: None,
+        keywords: None,
+        decorators_or_attributes: None,
+        semantic_refs: None,
+        container_symbol_id: None,
+        namespace_path: None,
+        raw_kind: None,
+        modifiers: None,
+    }
+}
+
+// ── File outline across tiers ─────────────────────────────────────────
+
+#[test]
+fn file_outline_file_only_returns_empty_symbols() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let outline = svc
+        .get_file_outline(&FileOutlineRequest {
+            repo_id: "multi-tier".into(),
+            file_path: "README.md".into(),
+        })
+        .unwrap();
+
+    assert_eq!(outline.file.capability_tier, CapabilityTier::FileOnly);
+    assert!(
+        outline.symbols.is_empty(),
+        "file-only file should have no symbols"
+    );
+}
+
+#[test]
+fn file_outline_syntax_only_returns_syntax_symbols() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let outline = svc
+        .get_file_outline(&FileOutlineRequest {
+            repo_id: "multi-tier".into(),
+            file_path: "src/main.rs".into(),
+        })
+        .unwrap();
+
+    assert_eq!(outline.file.capability_tier, CapabilityTier::SyntaxOnly);
+    assert_eq!(outline.symbols.len(), 2);
+    assert!(outline
+        .symbols
+        .iter()
+        .all(|s| s.capability_tier == CapabilityTier::SyntaxOnly));
+}
+
+#[test]
+fn file_outline_syntax_plus_semantic_returns_merged_symbols() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let outline = svc
+        .get_file_outline(&FileOutlineRequest {
+            repo_id: "multi-tier".into(),
+            file_path: "src/app.ts".into(),
+        })
+        .unwrap();
+
+    assert_eq!(
+        outline.file.capability_tier,
+        CapabilityTier::SyntaxPlusSemantic
+    );
+    assert_eq!(outline.symbols.len(), 2);
+    assert!(outline
+        .symbols
+        .iter()
+        .all(|s| s.capability_tier == CapabilityTier::SyntaxPlusSemantic));
+}
+
+// ── Symbol search across tiers ────────────────────────────────────────
+
+#[test]
+fn search_symbols_returns_results_from_all_tiers() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    // Search for a broad term that matches symbols in both tiers.
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "multi-tier".into(),
+            text: "Config App greet hello".into(),
+            filters: QueryFilters::default(),
+            limit: 20,
+            offset: 0,
+        })
+        .unwrap();
+
+    // Should find symbols from both syntax-only and syntax-plus-semantic files.
+    let tiers: Vec<CapabilityTier> = result
+        .items
+        .iter()
+        .map(|s| s.record.capability_tier)
+        .collect();
+    assert!(
+        tiers.contains(&CapabilityTier::SyntaxOnly),
+        "should contain syntax-only symbols"
+    );
+    assert!(
+        tiers.contains(&CapabilityTier::SyntaxPlusSemantic),
+        "should contain syntax-plus-semantic symbols"
+    );
+}
+
+#[test]
+fn search_symbols_filter_by_syntax_only() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let result = svc
+        .search_symbols(&SymbolQuery {
+            repo_id: "multi-tier".into(),
+            text: "greet Config hello App".into(),
+            filters: QueryFilters {
+                capability_tier: Some(CapabilityTier::SyntaxOnly),
+                ..QueryFilters::default()
+            },
+            limit: 20,
+            offset: 0,
+        })
+        .unwrap();
+
+    assert!(!result.items.is_empty());
+    assert!(
+        result
+            .items
+            .iter()
+            .all(|s| s.record.capability_tier == CapabilityTier::SyntaxOnly),
+        "all results should be syntax-only when filtered"
+    );
+}
+
+// ── Symbol lookup across tiers ────────────────────────────────────────
+
+#[test]
+fn get_symbol_works_for_syntax_only() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let greet_id = core_model::build_symbol_id(
+        "multi-tier",
+        "src/main.rs",
+        "crate::greet",
+        SymbolKind::Function,
+    )
+    .unwrap();
+
+    let record = svc.get_symbol(&greet_id).unwrap();
+    assert_eq!(record.name, "greet");
+    assert_eq!(record.capability_tier, CapabilityTier::SyntaxOnly);
+}
+
+#[test]
+fn get_symbol_works_for_syntax_plus_semantic() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let app_id =
+        core_model::build_symbol_id("multi-tier", "src/app.ts", "crate::App", SymbolKind::Class)
+            .unwrap();
+
+    let record = svc.get_symbol(&app_id).unwrap();
+    assert_eq!(record.name, "App");
+    assert_eq!(record.capability_tier, CapabilityTier::SyntaxPlusSemantic);
+}
+
+// ── File content across tiers ─────────────────────────────────────────
+
+#[test]
+fn file_content_returns_content_for_file_only() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let content = svc
+        .get_file_content(&FileContentRequest {
+            repo_id: "multi-tier".into(),
+            file_path: "README.md".into(),
+        })
+        .unwrap();
+
+    assert_eq!(content.file.capability_tier, CapabilityTier::FileOnly);
+    assert!(content.content.contains("Hello"));
+}
+
+#[test]
+fn file_content_returns_content_for_syntax_only() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let content = svc
+        .get_file_content(&FileContentRequest {
+            repo_id: "multi-tier".into(),
+            file_path: "src/main.rs".into(),
+        })
+        .unwrap();
+
+    assert_eq!(content.file.capability_tier, CapabilityTier::SyntaxOnly);
+    assert!(content.content.contains("greet"));
+}
+
+// ── File tree across tiers ────────────────────────────────────────────
+
+#[test]
+fn file_tree_entries_carry_capability_tier() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let entries = svc
+        .get_file_tree(&FileTreeRequest {
+            repo_id: "multi-tier".into(),
+            path_prefix: None,
+        })
+        .unwrap();
+
+    assert_eq!(entries.len(), 3);
+
+    let readme = entries.iter().find(|e| e.path == "README.md").unwrap();
+    assert_eq!(readme.capability_tier, CapabilityTier::FileOnly);
+    assert_eq!(readme.symbol_count, 0);
+
+    let rs = entries.iter().find(|e| e.path == "src/main.rs").unwrap();
+    assert_eq!(rs.capability_tier, CapabilityTier::SyntaxOnly);
+    assert_eq!(rs.symbol_count, 2);
+
+    let ts = entries.iter().find(|e| e.path == "src/app.ts").unwrap();
+    assert_eq!(ts.capability_tier, CapabilityTier::SyntaxPlusSemantic);
+    assert_eq!(ts.symbol_count, 2);
+}
+
+// ── Repo outline across tiers ─────────────────────────────────────────
+
+#[test]
+fn repo_outline_files_carry_capability_tier() {
+    let (store, blob_store, _dir) = seed_multi_tier_store();
+    let svc = StoreQueryService::new(&store, &blob_store);
+
+    let outline = svc
+        .get_repo_outline(&RepoOutlineRequest {
+            repo_id: "multi-tier".into(),
+        })
+        .unwrap();
+
+    assert_eq!(outline.files.len(), 3);
+
+    let tiers: Vec<CapabilityTier> = outline.files.iter().map(|f| f.capability_tier).collect();
+    assert!(tiers.contains(&CapabilityTier::FileOnly));
+    assert!(tiers.contains(&CapabilityTier::SyntaxOnly));
+    assert!(tiers.contains(&CapabilityTier::SyntaxPlusSemantic));
+}

--- a/crates/server-mcp/src/tools.rs
+++ b/crates/server-mcp/src/tools.rs
@@ -4,7 +4,7 @@
 //! deserializes the request, calls the query engine, and returns a
 //! serialized payload or typed error.
 
-use core_model::SymbolKind;
+use core_model::{CapabilityTier, SymbolKind};
 use query_engine::{
     FileContentRequest, FileOutlineRequest, FileTreeRequest, QueryFilters, QueryService,
     RepoOutlineRequest, SymbolQuery, TextQuery,
@@ -24,6 +24,8 @@ pub struct SearchSymbolsParams {
     pub kind: Option<String>,
     #[serde(default)]
     pub language: Option<String>,
+    #[serde(default)]
+    pub capability_tier: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: usize,
     #[serde(default)]
@@ -158,6 +160,11 @@ pub fn search_symbols(svc: &dyn QueryService, params: serde_json::Value) -> Tool
         serde_json::from_value(params).map_err(|e| McpError::invalid_params(e.to_string()))?;
 
     let kind = p.kind.as_deref().map(parse_symbol_kind).transpose()?;
+    let capability_tier = p
+        .capability_tier
+        .as_deref()
+        .map(parse_capability_tier)
+        .transpose()?;
 
     let query = SymbolQuery {
         repo_id: p.repo_id,
@@ -165,7 +172,7 @@ pub fn search_symbols(svc: &dyn QueryService, params: serde_json::Value) -> Tool
         filters: QueryFilters {
             kind,
             language: p.language,
-            capability_tier: None,
+            capability_tier,
             file_path: None,
         },
         limit: p.limit,
@@ -256,6 +263,7 @@ pub fn get_file_outline(svc: &dyn QueryService, params: serde_json::Value) -> To
                 "file_path": outline.file.file_path,
                 "language": outline.file.language,
                 "symbol_count": outline.file.symbol_count,
+                "capability_tier": outline.file.capability_tier.as_str(),
             },
             "symbols": symbols,
         }),
@@ -279,6 +287,7 @@ pub fn get_file_content(svc: &dyn QueryService, params: serde_json::Value) -> To
                 "file_path": content.file.file_path,
                 "language": content.file.language,
                 "symbol_count": content.file.symbol_count,
+                "capability_tier": content.file.capability_tier.as_str(),
             },
             "content": content.content,
         }),
@@ -303,6 +312,7 @@ pub fn get_file_tree(svc: &dyn QueryService, params: serde_json::Value) -> ToolR
                 "path": e.path,
                 "language": e.language,
                 "symbol_count": e.symbol_count,
+                "capability_tier": e.capability_tier.as_str(),
             })
         })
         .collect();
@@ -328,6 +338,7 @@ pub fn get_repo_outline(svc: &dyn QueryService, params: serde_json::Value) -> To
                 "path": e.path,
                 "language": e.language,
                 "symbol_count": e.symbol_count,
+                "capability_tier": e.capability_tier.as_str(),
             })
         })
         .collect();
@@ -466,6 +477,18 @@ fn parse_symbol_kind(s: &str) -> Result<SymbolKind, McpError> {
         "constant" => Ok(SymbolKind::Constant),
         other => Err(McpError::invalid_params(format!(
             "unknown symbol kind: {other}"
+        ))),
+    }
+}
+
+fn parse_capability_tier(s: &str) -> Result<CapabilityTier, McpError> {
+    match s.to_lowercase().as_str() {
+        "file_only" => Ok(CapabilityTier::FileOnly),
+        "syntax_only" => Ok(CapabilityTier::SyntaxOnly),
+        "syntax_plus_semantic" => Ok(CapabilityTier::SyntaxPlusSemantic),
+        "semantic_only" => Ok(CapabilityTier::SemanticOnly),
+        other => Err(McpError::invalid_params(format!(
+            "unknown capability tier: {other}"
         ))),
     }
 }

--- a/crates/server-mcp/tests/e2e_integration.rs
+++ b/crates/server-mcp/tests/e2e_integration.rs
@@ -6,11 +6,12 @@
 use serde_json::json;
 use tempfile::TempDir;
 
+use core_model::{CapabilityTier, FileRecord, SymbolKind, SymbolRecord};
 use indexer::{DefaultBackendRegistry, DispatchContext};
 use query_engine::StoreQueryService;
 use server_mcp::types::{ErrorCode, Status};
 use server_mcp::ToolRegistry;
-use syntax_platform::RustSyntaxBackend;
+use syntax_platform::{PythonSyntaxBackend, RustSyntaxBackend};
 
 // ── Test infrastructure ──────────────────────────────────────────────────
 
@@ -666,4 +667,349 @@ fn e2e_file_only_repo_unknown_path_not_found() {
     );
     assert_eq!(resp.status, Status::Error);
     assert_eq!(resp.error.unwrap().code, ErrorCode::NotFound);
+}
+
+// ── Multi-tier repo E2E (#182) ──────────────────────────────────────────
+
+/// Indexes a repo with mixed tiers:
+/// - `src/lib.rs` (Rust) → syntax-only with symbols (real indexer)
+/// - `app/models.py` (Python) → syntax-only with symbols (real indexer)
+/// - `README.md` (markdown) → file-only (real indexer, no syntax backend)
+/// - `src/app.ts` (TypeScript) → syntax-plus-semantic (seeded after indexing)
+fn indexed_multi_tier_store() -> (store::MetadataStore, store::BlobStore, TempDir, TempDir) {
+    let repo_dir = TempDir::new().expect("repo temp dir");
+
+    let src = repo_dir.path().join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("lib.rs"),
+        "/// A function.\npub fn greet() {}\npub struct Config {}\n",
+    )
+    .expect("write lib.rs");
+
+    let app = repo_dir.path().join("app");
+    std::fs::create_dir_all(&app).expect("create app dir");
+    std::fs::write(
+        app.join("models.py"),
+        "class User:\n    \"\"\"A user.\"\"\"\n    def get_name(self):\n        return self.name\n",
+    )
+    .expect("write models.py");
+
+    std::fs::write(repo_dir.path().join("README.md"), "# Hello\n").expect("write readme");
+
+    let blob_dir = TempDir::new().expect("blob temp dir");
+    let blob_store =
+        store::BlobStore::open(&blob_dir.path().join("blobs")).expect("open blob store");
+    let mut db = store::MetadataStore::open_in_memory().expect("open store");
+
+    let mut registry = DefaultBackendRegistry::new();
+    registry.register_syntax(
+        RustSyntaxBackend::backend_id(),
+        Box::new(RustSyntaxBackend::new()),
+    );
+    registry.register_syntax(
+        PythonSyntaxBackend::backend_id(),
+        Box::new(PythonSyntaxBackend::new()),
+    );
+
+    let ctx = indexer::PipelineContext {
+        repo_id: "multi-tier-repo".to_string(),
+        source_root: repo_dir.path().to_path_buf(),
+        registry: &registry,
+        dispatch_context: DispatchContext::default(),
+        correlation_id: None,
+        use_git_diff: false,
+    };
+
+    let result = indexer::run(&ctx, &mut db, &blob_store).expect("indexing should succeed");
+    assert!(result.metrics.symbols_extracted > 0);
+    assert!(result.metrics.files_file_only >= 1);
+
+    // Seed a syntax-plus-semantic file (simulates a TypeScript file that was
+    // enriched by a semantic backend). We cannot run a real semantic backend
+    // in tests, so we directly insert the records at the expected tier.
+    let ts_content = b"export function hello() {}\nexport class App {}\n";
+    let ts_hash = store::content_hash(ts_content);
+    blob_store.put(ts_content).unwrap();
+    db.files()
+        .upsert(&FileRecord {
+            repo_id: "multi-tier-repo".into(),
+            file_path: "src/app.ts".into(),
+            language: "typescript".into(),
+            file_hash: ts_hash,
+            summary: "App source".into(),
+            symbol_count: 2,
+            capability_tier: CapabilityTier::SyntaxPlusSemantic,
+            updated_at: "2026-03-16T00:00:00Z".into(),
+        })
+        .unwrap();
+    for (name, kind) in [("hello", SymbolKind::Function), ("App", SymbolKind::Class)] {
+        let qualified_name = format!("crate::{name}");
+        db.symbols()
+            .upsert(&SymbolRecord {
+                id: core_model::build_symbol_id(
+                    "multi-tier-repo",
+                    "src/app.ts",
+                    &qualified_name,
+                    kind,
+                )
+                .unwrap(),
+                repo_id: "multi-tier-repo".into(),
+                file_path: "src/app.ts".into(),
+                language: "typescript".into(),
+                kind,
+                name: name.into(),
+                qualified_name,
+                signature: format!("function {name}()"),
+                start_line: 1,
+                end_line: 2,
+                start_byte: 0,
+                byte_length: 25,
+                content_hash: format!("hash-{name}"),
+                capability_tier: CapabilityTier::SyntaxPlusSemantic,
+                confidence_score: 0.95,
+                source_backend: "semantic-typescript".into(),
+                indexed_at: "2026-03-16T00:00:00Z".into(),
+                docstring: None,
+                summary: None,
+                parent_symbol_id: None,
+                keywords: None,
+                decorators_or_attributes: None,
+                semantic_refs: None,
+                container_symbol_id: None,
+                namespace_path: None,
+                raw_kind: None,
+                modifiers: None,
+            })
+            .unwrap();
+    }
+    // Note: we do NOT upsert the repo record here — INSERT OR REPLACE on
+    // repos cascades deletes to files/symbols. The seeded TS file is visible
+    // in queries without updating repo-level aggregates.
+
+    (db, blob_store, blob_dir, repo_dir)
+}
+
+#[test]
+fn e2e_multi_tier_file_outline_syntax_file_carries_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_outline",
+        json!({ "repo_id": "multi-tier-repo", "file_path": "src/lib.rs" }),
+    );
+    assert_eq!(resp.status, Status::Success, "error: {:?}", resp.error);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["capability_tier"], "syntax_only");
+    let symbols = payload["symbols"].as_array().unwrap();
+    assert!(!symbols.is_empty());
+    assert_eq!(symbols[0]["capability_tier"], "syntax_only");
+}
+
+#[test]
+fn e2e_multi_tier_file_outline_file_only_carries_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_outline",
+        json!({ "repo_id": "multi-tier-repo", "file_path": "README.md" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["capability_tier"], "file_only");
+    let symbols = payload["symbols"].as_array().unwrap();
+    assert!(symbols.is_empty());
+}
+
+#[test]
+fn e2e_multi_tier_file_outline_semantic_file_carries_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_outline",
+        json!({ "repo_id": "multi-tier-repo", "file_path": "src/app.ts" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["capability_tier"], "syntax_plus_semantic");
+    let symbols = payload["symbols"].as_array().unwrap();
+    assert_eq!(symbols.len(), 2);
+    assert_eq!(symbols[0]["capability_tier"], "syntax_plus_semantic");
+}
+
+#[test]
+fn e2e_multi_tier_file_content_carries_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "get_file_content",
+        json!({ "repo_id": "multi-tier-repo", "file_path": "src/lib.rs" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["file"]["capability_tier"], "syntax_only");
+    assert!(payload["content"].as_str().unwrap().contains("greet"));
+
+    let resp2 = reg.call(
+        "get_file_content",
+        json!({ "repo_id": "multi-tier-repo", "file_path": "README.md" }),
+    );
+    assert_eq!(resp2.status, Status::Success);
+    let payload2 = resp2.payload.unwrap();
+    assert_eq!(payload2["file"]["capability_tier"], "file_only");
+}
+
+#[test]
+fn e2e_multi_tier_file_tree_entries_carry_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call("get_file_tree", json!({ "repo_id": "multi-tier-repo" }));
+    assert_eq!(resp.status, Status::Success);
+    let entries = resp.payload.unwrap()["entries"].as_array().unwrap().clone();
+    assert!(entries.len() >= 3);
+
+    let readme = entries.iter().find(|e| e["path"] == "README.md").unwrap();
+    assert_eq!(readme["capability_tier"], "file_only");
+    assert_eq!(readme["symbol_count"], 0);
+
+    let rs = entries.iter().find(|e| e["path"] == "src/lib.rs").unwrap();
+    assert_eq!(rs["capability_tier"], "syntax_only");
+    assert!(rs["symbol_count"].as_u64().unwrap() >= 2);
+
+    let py = entries
+        .iter()
+        .find(|e| e["path"] == "app/models.py")
+        .unwrap();
+    assert_eq!(py["capability_tier"], "syntax_only");
+    assert!(py["symbol_count"].as_u64().unwrap() >= 2);
+
+    let ts = entries.iter().find(|e| e["path"] == "src/app.ts").unwrap();
+    assert_eq!(ts["capability_tier"], "syntax_plus_semantic");
+    assert_eq!(ts["symbol_count"], 2);
+}
+
+#[test]
+fn e2e_multi_tier_repo_outline_files_carry_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call("get_repo_outline", json!({ "repo_id": "multi-tier-repo" }));
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    let files = payload["files"].as_array().unwrap();
+    assert!(files.len() >= 3);
+
+    let tiers: Vec<&str> = files
+        .iter()
+        .filter_map(|f| f["capability_tier"].as_str())
+        .collect();
+    assert!(tiers.contains(&"file_only"));
+    assert!(tiers.contains(&"syntax_only"));
+    assert!(tiers.contains(&"syntax_plus_semantic"));
+}
+
+#[test]
+fn e2e_multi_tier_search_symbols_finds_across_languages() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let resp = reg.call(
+        "search_symbols",
+        json!({ "repo_id": "multi-tier-repo", "query": "greet User Config get_name" }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let items = resp.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert!(
+        items.len() >= 2,
+        "should find symbols from multiple languages"
+    );
+
+    let languages: Vec<&str> = items
+        .iter()
+        .filter_map(|i| i["language"].as_str())
+        .collect();
+    assert!(languages.contains(&"rust"));
+    assert!(languages.contains(&"python"));
+
+    for item in &items {
+        assert!(
+            item["capability_tier"].is_string(),
+            "each result should carry capability_tier"
+        );
+    }
+}
+
+#[test]
+fn e2e_multi_tier_get_symbol_carries_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    let search = reg.call(
+        "search_symbols",
+        json!({ "repo_id": "multi-tier-repo", "query": "greet" }),
+    );
+    let items = search.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert!(!items.is_empty());
+    let id = items[0]["id"].as_str().unwrap();
+
+    let resp = reg.call("get_symbol", json!({ "id": id }));
+    assert_eq!(resp.status, Status::Success);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["capability_tier"], "syntax_only");
+    assert_eq!(payload["name"], "greet");
+}
+
+#[test]
+fn e2e_multi_tier_search_symbols_filter_by_capability_tier() {
+    let (db, blob_store, _blob_dir, _repo_dir) = indexed_multi_tier_store();
+    let svc = StoreQueryService::new(&db, &blob_store);
+    let reg = ToolRegistry::new(&svc);
+
+    // Filter to syntax_plus_semantic only — should return TS symbols.
+    let resp = reg.call(
+        "search_symbols",
+        json!({
+            "repo_id": "multi-tier-repo",
+            "query": "hello App greet Config User",
+            "capability_tier": "syntax_plus_semantic"
+        }),
+    );
+    assert_eq!(resp.status, Status::Success);
+    let items = resp.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert!(!items.is_empty(), "should find semantic symbols");
+    for item in &items {
+        assert_eq!(
+            item["capability_tier"], "syntax_plus_semantic",
+            "all results should be syntax_plus_semantic when filtered"
+        );
+    }
+
+    // Filter to syntax_only — should exclude TS symbols.
+    let resp2 = reg.call(
+        "search_symbols",
+        json!({
+            "repo_id": "multi-tier-repo",
+            "query": "hello App greet Config User",
+            "capability_tier": "syntax_only"
+        }),
+    );
+    assert_eq!(resp2.status, Status::Success);
+    let items2 = resp2.payload.unwrap()["items"].as_array().unwrap().clone();
+    assert!(!items2.is_empty());
+    for item in &items2 {
+        assert_eq!(item["capability_tier"], "syntax_only");
+    }
 }

--- a/docs/architecture/capability-tier-query-behavior.md
+++ b/docs/architecture/capability-tier-query-behavior.md
@@ -1,0 +1,105 @@
+# Capability Tier Query Behavior
+
+This document describes how query surfaces behave across capability tiers.
+
+## Capability Tiers
+
+Every indexed file is classified into one of these tiers:
+
+| Tier                 | Meaning                                              |
+|----------------------|------------------------------------------------------|
+| `file_only`          | File record and content only; no extracted symbols   |
+| `syntax_only`        | Symbols extracted by a syntax backend (tree-sitter)  |
+| `syntax_plus_semantic` | Syntax baseline enriched by a semantic backend     |
+| `semantic_only`      | Transitional: semantic backend only, no syntax       |
+
+## Query Surface Behavior by Tier
+
+### File Outline (`get_file_outline`)
+
+| Tier                   | File metadata | Symbols               |
+|------------------------|---------------|-----------------------|
+| `file_only`            | present       | empty list            |
+| `syntax_only`          | present       | syntax-derived        |
+| `syntax_plus_semantic` | present       | merged syntax+semantic|
+
+The response includes `capability_tier` on both the file record and each
+symbol record. Consumers can use this to understand why a file has no symbols
+(file-only tier) versus having syntax-only coverage.
+
+### Symbol Search (`search_symbols`)
+
+Returns symbols from all tiers by default. The MCP `search_symbols` tool
+accepts an optional `capability_tier` parameter (one of `file_only`,
+`syntax_only`, `syntax_plus_semantic`, `semantic_only`) to restrict results
+to a specific tier.
+
+Ranking applies a confidence boost for semantic-tier symbols, reflecting their
+higher fidelity. Syntax-only symbols receive no boost. This means
+semantic-enriched symbols will rank higher than syntax-only symbols when query
+relevance is otherwise equal.
+
+### Exact Symbol Lookup (`get_symbol`, `get_symbols`)
+
+Works identically across all tiers. Every symbol record carries
+`capability_tier` and `source_backend` for provenance.
+
+### File Content (`get_file_content`)
+
+Returns file content regardless of tier. The response includes
+`capability_tier` on the file metadata so consumers know what level of symbol
+coverage is available for that file.
+
+### File Tree (`get_file_tree`)
+
+Each entry includes `capability_tier`, `language`, and `symbol_count`.
+Consumers can use this to identify which files in a repo have symbol coverage
+and which are file-only.
+
+### Repo Outline (`get_repo_outline`)
+
+File entries include `capability_tier`. The repo-level counts
+(`file_count`, `symbol_count`, `language_counts`) reflect all tiers.
+
+### Text Search (`search_text`)
+
+Returns matches from all tiers. Results include the symbol record (with
+`capability_tier`) when the match is associated with a symbol.
+
+## MCP Response Format
+
+All file-oriented MCP tool responses include `capability_tier` as a string
+field in the appropriate location:
+
+```json
+{
+  "file": {
+    "file_path": "src/lib.rs",
+    "language": "rust",
+    "symbol_count": 3,
+    "capability_tier": "syntax_only"
+  }
+}
+```
+
+File tree and repo outline entries:
+
+```json
+{
+  "path": "README.md",
+  "language": "markdown",
+  "symbol_count": 0,
+  "capability_tier": "file_only"
+}
+```
+
+Symbol records always include `capability_tier`:
+
+```json
+{
+  "name": "greet",
+  "kind": "function",
+  "capability_tier": "syntax_only",
+  "source_backend": "syntax-rust"
+}
+```


### PR DESCRIPTION
## Summary

  - Issue: Closes #182
  - Scope: Rework capability-tier query surfaces so file-oriented MCP responses expose capability tier metadata, search_symbols supports capability-tier filtering, and the behavior is documented and covered by
    integration tests.

  ## Changes

  - Added capability_tier to query-engine file tree/repo outline entries so file-oriented query surfaces can report tier information consistently.
  - Included capability_tier in MCP payloads for get_file_outline, get_file_content, get_file_tree, and get_repo_outline.
  - Extended MCP search_symbols to accept an optional capability_tier filter and wired the CLI MCP schema to advertise that parameter.
  - Added query-engine integration coverage for file-only, syntax-only, and syntax-plus-semantic behavior.
  - Added MCP end-to-end coverage for mixed-tier repositories, including capability-tier payload assertions and search_symbols filtering.
  - Added capability-tier query behavior documentation for consumers.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: file_outline returns file metadata plus an empty symbol list for file-only repos, syntax-derived symbols for syntax-indexed repos, and merged symbols for syntax-plus-semantic repos.
  - [x] Criterion 2: symbol_search returns stable, non-empty results on representative syntax-indexed repositories where relevant symbols exist.
  - [x] Criterion 3: Exact symbol lookup continues to work across syntax-indexed and syntax-plus-semantic repositories.
  - [x] Criterion 4: Exact file/source retrieval semantics remain coherent across capability tiers.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional tests run:

  - [x] cargo test -p query-engine --test capability_tier_integration
  - [x] cargo test -p server-mcp --test e2e_integration
  - [x] cargo test -p cli mcp_stdio

  ## Risk and Mitigation

  - Risk: Syntax-plus-semantic MCP coverage is partly seeded in tests rather than produced by a live semantic backend runtime.
  - Mitigation: The seeded path still validates the query/service contract for syntax_plus_semantic, while existing query-engine and MCP E2E coverage exercises the behavior end to end from the consumer side.

  ## Security/Observability Impact

  - Security: No new privileged operations or external network behavior; changes are limited to query payload shape, filtering, docs, and tests.
  - Logs/Metrics/Tracing: No tracing or metric contract changes. Existing query spans remain unchanged.