### PR TITLE
Update benchmark and token-efficiency evaluation strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,43 +529,54 @@ adapter availability:
 
 | Level | Languages | What works |
 |-------|-----------|------------|
-| Semantic + syntax | TypeScript, Kotlin (when runtimes are available) | Symbol search, file outline, file tree, file content, repo outline |
-| Syntax only | Rust | Symbol search, file outline, file tree, file content, repo outline |
-| File-level only | All other recognized languages | File tree, file content, repo outline (zero symbols) |
+| Semantic (no syntax backend yet) | TypeScript, Kotlin (when runtimes are available) | Symbol search, file outline, file tree, file content, repo outline |
+| Syntax | Go, Java, JavaScript, PHP, Python, Rust | Symbol search, file outline, file tree, file content, repo outline |
+| File-level only | Other recognized languages (Ruby, C, C++, C#, Swift, Shell, JSON, YAML, TOML, Markdown, SQL, Dockerfile) | File tree, file content, repo outline (zero symbols) |
 | Not indexed | Unrecognized files (`Language::Unknown`) | Excluded at discovery |
 
-File-level indexing is the baseline — every recognized file gets a file record,
-stored content blob, and appears in file tree and repo outline queries. Symbol
-extraction is additive on top of that baseline when adapters are available.
+Syntax indexing is the baseline for major recognized code languages. Every
+recognized file gets a file record, stored content blob, and appears in file
+tree and repo outline queries. Symbol extraction is additive on top of that
+baseline.
 
-### Long-term architecture direction
+### Capability tier model
 
-The current capability table reflects the product as it exists today, not the
-intended end state.
+CodeAtlas classifies every indexed file into a capability tier that describes
+the depth of indexing it received:
 
-CodeAtlas is now explicitly moving toward:
+- **File-only**: file record and content blob only; no extracted symbols.
+- **Syntax-only**: symbols extracted by a tree-sitter syntax backend.
+- **Syntax-plus-semantic**: syntax baseline enriched by a semantic backend.
+- **Semantic-only** (transitional): semantic backend produced symbols but no
+  syntax backend is available yet. This currently applies to TypeScript and
+  Kotlin, which have semantic backends but have not yet been migrated onto the
+  syntax platform. This tier will be resolved by adding syntax backends for
+  those languages.
 
-- file-level persistence as the universal floor for recognized files
-- syntax indexing as the default baseline for most recognized code languages
-- semantic indexing as an enrichment layer on top of syntax
-- file-only indexing as the explicit last fallback rather than the common case
+All query surfaces expose the capability tier on file and symbol records so
+consumers can understand indexing depth. See
+`docs/architecture/capability-tier-query-behavior.md` for the full query
+behavior spec.
 
-This project is still early enough that clean long-term architecture is favored
-over preserving awkward intermediate interfaces. If the indexing model, schema,
-or crate boundaries need to be refactored to support that direction, those
-refactors are in scope.
+### Architecture
 
-The planning artifact for that next major architecture initiative is:
-`docs/planning/universal-syntax-indexing.md`.
+Syntax indexing is the default baseline for recognized code languages, backed
+by a multi-language tree-sitter platform (`syntax-platform` crate). Semantic
+indexing enriches the syntax baseline where language-native runtimes are
+available. TypeScript and Kotlin currently run semantic-only paths because
+they do not yet have syntax backends on the new subsystem; once those are
+added, they will achieve the full syntax-plus-semantic tier. File-only
+indexing remains as the fallback for languages without a syntax backend.
 
-The canonical technical design source for that initiative will live in:
-`docs/architecture/universal-syntax-indexing-architecture.md`.
+The canonical architecture design is in
+`docs/architecture/universal-syntax-indexing-architecture.md`. The planning
+artifact is in `docs/planning/universal-syntax-indexing.md`.
 
 ### What does not exist yet
 
 - Watcher/local file-system triggered update mode.
 - Semantic adapters beyond the current TypeScript and Kotlin implementations.
-- Syntax adapters beyond Rust (other recognized languages are file-level only).
+- Syntax backends for additional languages beyond the current set (Go, Java, JavaScript, PHP, Python, Rust).
 - Docker packaging for the persistent service.
 - Hosted auth, quotas, and multi-tenant controls.
 - Production observability dashboards and hosted telemetry/export integrations beyond the local CLI baseline.

--- a/docs/architecture/capability-tier-query-behavior.md
+++ b/docs/architecture/capability-tier-query-behavior.md
@@ -6,12 +6,12 @@ This document describes how query surfaces behave across capability tiers.
 
 Every indexed file is classified into one of these tiers:
 
-| Tier                 | Meaning                                              |
-|----------------------|------------------------------------------------------|
-| `file_only`          | File record and content only; no extracted symbols   |
-| `syntax_only`        | Symbols extracted by a syntax backend (tree-sitter)  |
-| `syntax_plus_semantic` | Syntax baseline enriched by a semantic backend     |
-| `semantic_only`      | Transitional: semantic backend only, no syntax       |
+| Tier                 | Meaning                                              | Example languages |
+|----------------------|------------------------------------------------------|-------------------|
+| `file_only`          | File record and content only; no extracted symbols   | Ruby, C, C++, Markdown, JSON |
+| `syntax_only`        | Symbols extracted by a syntax backend (tree-sitter)  | Go, Java, JavaScript, PHP, Python, Rust |
+| `syntax_plus_semantic` | Syntax baseline enriched by a semantic backend     | (no languages at this tier yet — will apply once TypeScript/Kotlin gain syntax backends) |
+| `semantic_only`      | Transitional: semantic backend only, no syntax       | TypeScript (with tsserver), Kotlin (with JVM bridge) — will be resolved by adding syntax backends |
 
 ## Query Surface Behavior by Tier
 

--- a/docs/benchmarks/blog-benchmark-kit.md
+++ b/docs/benchmarks/blog-benchmark-kit.md
@@ -20,11 +20,16 @@ Use this kit to collect evidence for:
 
 Use 4-7 repositories with distinct characteristics:
 
-- Rust-heavy repo (syntax adapter coverage)
-- TypeScript repo with `tsserver` available (semantic adapter coverage)
-- Kotlin repo with JVM bridge available (semantic adapter coverage)
-- mixed-language application repo (mix of symbol-bearing and file-only files)
-- recognized-language repo with no current adapter (e.g. Python, Go — file-level only)
+- Rust repo (syntax-only coverage)
+- PHP/Laravel repo (syntax-only coverage, proving-ground ecosystem)
+- Python repo (syntax-only coverage)
+- Go repo (syntax-only coverage)
+- TypeScript repo with `tsserver` available (semantic-only coverage today;
+  will become syntax-plus-semantic once a TypeScript syntax backend is added)
+- Kotlin repo with JVM bridge available (semantic-only coverage today;
+  will become syntax-plus-semantic once a Kotlin syntax backend is added)
+- mixed-language application repo (mix of syntax-bearing and file-only files)
+- recognized-language repo without syntax backend (e.g. Ruby, C — file-level only)
 - medium/large service or app repo
 - repo with frequent small edits for incremental-refresh demos
 
@@ -59,8 +64,8 @@ The script writes CSV outputs under a timestamped directory.
 Collected from `codeatlas quality-report`:
 
 - files discovered
-- files with symbols (symbol-bearing adapter output)
-- files file-only (indexed without symbols)
+- files with symbols (syntax or semantic extraction output)
+- files file-only (indexed without symbols — no syntax backend available)
 - files errored (real adapter failures)
 - symbols extracted
 - semantic symbols
@@ -178,25 +183,30 @@ The prompt pair should answer the same question with different context shapes.
 
 - multi-repo developers
 - AI-assisted exploration and symbol lookup
+- repos in syntax-indexed languages (Go, Java, JavaScript, PHP, Python, Rust)
 - repos with strong TypeScript or Kotlin semantic coverage
 
 ### 4. Honest boundaries
 
 - local-first, not hosted
 - exact token counts vary by model
-- semantic quality depends on adapter availability
-- most recognized languages are currently file-level only (no symbol extraction)
-- symbol search is only useful on languages with working adapters (Rust, TypeScript, Kotlin)
+- semantic quality depends on runtime availability (TypeScript, Kotlin)
+- syntax-only coverage is shallower than semantic — no type references,
+  call-site resolution, or confidence-boosted ranking
+- languages without syntax backends (Ruby, C, C++, C#, Swift) remain
+  file-only with no symbol extraction
 
 ## Example Claims You Can Back With Data
 
 - "One CodeAtlas service handled N repos with one MCP configuration."
 - "Semantic coverage reached X% on repo Y."
-- "File-level index coverage reached X% on repo Z (a Python/Go repo with no symbol adapter)."
+- "Syntax-indexed symbol coverage reached X% on repo Z (a PHP/Laravel repo)."
 - "A repo refresh after a small edit was X times faster than a fresh index."
 - "The CodeAtlas-assisted prompt was X% smaller by estimated token count."
 - "Symbol lookup and file-outline queries stayed below X ms on repo Y."
 - "File tree and file content retrieval worked on repo Z even with zero symbol coverage."
+- "A Laravel/PHP repo that was previously file-only now has symbol search,
+  file outlines, and meaningful token reduction compared to raw-file prompts."
 
 ## Run Flow
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -353,16 +353,22 @@ CODEATLAS_OTEL=1 cargo run -p cli -- index <repo-path>
 
 ### No symbols extracted
 
-This is expected for repositories in recognized languages that lack symbol
-adapters (e.g. Python, Go, Java without semantic runtimes). File-level indexing
-still provides file tree, file content retrieval, and repo outline.
+This is expected for repositories in recognized languages without a syntax
+backend (e.g. Ruby, C, C++, C#, Swift). File-level indexing still provides
+file tree, file content retrieval, and repo outline.
+
+For languages with syntax backends (Go, Java, JavaScript, PHP, Python, Rust),
+zero symbols on files that contain declarations is often worth investigating.
+Note that zero symbols can be legitimate if the files contain only comments,
+configuration, or code patterns that do not produce extractable declarations.
 
 If you expected symbols, check:
 
 - repo path is valid
-- files are supported by current language detection and adapters
+- files are supported by current language detection and syntax backends
 - the quality report's "files with symbols" vs "file-only" breakdown
 - file errors printed by the CLI
+- that files have the correct extension for language detection
 
 ### Semantic coverage unexpectedly zero
 
@@ -374,8 +380,8 @@ Check:
 
 ### High file error count
 
-File errors indicate real adapter failures, not missing adapters. Missing
-adapters produce file-only indexed records instead of errors.
+File errors indicate real backend failures, not missing backends. Languages
+without a registered syntax backend produce file-only records instead of errors.
 
 Check:
 


### PR DESCRIPTION
## Summary

  - Issue: Closes #183
  - Scope: Update user-facing docs, benchmark guidance, and operations guidance to reflect the new file/syntax/semantic capability model and the token-efficiency story for syntax-indexed repositories.

  ## Changes

  - Updated the README capability overview to describe current indexing depth by language, including syntax-backed languages, file-only fallbacks, and the transitional semantic-only status of TypeScript and Kotlin.
  - Added clearer capability-tier explanations and linked the query behavior spec so users can understand file-only, syntax-only, syntax-plus-semantic, and semantic-only states.
  - Revised the benchmark kit to distinguish syntax-only, semantic-only, and file-only repo categories in the benchmark matrix.
  - Added Laravel/PHP proving-ground expectations to the benchmark guidance and example claims.
  - Updated benchmark methodology language so token-efficiency and coverage are framed around file, syntax, and semantic indexing separately.
  - Tightened runbook troubleshooting guidance to reflect current syntax backend availability and to explain when zero extracted symbols are expected versus worth investigating.

  ## Acceptance Criteria Mapping

  - [x] Criterion 1: Docs explain syntax indexing as the normal baseline for major recognized languages.
  - [x] Criterion 2: Benchmark guidance distinguishes file, syntax, and semantic coverage.
  - [x] Criterion 3: Benchmark guidance includes Laravel/PHP proving-ground expectations.
  - [x] Criterion 4: Docs remain honest about where semantic enrichment still exceeds syntax-only capability.

  ## Test Evidence

  - [ ] cargo fmt --all -- --check
  - [ ] cargo clippy --all-targets --all-features -- -D warnings
  - [ ] cargo test --all --all-features
  - [x] Additional tests/benchmarks (if required by issue)

  Additional validation:

  - [x] Doc review against docs/planning/universal-syntax-indexing.md
  - [x] Doc review against docs/architecture/universal-syntax-indexing-architecture.md
  - [x] Cross-check of updated language/tier claims against current syntax backend registrations and capability model

  ## Risk and Mitigation

  - Risk: Documentation can drift from the actual capability model as more syntax and semantic backends land.
  - Mitigation: The updated docs explicitly call out transitional states, name the current language coverage, and anchor the narrative to the canonical planning and architecture docs.

  ## Security/Observability Impact

  - Security: No security behavior changes; docs only.
  - Logs/Metrics/Tracing: No observability contract changes; docs now describe existing coverage and quality-report behavior more accurately.